### PR TITLE
chore: bump plugin versions to 1.0.1 and fix typo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 *.parquet
 *.json
 !gemini-extension.json
+!claude-extension.json
 !.cursor-plugin/plugin.json
 !.claude-plugin/marketplace.json
 !.claude-plugin/plugin.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ Thumbs.db
 *.parquet
 *.json
 !gemini-extension.json
-!claude-extension.json
 !.cursor-plugin/plugin.json
 !.claude-plugin/marketplace.json
 !.claude-plugin/plugin.json

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, and data preparation",
   "author": "DataRobot",
   "skills": [

--- a/skills/datarobot-app-framework-cicd/SKILL.md
+++ b/skills/datarobot-app-framework-cicd/SKILL.md
@@ -201,7 +201,7 @@ task infra:encrypt-secrets
 # 2. Push GitHub secrets
 task infra:setup-github-secrets
 
-# 3. Initialise Pulumi (sets backend + creates dev stack)
+# 3. Initialize Pulumi (sets backend + creates dev stack)
 task infra:pulumi-login-azure
 ```
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

- Bump all plugin versions from `1.0.0` to `1.0.1`: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`
- Fix typo in `datarobot-app-framework-cicd` SKILL.md: `Initialise` → `Initialize` (British → American spelling, consistent with the rest of the document)

## Rationale

Plugin versions should be bumped alongside content changes to ensure downstream consumers pick up the latest skill content. The `Initialise` typo was inconsistent with American English used throughout the file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata/doc-only changes: bumps plugin/extension version numbers and fixes a spelling typo in documentation, with no runtime code paths affected.
> 
> **Overview**
> Updates plugin/extension manifests (`.claude-plugin/*`, `.cursor-plugin/plugin.json`, `gemini-extension.json`) to bump the published version from `1.0.0` to `1.0.1`.
> 
> Fixes a small docs typo in `skills/datarobot-app-framework-cicd/SKILL.md` by changing “Initialise” to “Initialize” in the setup instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2794f1b3c1b32af272d7e0886f09744e629c7c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->