### PR TITLE
Fix skill install path and add claude marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "datarobot-agent-skills",
+  "name": "datarobot-skills",
   "owner": {
     "name": "DataRobot"
   },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "datarobot-agent-skills",
+  "owner": {
+    "name": "DataRobot"
+  },
+  "plugins": [
+    {
+      "name": "datarobot-agent-skills",
+      "source": "./",
+      "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "datarobot-agent-skills",
+  "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
+  "version": "1.0.0",
+  "skills": "./skills/"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.0.0",
-  "skills": "./skills/"
+  "version": "1.0.0"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ Thumbs.db
 *.json
 !gemini-extension.json
 !.cursor-plugin/plugin.json
+!.claude-plugin/marketplace.json
+!.claude-plugin/plugin.json
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Available skills (in datarobot-* folders):
 - datarobot-model-monitoring: Model performance monitoring
 - datarobot-model-explainability: Model explainability and diagnostics
 - datarobot-data-preparation: Data upload and validation
+- datarobot-app-framework-cicd: CI/CD pipelines for DataRobot application templates
 - datarobot-external-agent-monitoring: External agent OTel instrumentation for DataRobot monitoring
 
 When asked to use a DataRobot skill, read the corresponding SKILL.md file for detailed guidance.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npx ai-agent-skills install datarobot-oss/datarobot-agent-skills
 **For a specific skill:**
 
 ```bash
-npx ai-agent-skills install datarobot-oss/datarobot-agent-skills/datarobot-predictions
+npx ai-agent-skills install datarobot-oss/datarobot-agent-skills/skills/datarobot-predictions
 ```
 
 **For a specific agent:**


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Claude plugin manifest files and updates documentation/ignore rules without changing runtime code or data handling.
> 
> **Overview**
> Adds Claude Code plugin metadata by introducing `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`, and updates `.gitignore` to keep these JSON files tracked despite the general `*.json` ignore.
> 
> Fixes the README’s per-skill installation command to reference the `skills/` subdirectory and updates the Cursor skills list to include `datarobot-app-framework-cicd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03eec8b991123e23315abe57235c785ef7529cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->