### PR TITLE
Added cursor plugin

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "datarobot-agent-skills",
+  "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
+  "version": "1.0.0",
+  "author": {
+    "name": "DataRobot",
+    "email": "carson.gee@datarobot.com"
+  },
+  "license": "Apache-2.0",
+  "keywords": ["datarobot", "machine-learning", "mlops", "automl"],
+  "skills": [
+    "datarobot-data-preparation",
+    "datarobot-feature-engineering",
+    "datarobot-model-deployment",
+    "datarobot-model-explainability",
+    "datarobot-model-monitoring",
+    "datarobot-model-training",
+    "datarobot-predictions"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 *.parquet
 *.json
 !gemini-extension.json
+!.cursor-plugin/plugin.json
 
 # Environment variables
 .env


### PR DESCRIPTION

## Summary

Added a cursor plugin definition

### Question

Is now a good time to drop these into a "skills" folder? Otherwise updating the Cursor plugin will be manual and likely to fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new JSON manifest and a `.gitignore` exception with no runtime code changes.
> 
> **Overview**
> Adds a new Cursor plugin manifest at `.cursor-plugin/plugin.json` defining the `datarobot-agent-skills` plugin and its referenced skill IDs.
> 
> Updates `.gitignore` to keep ignoring `*.json` generally while explicitly committing the Cursor plugin manifest (`!.cursor-plugin/plugin.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90aeff46ba55df9d4fc248c25725942233d58440. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->