### PR TITLE
chore: drop GH_PAT setup from e2e workflow

### DIFF
--- a/.github/workflows/test-skills-e2e.yml
+++ b/.github/workflows/test-skills-e2e.yml
@@ -44,17 +44,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Configure git credentials for private package access
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          if [ -z "${GH_PAT}" ]; then
-            echo "::error::GH_PAT secret is not set — cannot clone datarobot/datarobot-agent-tester"
-            exit 1
-          fi
-          echo "machine github.com login x-access-token password ${GH_PAT}" >> ~/.netrc
-          chmod 600 ~/.netrc
-
       - name: Install e2e dependencies
         run: uv sync --group e2e
 


### PR DESCRIPTION
## Summary
- `datarobot/datarobot-agent-tester` is now public, so the `.netrc` credential setup is no longer needed — `uv sync` can clone it anonymously over HTTPS.
- After merge, the `GH_PAT` repo secret can be deleted from settings.

## Test plan
- [ ] CI `Skill quality evaluation` job still installs `datarobot-agent-tester` and runs the e2e suite to green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a GitHub Actions step that wrote a `.netrc` using `GH_PAT`; failures would be limited to dependency installation if private access were still required.
> 
> **Overview**
> The `Test Skills E2E` workflow no longer configures a `.netrc` with the `GH_PAT` secret before running `uv sync --group e2e`, relying on anonymous HTTPS access for dependencies instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00421d74dcefc846a568d0e31fd0563f8c40bce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->