### PR TITLE
[APP-5881] Update CI/CD skills

### DIFF
--- a/skills/datarobot-app-framework-cicd/README.md
+++ b/skills/datarobot-app-framework-cicd/README.md
@@ -205,7 +205,7 @@ See these live implementations:
 
 ## Contributing
 
-This is the **canonical upstream source** for this skill at [datarobot-agent-skills](https://github.com/datarobot-oss/datarobot-agent-skills/tree/main/skills/datarobot-app-framework-cicd). Downstream templates (such as `af-component-base`) bundle a local copy — when this skill is updated, those copies should be synced.
+This is the **canonical upstream source** for this skill at [datarobot-agent-skills](https://github.com/datarobot-oss/datarobot-agent-skills/tree/main/skills/datarobot-app-framework-cicd). Downstream repositories (such as [af-component-base](https://github.com/datarobot-community/af-component-base)) bundle a local copy, when this skill is updated, those copies should be synced.
 
 Contributions welcome via pull request.
 

--- a/skills/datarobot-app-framework-cicd/README.md
+++ b/skills/datarobot-app-framework-cicd/README.md
@@ -205,7 +205,9 @@ See these live implementations:
 
 ## Contributing
 
-This skill is part of the DataRobot Agent Skills repository. Contributions welcome!
+This is the **canonical upstream source** for this skill at [datarobot-agent-skills](https://github.com/datarobot-oss/datarobot-agent-skills/tree/main/skills/datarobot-app-framework-cicd). Downstream templates (such as `af-component-base`) bundle a local copy — when this skill is updated, those copies should be synced.
+
+Contributions welcome via pull request.
 
 ## License
 

--- a/skills/datarobot-app-framework-cicd/SKILL.md
+++ b/skills/datarobot-app-framework-cicd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: datarobot-app-framework-cicd
 description: Guidance for setting up CI/CD pipelines for DataRobot application templates using GitLab, GitHub Actions, and Pulumi for infrastructure as code.
+context-tokens: "~6 000 (SKILL.md) + ~2 000 (scripts/*) + ~400 per examples/* file"
 ---
 
 # DataRobot Application Templates CI/CD Skill
@@ -9,15 +10,96 @@ This skill provides comprehensive guidance for setting up production-grade CI/CD
 
 ## Quick Start
 
-**Most common use case**: Set up CI/CD for an application template
+**Default behavior:** When a user asks to "set up CI/CD" without specifying a platform or backend, always use the [Simple Path](#simple-path-pulumi-cloud--github-secrets) below — three workflow files, two GitHub Secrets, done. Do not create `infra/scripts/`, do not add CI/CD tasks to `infra/Taskfile.yaml`, do not involve GPG encryption unless the user explicitly asks for it.
 
-1. **Choose platform**: GitLab CI/CD or GitHub Actions
-2. **Configure secrets**: Set up DataRobot API tokens, LLM keys, and Pulumi credentials
-3. **Add pipeline config**: Create `.gitlab-ci.yml` or `.github/workflows/*.yml`
-4. **Set up Pulumi**: Configure state backend for infrastructure tracking
-5. **Enable review apps**: Add manual deployment jobs for PR/MR validation
+Only deviate from the simple path when the user specifies:
+- A specific Pulumi state backend (Azure Blob, S3, GCS) → use `scripts/` and see [Implementation Pattern](#implementation-pattern)
+- GitLab CI/CD → see [GitLab CI/CD Configuration](#gitlab-cicd-configuration)
+- Many secrets to manage → consider GPG approach in `scripts/`
 
-**Example**: "Set up GitHub Actions CI/CD for my Talk to My Data Agent application template with review deployments and continuous delivery"
+## Simple Path: Pulumi Cloud + GitHub Secrets
+
+For most data scientists and AI engineers, this is all you need. No GPG encryption, no cloud storage account, no extra scripts.
+
+**What to create in the user's repository:**
+
+1. Copy the three workflow files to `.github/workflows/`:
+
+   | Source | Destination | Trigger |
+   |--------|-------------|---------|
+   | `examples/github-cd-pulumi-cloud.yml` | `.github/workflows/cd.yml` | Automatic — every merge to `main` |
+   | `examples/github-deploy-pulumi-cloud.yml` | `.github/workflows/deploy-pr.yml` | Manual — user picks PR branch + enters stack name (e.g. `pr-42`) |
+   | `examples/github-destroy-pulumi-cloud.yml` | `.github/workflows/destroy.yml` | Manual — user enters stack name to tear down |
+
+2. Create `.github/workflows/README.md` from `examples/workflows-README.md`. This is the setup guide that tells the user exactly what secrets and variables to add and how.
+
+3. Tell the user to follow the setup guide in `.github/workflows/README.md`.
+
+That's it. Do **not** add anything to `infra/Taskfile.yaml` or create `infra/scripts/` for this path.
+
+**Required GitHub Secrets** (both required — no defaults):
+
+| Name | Kind |
+|------|------|
+| `DATAROBOT_API_TOKEN` | Secret |
+| `PULUMI_ACCESS_TOKEN` | Secret |
+
+**Optional GitHub Variable** (defaults to `ci` if not set):
+
+| Name | Kind | Default |
+|------|------|---------|
+| `PULUMI_STACK_CI_NAME` | Variable | `ci` |
+
+**When to use the advanced approach (GPG + DIY backends) instead:**
+- You have many secrets (GPG encrypts all of `.env` behind a single passphrase — only one GitHub Secret needed)
+- Your organization prohibits Pulumi Cloud and requires a self-managed backend (Azure Blob / S3 / GCS)
+- You need GitLab CI/CD
+
+The templates and scripts for all of these are in `scripts/` in this skill directory. If the skill has already been propagated to the project's `infra/` directory (common in downstream templates), look in `infra/scripts/` instead. See the [Implementation Pattern](#implementation-pattern) section below for full setup guidance.
+
+| Scenario | Key files in `scripts/` |
+|----------|------------------------|
+| Azure Blob / S3 / GCS Pulumi backend | `pulumi-setup.sh`, `taskfile-snippets.yaml` |
+| GitHub Actions + GPG secrets | `github-deploy.yml`, `github-cd.yml`, `encrypt-secrets.sh`, `setup-github-secrets.sh` |
+| GitLab CI/CD | `gitlab-ci.yml`, `setup-gitlab-variables.sh` |
+
+### Adapting the deploy command
+
+The example workflows use `uv run pulumi up --yes` directly. Before copying them, check `infra/Taskfile.yaml` — the project may already wrap the deploy command in a task:
+
+```bash
+cat infra/Taskfile.yaml   # look for 'up-yes', 'deploy', or similar tasks
+```
+
+| What you find | What to use in CI |
+|---------------|-------------------|
+| `up-yes` task | `task up-yes` — non-interactive, purpose-built for CI; prefer this over raw Pulumi |
+| `deploy` task (alias for `up`) | Avoid — typically runs `pulumi up` interactively; only safe in CI if you confirm it passes `-y` internally |
+| No Taskfile or no relevant task | Keep `uv run pulumi up --yes` as-is |
+
+To use `task` in a workflow, add an install step and swap the run command:
+
+```yaml
+- name: Install Task
+  run: pip install go-task-bin
+
+- name: Deploy
+  working-directory: infra
+  env:
+    DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
+    PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  run: |
+    uv sync --all-extras
+    task up-yes
+```
+
+### DataRobot API token (service account)
+
+`DATAROBOT_API_TOKEN` should come from a **DataRobot service account** — a DataRobot user created for automation, not tied to anyone's personal login. This prevents CI/CD from breaking when the engineer who originally set it up leaves the team.
+
+To set one up: ask your DataRobot admin to create a dedicated user (e.g. `ci-bot@your-org.com`). Under that account, go to **Developer Tools → API Key** and generate a token. Store it as the `DATAROBOT_API_TOKEN` secret in GitHub.
+
+> **Note:** This is purely a DataRobot concept — it has no relation to Pulumi state management or backend configuration. "Service account" here just means a non-personal DataRobot user.
 
 ## When to use this skill
 
@@ -425,6 +507,14 @@ pulumi stack rm review-app-123 --yes
 ## Secrets Management
 
 All credentials (DataRobot API token, Pulumi access token, LLM keys, cloud storage keys) are stored in `.env` and committed to the repository encrypted as `.env.gpg`. The only secret that needs to be configured in the CI/CD system directly is `CICD_SECRET_PASSPHRASE` (the GPG passphrase). Non-sensitive stack name variables (`PULUMI_STACK_CI_NAME`, `PULUMI_STACK_REVIEW_NAME`) are set as plain variables, not secrets.
+
+### DataRobot API token (service account)
+
+`DATAROBOT_API_TOKEN` should come from a **DataRobot service account** — a DataRobot user created for automation, not tied to anyone's personal login. This prevents CI/CD from breaking when the engineer who originally set it up leaves the team.
+
+To set one up: ask your DataRobot admin to create a dedicated user (e.g. `ci-bot@your-org.com`). Under that account, go to **Developer Tools → API Key** and generate a token. Store it as the `DATAROBOT_API_TOKEN` secret in your CI/CD system.
+
+> **Note:** This is purely a DataRobot concept — it has no relation to Pulumi state management or backend configuration. "Service account" here just means a non-personal DataRobot user.
 
 ### GitHub
 

--- a/skills/datarobot-app-framework-cicd/examples/github-cd-pulumi-cloud.yml
+++ b/skills/datarobot-app-framework-cicd/examples/github-cd-pulumi-cloud.yml
@@ -1,0 +1,37 @@
+---
+# Continuous delivery: deploy to the persistent CI stack on every push to main.
+#
+# Required GitHub Secrets (Settings → Secrets and variables → Actions → Secrets):
+#   DATAROBOT_API_TOKEN  — DataRobot service account API key
+#   PULUMI_ACCESS_TOKEN  — from https://app.pulumi.com/account/tokens
+#
+# Optional GitHub Variable (defaults to "ci" if not set):
+#   PULUMI_STACK_CI_NAME — stack name for the CI environment (e.g. "ci", "prod")
+#
+# Pulumi Cloud uses PULUMI_ACCESS_TOKEN automatically — no explicit login step needed.
+
+name: Deploy (CD)
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Deploy
+        working-directory: infra
+        env:
+          DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          uv sync --all-extras
+          uv run pulumi stack select --create ${{ vars.PULUMI_STACK_CI_NAME || 'ci' }}
+          uv run pulumi up --yes

--- a/skills/datarobot-app-framework-cicd/examples/github-cd-pulumi-cloud.yml
+++ b/skills/datarobot-app-framework-cicd/examples/github-cd-pulumi-cloud.yml
@@ -31,7 +31,8 @@ jobs:
         env:
           DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_STACK: ${{ vars.PULUMI_STACK_CI_NAME || 'ci' }}
         run: |
           uv sync --all-extras
-          uv run pulumi stack select --create ${{ vars.PULUMI_STACK_CI_NAME || 'ci' }}
+          uv run pulumi stack select --create $PULUMI_STACK
           uv run pulumi up --yes

--- a/skills/datarobot-app-framework-cicd/examples/github-deploy-pulumi-cloud.yml
+++ b/skills/datarobot-app-framework-cicd/examples/github-deploy-pulumi-cloud.yml
@@ -1,0 +1,41 @@
+---
+# PR preview deployment: manually triggered so you control when a PR stack is created.
+# Go to: Actions → Deploy (PR Preview) → Run workflow → select your PR branch → enter stack name.
+#
+# Tip: use the PR number as the stack name (e.g. "pr-42") so it's easy to track and clean up.
+#
+# Required GitHub Secrets (Settings → Secrets and variables → Actions → Secrets):
+#   DATAROBOT_API_TOKEN  — DataRobot service account API key
+#   PULUMI_ACCESS_TOKEN  — from https://app.pulumi.com/account/tokens
+
+name: Deploy (PR Preview)
+on:
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "Stack name for this PR preview (e.g. 'pr-42')"
+        required: true
+        default: "pr-preview"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Deploy PR Preview Stack
+        working-directory: infra
+        env:
+          DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_STACK: ${{ github.event.inputs.stack_name }}
+        run: |
+          uv sync --all-extras
+          uv run pulumi stack select --create $PULUMI_STACK
+          uv run pulumi up --yes

--- a/skills/datarobot-app-framework-cicd/examples/github-destroy-pulumi-cloud.yml
+++ b/skills/datarobot-app-framework-cicd/examples/github-destroy-pulumi-cloud.yml
@@ -1,0 +1,41 @@
+---
+# Manual stack destroy: triggered from the GitHub Actions UI (Actions → Destroy Stack → Run workflow).
+# Use this to clean up review stacks after a PR is merged or closed.
+#
+# Required GitHub Secrets:
+#   DATAROBOT_API_TOKEN  — DataRobot service account API key
+#   PULUMI_ACCESS_TOKEN  — from https://app.pulumi.com/account/tokens
+
+name: Destroy Stack
+on:
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "Stack name to destroy (e.g. review-pr-42)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    env:
+      # Bind input to an env var — prevents it from being interpolated directly into shell.
+      PULUMI_STACK: ${{ github.event.inputs.stack_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Destroy Stack
+        working-directory: infra
+        env:
+          DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          uv sync --all-extras
+          uv run pulumi stack select ${{ env.PULUMI_STACK }}
+          uv run pulumi destroy --yes
+          uv run pulumi stack rm --yes

--- a/skills/datarobot-app-framework-cicd/examples/github-destroy-pulumi-cloud.yml
+++ b/skills/datarobot-app-framework-cicd/examples/github-destroy-pulumi-cloud.yml
@@ -36,6 +36,6 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           uv sync --all-extras
-          uv run pulumi stack select ${{ env.PULUMI_STACK }}
+          uv run pulumi stack select $PULUMI_STACK
           uv run pulumi destroy --yes
           uv run pulumi stack rm --yes

--- a/skills/datarobot-app-framework-cicd/examples/workflows-README.md
+++ b/skills/datarobot-app-framework-cicd/examples/workflows-README.md
@@ -1,0 +1,70 @@
+# CI/CD Setup
+
+This directory contains GitHub Actions workflows for deploying to DataRobot using Pulumi Cloud.
+
+## Workflows
+
+| File | Trigger | What it does |
+|------|---------|--------------|
+| `cd.yml` | Automatic — every merge to `main` | Deploys `main` to the persistent CI stack |
+| `deploy-pr.yml` | Manual — you choose branch and stack name | Deploys a preview stack from a PR branch |
+| `destroy.yml` | Manual — you enter the stack name | Destroys a named Pulumi stack |
+
+`cd.yml` is the only workflow that runs automatically. Everything else requires you to trigger it from the Actions tab.
+
+## One-time setup
+
+### 1. Create a Pulumi Cloud account
+
+Sign up at [app.pulumi.com](https://app.pulumi.com) (free tier is sufficient for most projects).
+
+Create an access token: click your **profile icon → Access Tokens → Create token**. Copy the token — you will need it in step 3.
+
+### 2. Get a DataRobot API key
+
+Ask your DataRobot admin to create a **service account** user (e.g. `ci-bot@your-org.com`) and generate an API key under **Developer Tools → API Key**. Using a service account instead of a personal API key prevents CI/CD from breaking when people leave the team.
+
+> If you are just getting started, you can use your own personal API key temporarily and replace it later.
+
+### 3. Add GitHub Secrets
+
+Go to: **Settings → Secrets and variables → Actions → Secrets tab → New repository secret**
+
+| Secret name | Where to get it |
+|-------------|----------------|
+| `DATAROBOT_API_TOKEN` | DataRobot → Developer Tools → API Key |
+| `PULUMI_ACCESS_TOKEN` | Pulumi Cloud → Profile → Access Tokens |
+
+Both secrets are required. The workflows will not run without them.
+
+### 4. (Optional) Set a custom CI stack name
+
+The `cd.yml` workflow deploys to a Pulumi stack named `ci` by default. To use a different name, add a repository variable:
+
+**Settings → Secrets and variables → Actions → Variables tab → New repository variable**
+
+| Variable name | Value |
+|---------------|-------|
+| `PULUMI_STACK_CI_NAME` | Your preferred stack name (e.g. `ci`, `prod`, `staging`) |
+
+Skip this step if `ci` is fine.
+
+## How to trigger deployments
+
+**Automatic deploy (merge to main):**
+`cd.yml` runs automatically every time code is merged to `main`. No action needed.
+
+**Manual PR preview deploy:**
+1. Open a PR and get ready to test it in a live environment.
+2. Go to **Actions → Deploy (PR Preview)** in the GitHub UI.
+3. Click **Run workflow**.
+4. Select your PR branch from the dropdown.
+5. Enter a stack name — tip: use the PR number (e.g. `pr-42`) so it's easy to track.
+6. Click **Run workflow**. Each stack is isolated, so multiple PRs can have their own live environment.
+
+**Destroy a stack (manual cleanup):**
+1. Go to **Actions → Destroy Stack**.
+2. Click **Run workflow → Run workflow**.
+3. Enter the exact stack name you want to destroy (e.g. `pr-42` or `ci`).
+
+> The CI stack (`ci`) is recreated automatically on the next merge to `main`. Destroy it only if you want to tear everything down.

--- a/skills/datarobot-app-framework-cicd/scripts/github-cd.yml
+++ b/skills/datarobot-app-framework-cicd/scripts/github-cd.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  PULUMI_STACK: ${{ vars.PULUMI_STACK_CI_NAME }}
+  PULUMI_STACK: ${{ vars.PULUMI_STACK_CI_NAME || 'ci' }}
 
 jobs:
   deploy:

--- a/skills/datarobot-app-framework-cicd/scripts/github-deploy.yml
+++ b/skills/datarobot-app-framework-cicd/scripts/github-deploy.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  PULUMI_STACK: ${{ vars.PULUMI_STACK_REVIEW_NAME }}-${{ github.event.number }}
+  PULUMI_STACK: ${{ vars.PULUMI_STACK_REVIEW_NAME || 'review' }}-${{ github.event.number }}
 
 jobs:
   # Test and lint job - runs first

--- a/skills/datarobot-app-framework-cicd/scripts/gitlab-ci.yml
+++ b/skills/datarobot-app-framework-cicd/scripts/gitlab-ci.yml
@@ -59,7 +59,7 @@ review_app:
   script:
     # Install Pulumi
     - curl -fsSL https://get.pulumi.com | sh
-    - export PATH="~/.pulumi/bin:$PATH"
+    - export PATH="$HOME/.pulumi/bin:$PATH"
     # Login to Pulumi backend (DIY backend example using Azure Blob)
     - pulumi login --cloud-url "azblob://dr-ai-apps-pulumi"
     # Create the stack if it doesn't exist (PULUMI_STACK selects it for all subsequent commands)
@@ -86,7 +86,7 @@ destroy_review_app:
     PULUMI_STACK: $PULUMI_STACK_REVIEW_NAME
   script:
     - curl -fsSL https://get.pulumi.com | sh
-    - export PATH="~/.pulumi/bin:$PATH"
+    - export PATH="$HOME/.pulumi/bin:$PATH"
     - pulumi login --cloud-url "azblob://dr-ai-apps-pulumi"
     # Destroy the stack (PULUMI_STACK identifies which stack to target)
     - pulumi destroy --yes
@@ -109,9 +109,10 @@ deploy_ci:
     PULUMI_STACK: $PULUMI_STACK_CI_NAME
   script:
     - curl -fsSL https://get.pulumi.com | sh
-    - export PATH="~/.pulumi/bin:$PATH"
+    - export PATH="$HOME/.pulumi/bin:$PATH"
     - pulumi login --cloud-url "azblob://dr-ai-apps-pulumi"
-    # PULUMI_STACK selects the stack — no explicit stack select needed
+    # Select stack, creating it if it doesn't exist yet
+    - pulumi stack select --create $PULUMI_STACK
     - pulumi up --yes
     - echo "Deployed $PULUMI_STACK stack"
   rules:

--- a/skills/datarobot-app-framework-cicd/scripts/gitlab-ci.yml
+++ b/skills/datarobot-app-framework-cicd/scripts/gitlab-ci.yml
@@ -11,7 +11,7 @@ variables:
   # Set PULUMI_STACK_CI_NAME and PULUMI_STACK_REVIEW_NAME as plain CI/CD
   # variables in GitLab (Settings → CI/CD → Variables) to override these
   # defaults.  Project variables always take precedence over the values below.
-  PULUMI_STACK_REVIEW_NAME: review-mr-$CI_MERGE_REQUEST_IID
+  PULUMI_STACK_REVIEW_NAME: review-mr
   PULUMI_STACK_CI_NAME: ci
   # ── Secrets ────────────────────────────────────────────────────────────────
   # Only one secret needs to be set in GitLab CI/CD settings:
@@ -55,7 +55,7 @@ test:
 review_app:
   stage: review
   variables:
-    PULUMI_STACK: $PULUMI_STACK_REVIEW_NAME
+    PULUMI_STACK: ${PULUMI_STACK_REVIEW_NAME}-${CI_MERGE_REQUEST_IID}
   script:
     # Install Pulumi
     - curl -fsSL https://get.pulumi.com | sh
@@ -83,7 +83,7 @@ review_app:
 destroy_review_app:
   stage: cleanup
   variables:
-    PULUMI_STACK: $PULUMI_STACK_REVIEW_NAME
+    PULUMI_STACK: ${PULUMI_STACK_REVIEW_NAME}-${CI_MERGE_REQUEST_IID}
   script:
     - curl -fsSL https://get.pulumi.com | sh
     - export PATH="$HOME/.pulumi/bin:$PATH"

--- a/skills/datarobot-app-framework-cicd/scripts/taskfile-snippets.yaml
+++ b/skills/datarobot-app-framework-cicd/scripts/taskfile-snippets.yaml
@@ -13,170 +13,174 @@
 # Tasks are then run as: task infra:encrypt-secrets, task infra:setup-github-secrets, etc.
 # Scripts referenced here are in infra/scripts/ and .env is assumed to be in project root (../../.env)
 
-# =============================================================================
-# Secrets Management Tasks
-# =============================================================================
+version: '3'
 
-encrypt-secrets:
-  desc: 🔒 Encrypt .env file for GitHub Actions
-  dir: scripts
-  cmds:
-    - ./encrypt-secrets.sh
-  preconditions:
-    - test -f ../../.env
+tasks:
 
-decrypt-secrets:
-  desc: 🔓 Decrypt .env.gpg file for local use
-  dir: scripts
-  cmds:
-    - ./decrypt-secrets.sh
-  preconditions:
-    - test -f ../../.env.gpg
+  # ===========================================================================
+  # Secrets Management Tasks
+  # ===========================================================================
 
-verify-secrets:
-  desc: 🔍 Verify .env file has required variables
-  cmds:
-    - |
-      REQUIRED_VARS="DATAROBOT_API_TOKEN DATAROBOT_ENDPOINT"
-      MISSING=""
-      for var in $REQUIRED_VARS; do
-        if ! grep -q "^${var}=" .env 2>/dev/null; then
-          MISSING="$MISSING $var"
+  encrypt-secrets:
+    desc: 🔒 Encrypt .env file for GitHub Actions
+    dir: scripts
+    cmds:
+      - ./encrypt-secrets.sh
+    preconditions:
+      - test -f ../../.env
+
+  decrypt-secrets:
+    desc: 🔓 Decrypt .env.gpg file for local use
+    dir: scripts
+    cmds:
+      - ./decrypt-secrets.sh
+    preconditions:
+      - test -f ../../.env.gpg
+
+  verify-secrets:
+    desc: 🔍 Verify .env file has required variables
+    cmds:
+      - |
+        REQUIRED_VARS="DATAROBOT_API_TOKEN DATAROBOT_ENDPOINT"
+        MISSING=""
+        for var in $REQUIRED_VARS; do
+          if ! grep -q "^${var}=" .env 2>/dev/null; then
+            MISSING="$MISSING $var"
+          fi
+        done
+        if [ -n "$MISSING" ]; then
+          echo "❌ Missing required variables:$MISSING"
+          exit 1
         fi
-      done
-      if [ -n "$MISSING" ]; then
-        echo "❌ Missing required variables:$MISSING"
-        exit 1
-      fi
-      echo "✅ All required variables present"
+        echo "✅ All required variables present"
 
-setup-github-secrets:
-  desc: 🔐 Setup GitHub secrets interactively
-  dir: scripts
-  cmds:
-    - ./setup-github-secrets.sh
+  setup-github-secrets:
+    desc: 🔐 Setup GitHub secrets interactively
+    dir: scripts
+    cmds:
+      - ./setup-github-secrets.sh
 
-setup-gitlab-vars:
-  desc: 🔐 Setup GitLab variables interactively
-  dir: scripts
-  cmds:
-    - ./setup-gitlab-variables.sh
+  setup-gitlab-vars:
+    desc: 🔐 Setup GitLab variables interactively
+    dir: scripts
+    cmds:
+      - ./setup-gitlab-variables.sh
 
-# =============================================================================
-# CI/CD Deployment Tasks
-# =============================================================================
+  # ===========================================================================
+  # CI/CD Deployment Tasks
+  # ===========================================================================
 
-pulumi-login-cloud:
-  desc: 🌐 Login to Pulumi Cloud
-  cmds:
-    - pulumi login
-  preconditions:
-    - sh: command -v pulumi
-      msg: "Pulumi not installed. Run: curl -fsSL https://get.pulumi.com | sh"
+  pulumi-login-cloud:
+    desc: 🌐 Login to Pulumi Cloud
+    cmds:
+      - pulumi login
+    preconditions:
+      - sh: command -v pulumi
+        msg: "Pulumi not installed. Run: curl -fsSL https://get.pulumi.com | sh"
 
-pulumi-login-azure:
-  desc: ☁️  Login to Azure Blob backend
-  cmds:
-    - pulumi login azblob://{{.CONTAINER}}
-  vars:
-    CONTAINER: '{{.CONTAINER | default "pulumi-state"}}'
-  preconditions:
-    - sh: command -v pulumi
-      msg: "Pulumi not installed"
-    - sh: test -n "$AZURE_STORAGE_ACCOUNT"
-      msg: "AZURE_STORAGE_ACCOUNT not set"
-    - sh: test -n "$AZURE_STORAGE_KEY"
-      msg: "AZURE_STORAGE_KEY not set"
+  pulumi-login-azure:
+    desc: ☁️  Login to Azure Blob backend
+    cmds:
+      - pulumi login azblob://{{.CONTAINER}}
+    vars:
+      CONTAINER: '{{.CONTAINER | default "pulumi-state"}}'
+    preconditions:
+      - sh: command -v pulumi
+        msg: "Pulumi not installed"
+      - sh: test -n "$AZURE_STORAGE_ACCOUNT"
+        msg: "AZURE_STORAGE_ACCOUNT not set"
+      - sh: test -n "$AZURE_STORAGE_KEY"
+        msg: "AZURE_STORAGE_KEY not set"
 
-pulumi-login-s3:
-  desc: ☁️  Login to S3 backend
-  cmds:
-    - pulumi login s3://{{.BUCKET}}
-  vars:
-    BUCKET: '{{.BUCKET | default "pulumi-state"}}'
-  preconditions:
-    - sh: command -v pulumi
-      msg: "Pulumi not installed"
-    - sh: test -n "$AWS_ACCESS_KEY_ID"
-      msg: "AWS_ACCESS_KEY_ID not set"
+  pulumi-login-s3:
+    desc: ☁️  Login to S3 backend
+    cmds:
+      - pulumi login s3://{{.BUCKET}}
+    vars:
+      BUCKET: '{{.BUCKET | default "pulumi-state"}}'
+    preconditions:
+      - sh: command -v pulumi
+        msg: "Pulumi not installed"
+      - sh: test -n "$AWS_ACCESS_KEY_ID"
+        msg: "AWS_ACCESS_KEY_ID not set"
 
-pulumi-stack-create:
-  desc: 📚 Create new Pulumi stack
-  cmds:
-    - pulumi stack select --create {{.STACK}}
-  vars:
-    STACK: '{{.STACK | default "dev"}}'
-  preconditions:
-    - sh: command -v pulumi
-      msg: "Pulumi not installed"
+  pulumi-stack-create:
+    desc: 📚 Create new Pulumi stack
+    cmds:
+      - pulumi stack select --create {{.STACK}}
+    vars:
+      STACK: '{{.STACK | default "dev"}}'
+    preconditions:
+      - sh: command -v pulumi
+        msg: "Pulumi not installed"
 
-pulumi-deploy:
-  desc: 🚀 Deploy with Pulumi
-  cmds:
-    - source .venv/bin/activate && pulumi up {{.FLAGS}}
-  vars:
-    FLAGS: '{{.FLAGS | default "--yes"}}'
-  preconditions:
-    - test -d .venv
-    - sh: command -v pulumi
-      msg: "Pulumi not installed"
+  pulumi-deploy:
+    desc: 🚀 Deploy with Pulumi
+    cmds:
+      - source .venv/bin/activate && pulumi up {{.FLAGS}}
+    vars:
+      FLAGS: '{{.FLAGS | default "--yes"}}'
+    preconditions:
+      - test -d .venv
+      - sh: command -v pulumi
+        msg: "Pulumi not installed"
 
-pulumi-destroy:
-  desc: 🗑️  Destroy Pulumi stack
-  cmds:
-    - source .venv/bin/activate && pulumi destroy {{.FLAGS}}
-  vars:
-    FLAGS: '{{.FLAGS | default "--yes"}}'
-  preconditions:
-    - test -d .venv
-    - sh: command -v pulumi
-      msg: "Pulumi not installed"
+  pulumi-destroy:
+    desc: 🗑️  Destroy Pulumi stack
+    cmds:
+      - source .venv/bin/activate && pulumi destroy {{.FLAGS}}
+    vars:
+      FLAGS: '{{.FLAGS | default "--yes"}}'
+    preconditions:
+      - test -d .venv
+      - sh: command -v pulumi
+        msg: "Pulumi not installed"
 
-pulumi-output:
-  desc: 📋 Show Pulumi stack outputs
-  cmds:
-    - pulumi stack output {{.FORMAT}}
-  vars:
-    FORMAT: '{{.FORMAT | default "--json"}}'
+  pulumi-output:
+    desc: 📋 Show Pulumi stack outputs
+    cmds:
+      - pulumi stack output {{.FORMAT}}
+    vars:
+      FORMAT: '{{.FORMAT | default "--json"}}'
 
-# =============================================================================
-# CI/CD Workflow Testing
-# =============================================================================
+  # ===========================================================================
+  # CI/CD Workflow Testing
+  # ===========================================================================
 
-ci-test-local:
-  desc: 🧪 Test CI pipeline locally
-  cmds:
-    - task: lint-check
-    - task: test
-    - echo "✅ CI checks passed"
+  ci-test-local:
+    desc: 🧪 Test CI pipeline locally
+    cmds:
+      - task: lint-check
+      - task: test
+      - echo "✅ CI checks passed"
 
-ci-simulate-deploy:
-  desc: 🎭 Simulate GitHub Actions deployment locally
-  cmds:
-    - task: decrypt-secrets
-    - task: install
-    - task: ci-test-local
-    - task: pulumi-deploy
-    - echo "✅ Deployment simulation complete"
+  ci-simulate-deploy:
+    desc: 🎭 Simulate GitHub Actions deployment locally
+    cmds:
+      - task: decrypt-secrets
+      - task: install
+      - task: ci-test-local
+      - task: pulumi-deploy
+      - echo "✅ Deployment simulation complete"
 
 # =============================================================================
 # Usage Examples
 # =============================================================================
 #
 # Secrets management:
-#   task encrypt-secrets              # Encrypt .env for GitHub
-#   task decrypt-secrets              # Decrypt for local use
-#   task verify-secrets               # Check required vars
+#   task infra:encrypt-secrets              # Encrypt .env for GitHub
+#   task infra:decrypt-secrets              # Decrypt for local use
+#   task infra:verify-secrets               # Check required vars
 #
 # Pulumi operations:
-#   task pulumi-login-cloud           # Login to Pulumi Cloud
-#   task pulumi-login-azure           # Login to Azure backend
-#   task pulumi-stack-create STACK=dev        # Create new stack
-#   task pulumi-deploy                # Deploy current stack
-#   task pulumi-deploy FLAGS="--preview-only" # Preview changes
-#   task pulumi-destroy               # Destroy current stack
-#   task pulumi-output                # Show outputs
+#   task infra:pulumi-login-cloud           # Login to Pulumi Cloud
+#   task infra:pulumi-login-azure           # Login to Azure backend
+#   task infra:pulumi-stack-create STACK=dev        # Create new stack
+#   task infra:pulumi-deploy                # Deploy current stack
+#   task infra:pulumi-deploy FLAGS="--preview-only" # Preview changes
+#   task infra:pulumi-destroy               # Destroy current stack
+#   task infra:pulumi-output                # Show outputs
 #
 # Testing CI/CD:
-#   task ci-test-local                # Run all CI checks
-#   task ci-simulate-deploy           # Simulate full deployment
+#   task infra:ci-test-local                # Run all CI checks
+#   task infra:ci-simulate-deploy           # Simulate full deployment

--- a/skills/datarobot-app-framework-cicd/scripts/taskfile-snippets.yaml
+++ b/skills/datarobot-app-framework-cicd/scripts/taskfile-snippets.yaml
@@ -44,7 +44,7 @@ tasks:
         REQUIRED_VARS="DATAROBOT_API_TOKEN DATAROBOT_ENDPOINT"
         MISSING=""
         for var in $REQUIRED_VARS; do
-          if ! grep -q "^${var}=" .env 2>/dev/null; then
+          if ! grep -q "^${var}=" ../.env 2>/dev/null; then
             MISSING="$MISSING $var"
           fi
         done


### PR DESCRIPTION
## Summary

Add a new default “Simple Path” for GitHub Actions CI/CD using Pulumi Cloud + two GitHub Secrets, explicitly steering users away from infra/scripts/, Taskfile changes, and GPG unless they opt into advanced setups.

## Rationale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the recommended default CI/CD setup and tweaks stack-naming/defaults in the reference GitHub/GitLab pipeline templates, which could affect downstream repos that copy these files.
> 
> **Overview**
> Adds a new **default “Simple Path”** in `SKILL.md` for GitHub Actions CI/CD using Pulumi Cloud + GitHub Secrets, explicitly steering users away from `infra/scripts/`, Taskfile changes, and GPG unless they opt into advanced setups.
> 
> Introduces new `examples/` GitHub Actions workflows (`cd`, manual PR deploy, manual destroy) plus a companion `workflows-README.md` setup guide, and tightens existing reference templates by adding sensible stack-name defaults and fixing GitLab stack naming/Pulumi PATH handling. Also updates contributor guidance in `README.md` and converts `taskfile-snippets.yaml` into a valid Taskfile with corrected `.env` path usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d738063b90c11545239cfcee2df224d6a10bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->