### PR TITLE
[CFX-5637] Pin Trivy version to v0.35.0 (commit SHA)

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy secret scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -41,7 +41,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy secret scanner (table output)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         if: always()
         with:
           scan-type: 'fs'


### PR DESCRIPTION


# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pinned commit SHA for trivy-action v0.35.0 (57a97c7e7821a5776cebc9bb87c984fa69cba8f1)
It is said that this Trivy release was not compromised 
https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0

## Rationale

## CHANGES
- pinned trivy-action version to commit SHA in `.github/workflows/security-scan.yaml` file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that pins a GitHub Action dependency to a fixed commit, reducing supply-chain drift; main impact is potential behavior differences from the previously unpinned `master` reference.
> 
> **Overview**
> Pins `aquasecurity/trivy-action` to the v0.35.0 commit SHA (`57a97c7e…`) in the `trivy-scan` GitHub Actions workflow for both SARIF and table secret-scan steps, replacing the floating `@master` reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484daa22b005cc790b0185f0b0540cefea18df6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->