### PR TITLE
[CFX-5371] Add datarobot-agent-assist skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.0.0"
+      "version": "1.0.2"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.0.2"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ Use this skill when setting up CI/CD pipelines for DataRobot application templat
 ### datarobot-external-agent-monitoring
 Use this skill when instrumenting external AI agents for DataRobot monitoring. Supports Google ADK, LangChain, LangGraph, CrewAI, LlamaIndex, PydanticAI, and generic Python agents. Creates shell deployments and configures OpenTelemetry to send traces, logs, and metrics to DataRobot.
 
+### datarobot-agent-assist
+Use this skill to build AI agents and deploy them to DataRobot. Supports building LangGraph, CrewAI, LlamaIndex, NAT and Base agents. Created agents can be bundled with MCP server, backend APIs & React frontend.
+
 ## How to Use
 
 When a user requests a DataRobot-related task:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Available skills (in datarobot-* folders):
 - datarobot-data-preparation: Data upload and validation
 - datarobot-app-framework-cicd: CI/CD pipelines for DataRobot application templates
 - datarobot-external-agent-monitoring: External agent OTel instrumentation for DataRobot monitoring
+- datarobot-agent-assist: Building and deploying agents
 
 When asked to use a DataRobot skill, read the corresponding SKILL.md file for detailed guidance.
 ```
@@ -225,6 +226,7 @@ This repository contains skills for common DataRobot workflows. You can also con
 | `skills/datarobot-data-preparation/` | Utilities for data upload, dataset management, and data validation. | [SKILL.md](skills/datarobot-data-preparation/SKILL.md) |
 | `skills/datarobot-app-framework-cicd/` | Set up CI/CD pipelines for DataRobot application templates with GitLab and GitHub Actions. | [SKILL.md](skills/datarobot-app-framework-cicd/SKILL.md) |
 | `skills/datarobot-external-agent-monitoring/` | Instrument any external AI agent with OpenTelemetry to send traces, logs, and metrics to DataRobot for monitoring and observability. Supports Google ADK, LangChain, LangGraph, CrewAI, LlamaIndex, PydanticAI, and generic Python agents. | [SKILL.md](skills/datarobot-external-agent-monitoring/SKILL.md) |
+| `skills/datarobot-agent-assist/` | Build AI agents and deploy them to DataRobot. Supports building LangGraph, CrewAI, LlamaIndex, NAT and Base agents. Created agents can be bundled with MCP server, backend APIs & React frontend. | [SKILL.md](skills/datarobot-agent-assist/SKILL.md) |
 
 ## Using skills in your coding agent
 
@@ -246,6 +248,7 @@ Some skills include helper scripts that an agent can run directly:
 - **datarobot-model-training**: `create_project.py`, `start_training.py`, `list_models.py`
 - **datarobot-data-preparation**: `upload_dataset.py`
 - **datarobot-external-agent-monitoring**: `create_shell_deployment.py`, `verify_otel_connection.py`
+- **datarobot-agent-assist**: `select_framework.py`, `clone_template.py`, `setup_template.py`, `list_llm_models.py`, `rehearsal.py`, `env_utils.py`
 
 These scripts are located in each skill's `scripts/` directory and can be executed directly or used as references when writing code.
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,8 +37,15 @@ tasks:
     cmds:
       - yamlfmt -lint .
 
+  mypy:
+    desc: Run mypy type checker on Python scripts (override dir with DIR=<path>)
+    vars:
+      DIR: '{{.DIR | default "skills/"}}'
+    cmds:
+      - uv run --group dev mypy {{.DIR}}
+
   lint:
-    desc: Run all linting checks (validate skills + ruff + shellcheck + yamlfmt)
+    desc: Run all linting checks (validate skills + ruff + mypy + shellcheck + yamlfmt)
     deps:
       - validate
       - ruff:check

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -50,6 +50,7 @@ tasks:
       - validate
       - ruff:check
       - ruff:format:check
+      - mypy
       - shellcheck
       - yamlfmt:check
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -48,6 +48,11 @@
       "name": "datarobot-external-agent-monitoring",
       "description": "Instrument any external AI agent with OpenTelemetry to send traces, logs, and metrics to DataRobot for monitoring, observability, and governance",
       "path": "skills/datarobot-external-agent-monitoring/SKILL.md"
+    },
+    {
+      "name": "datarobot-agent-assist",
+      "description": "Build AI agents and deploy them to DataRobot. Supports building LangGraph, CrewAI, LlamaIndex, NAT and Base agents. Created agents can be bundled with MCP server, backend APIs & React frontend",
+      "path": "skills/datarobot-agent-assist/SKILL.md"
     }
   ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, and data preparation",
   "author": "DataRobot",
   "skills": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,30 @@ e2e = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 
+[tool.mypy]
+# The strategy moving forward is to delete these one by one and get the errors back to zero.
+exclude = [
+    "skills/datarobot-data-preparation",
+    "skills/datarobot-predictions",
+    "skills/datarobot-model-training",
+    "skills/datarobot-external-agent-monitoring",
+]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+enable_error_code = "ignore-without-code"
+implicit_reexport = true
+ignore_missing_imports = true
+no_implicit_optional = true
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ requires-python = ">=3.11"
 dependencies = []
 
 [dependency-groups]
+dev = [
+    "mypy>=1.10",
+]
 e2e = [
     "datarobot-agent-tester @ git+https://github.com/datarobot/datarobot-agent-tester@main",
     "python-dotenv>=1.0",

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   via built-in rehearsal engine, template-based coding, and deployment. Combines agent design guidance
   with interactive pre-code simulation (DataRobot LLM Gateway, feedback report). Use when the user
   wants to design, build, code, or deploy an AI agent for DataRobot, run a spec simulation before
-  coding, mentions "agent spec", "datarobot-agent-assist", "dr-assist", "dress rehearsal", or creating agents on DataRobot's
+  coding, mentions "agent spec", "datarobot-agent-assist", "dr-assist", "dress rehearsal", or is creating agents on DataRobot's
   platform.
 ---
 
@@ -15,7 +15,7 @@ This skill merges **agent design, coding, and deployment** with **interactive dr
 
 Assistance falls into three categories:
 
-1. **Designing an AI agent** → Clarify requirements, build `agent_spec.md`, optionally simulate before code
+1. **Designing an AI agent** → Clarify requirements, build `agent_spec.md`, optionally simulate the agent before coding
 2. **Coding an AI agent** → Adapt the DataRobot agent application template to the spec
 3. **Deploying an AI agent** → Follow `AGENTS.md` deployment instructions
 
@@ -36,7 +36,7 @@ What would you like to do?
   3. Deploy an AI agent     → Deploy an implemented agent to DataRobot
 ```
 
-After the user selects an option, and before proceeding, make sure the DataRobot CLI minimum v0.2.64 or higher is installed and authenticated (see **DataRobot CLI Setup** section at the bottom).
+After the user selects an option, and before proceeding, make sure the DataRobot CLI minimum v0.2.66 or higher is installed and authenticated (see **DataRobot CLI Setup** section at the bottom).
 - If the CLI is not set up, ALWAYS RUN shell command to install it before proceeding.
 - ALWAYS RUN the shell command to upgrade CLI before proceeding.
 - If the CLI is not authenticated, ALWAYS RUN shell command to authenticate before proceeding.
@@ -178,7 +178,7 @@ Then offer to implement any changes to `agent_spec.md`.
 
 ## 2. Coding an AI Agent
 
-**On Windows: coding is not supported here. Tell the user to use another IDE (Claude Code, Cursor, VS Code, etc.).**
+**On Windows: coding is not supported. STOP and do NOT proceed with the next steps!**
 
 ### Pre-coding Checklist
 
@@ -264,6 +264,8 @@ Then offer to implement any changes to `agent_spec.md`.
 ---
 
 ## Helper Scripts
+
+The following are the examples of helper scripts used in the skill. They are located in the `scripts` directory and are designed to assist with various tasks.
 
 ### list_llm_models.py
 
@@ -356,7 +358,7 @@ frontend:
 
 When tools require external service auth, note that credentials must be configured as **runtime parameters** in the infrastructure code (see `AGENTS.md` for the pattern).
 
-See [references/agent-spec-examples.md](references/agent-spec-examples.md) for complete worked examples.
+See [references/agent-spec-examples.md](references/agent-spec-examples.md) for complete working examples.
 
 ---
 
@@ -415,7 +417,7 @@ Check if the CLI is installed:
 dr --version
 ```
 
-Expected output: `DataRobot CLI version: v0.2.64` (or similar)
+Expected output: `DataRobot CLI version: v0.2.66` (or similar)
 
 ### Install DataRobot CLI
 

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -36,10 +36,19 @@ What would you like to do?
   3. Deploy an AI agent     → Deploy an implemented agent to DataRobot
 ```
 
-After the user selects an option, and before proceeding, make sure the DataRobot CLI minimum v0.2.66 or higher is installed and authenticated (see **DataRobot CLI Setup** section at the bottom).
-- If the CLI is not set up, ALWAYS RUN shell command to install it before proceeding.
-- ALWAYS RUN the shell command to upgrade CLI before proceeding.
-- If the CLI is not authenticated, ALWAYS RUN shell command to authenticate before proceeding.
+After the user selects an option, and before proceeding, run through the **[Pre-requisite Check](#pre-requisite-check)** section below.
+
+---
+
+## Pre-requisite Check
+
+Run in order before proceeding:
+
+1. **Git** — run `git --version`. If missing, tell the user to install from https://git-scm.com and stop.
+2. **DataRobot CLI** — follow **DataRobot CLI Setup** at the bottom:
+   - If missing, **ALWAYS RUN** the install command before proceeding
+   - **ALWAYS RUN** the upgrade command before proceeding
+   - If not authenticated, **ALWAYS RUN** the auth command before proceeding
 
 ---
 

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -45,7 +45,8 @@ After the user selects an option, and before proceeding, run through the **[Pre-
 Run in order before proceeding:
 
 1. **Git** — run `git --version`. If missing, tell the user to install from https://git-scm.com and stop.
-2. **DataRobot CLI** — follow **DataRobot CLI Setup** at the bottom:
+2. **Python** — run `python --version`. If missing or below 3.11, tell the user to install Python 3.11+ from https://python.org and stop.
+3. **DataRobot CLI** — follow **DataRobot CLI Setup** at the bottom:
    - If missing, **ALWAYS RUN** the install command before proceeding
    - **ALWAYS RUN** the upgrade command before proceeding
    - If not authenticated, **ALWAYS RUN** the auth command before proceeding

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: datarobot-agent-assist
+description: >-
+  Unified DataRobot agent workflow — design (agent_spec.md), optional dress-rehearsal simulation
+  via built-in rehearsal engine, template-based coding, and deployment. Combines agent design guidance
+  with interactive pre-code simulation (DataRobot LLM Gateway, feedback report). Use when the user
+  wants to design, build, code, or deploy an AI agent for DataRobot, run a spec simulation before
+  coding, mentions "agent spec", "datarobot-agent-assist", "dr-assist", "dress rehearsal", or creating agents on DataRobot's
+  platform.
+---
+
+# DataRobot Agent Assist
+
+This skill merges **agent design, coding, and deployment** with **interactive dress-rehearsal simulation** in one place.
+
+Assistance falls into three categories:
+
+1. **Designing an AI agent** → Clarify requirements, build `agent_spec.md`, optionally simulate before code
+2. **Coding an AI agent** → Adapt the DataRobot agent application template to the spec
+3. **Deploying an AI agent** → Follow `AGENTS.md` deployment instructions
+
+If the user's first message is simply `1`, `2`, or `3`, treat it as selecting one of these categories.
+
+---
+
+## On Activation
+
+Present the three options clearly:
+
+```
+Welcome! I help you design, code, and deploy AI agents (with optional dress-rehearsal simulation before coding).
+
+What would you like to do?
+  1. Design an AI agent     → Describe your idea
+  2. Code an AI agent       → Load and implement an existing agent_spec.md
+  3. Deploy an AI agent     → Deploy an implemented agent to DataRobot
+```
+
+After the user selects an option, and before proceeding, make sure the DataRobot CLI minimum v0.2.64 or higher is installed and authenticated (see **DataRobot CLI Setup** section at the bottom).
+- If the CLI is not set up, ALWAYS RUN shell command to install it before proceeding.
+- ALWAYS RUN the shell command to upgrade CLI before proceeding.
+- If the CLI is not authenticated, ALWAYS RUN shell command to authenticate before proceeding.
+
+---
+
+## 1. Designing an AI Agent
+
+### Clarification Phase
+
+- Ask **at most 2 rounds** of clarifying questions before proposing an initial draft spec. If tools are still ambiguous after two rounds, start simple.
+- Focus questions on:
+  - What the agent does and who uses it
+  - What tools it needs and what external services those tools call
+  - Whether those services require authentication (API key, OAuth2, bearer token, etc.)
+  - Whether the user needs a custom frontend beyond the default chat UI
+
+- If the user mentions UI-related needs early ("dashboard", "visualization", "multi-page", "admin panel", "settings page"), capture it immediately in the `frontend` field — do **not** defer.
+
+### Model Selection
+
+- To check available models: Run the helper script:
+   ```
+   python <skill_scripts_dir>/list_llm_models.py \
+     --json
+   ```
+
+  **CRITICAL**: In case the script fails due to any reason, do **not** proceed. Instead, return the error message to the user and ask how they want to proceed.
+
+- Recommend a `gpt-5`, `claude-4-5`, or `gemini-2.5` model from the list unless the user specifies cost or other constraints.
+- Only display the full model catalog when the user **explicitly** asks to browse models.
+- If the user's desired model is unavailable, suggest starting with an available one and updating after implementation.
+
+### Spec Display
+
+- **Always write the current spec to `agent_spec.md`** (YAML format) whenever showing it to the user.
+- Show the spec frequently and iteratively — even if incomplete or partial.
+- Do **not** summarize the spec in prose; display it as YAML in a code block.
+- After displaying, invite the user to refine system prompts, add/modify tools, change the model, or update examples.
+
+### Frontend Check (Mandatory Before Coding or Simulating)
+
+Before offering to simulate or code, if the spec does not already have a `frontend` field set, **always ask**:
+
+> "The template includes a default chat UI — is that sufficient, or would you like a custom frontend such as a dashboard, data visualization, or multi-page app?"
+
+Then update the spec accordingly:
+- Default UI → `frontend.type: "chat"`
+- Custom UI → `frontend.type: "multi-page"` or `"custom"` with `pages` and optional `requirements`
+
+### Agent Simulation (Before Coding)
+
+Always offer to simulate the agent before coding it. **Run simulation** by following [Dress Rehearsal](#dress-rehearsal) in this skill end to end: initialize with `rehearsal.py --init`, drive turns with `--session`, handle `NOTE:` / `DONE`, and produce the dress rehearsal feedback report. Do not substitute improvised role-play or manual mock tool traces for this flow.
+
+Script path (from project root):
+
+`python <skill_scripts_dir>/rehearsal.py ...`
+
+---
+
+## Dress Rehearsal
+
+Simulate an `agent_spec.md` interactively before writing any code. Responses go through the DataRobot LLM Gateway; the rehearsal script handles API calls, state, and output. You orchestrate the loop, handle out-of-character commands, and produce the feedback report at the end.
+
+**Engine location:** `<skill_scripts_dir>/rehearsal.py` (relative to repository root).
+
+### Step 1 — Initialize the session
+
+```bash
+python <skill_scripts_dir>/rehearsal.py --init [--spec agent_spec.md]
+```
+
+If `agent_spec.md` does not exist and no path was provided, say so and stop.
+
+The script creates a unique session directory in the system temp dir and prints two lines:
+```
+session=<session_dir>
+output=<output_file>
+```
+
+Retain `session_dir` for all subsequent calls. Read the `output_file` and display its contents verbatim, then say:
+
+> You are now the **end user** of this agent. Type messages as a real user would.
+>
+> **Out-of-character commands:**
+> - `NOTE: <text>` — record a design observation
+> - `DONE` — end the session and generate your feedback report
+
+### Step 2 — Simulation loop
+
+Keep track of any notes and the number of turns as the session progresses — you'll need these for the report.
+
+**On each user message:**
+
+- If it starts with `NOTE:` — acknowledge the note, prompt for next message. Do not call the script.
+- If it is `DONE` — proceed to Step 3.
+- Otherwise — run the turn:
+
+```bash
+python <skill_scripts_dir>/rehearsal.py --session {session_dir} "{user_message}"
+```
+
+The script prints `output=<output_file>`. Read that file and display its contents verbatim. It will contain `[TOOL CALL]`, `[SIMULATED RETURN]`, and `[Agent]:` blocks as appropriate.
+
+If the script exits non-zero, display the error and ask whether to continue or abort.
+
+### Step 3 — Feedback report
+
+Before writing the report, review the session and consider each of these areas — only surface the ones where you have something concrete to say:
+
+- **System prompt** — wording, missing constraints, persona, tone
+- **Tools** — input/output scoping, missing or redundant tools, argument naming
+- **Model** — only flag if clearly wrong for the observed task complexity
+- **Example prompts** — additions or revisions based on what was tested
+- **Other** — edge cases, UX concerns, data dependency risks
+
+Then write the report in this format:
+
+```
+════════════════════════════════════════════
+  DRESS REHEARSAL REPORT
+════════════════════════════════════════════
+
+{1–2 sentences: what was tested and how the agent performed overall}
+{If notes were recorded: "Notes: " followed by each note on its own line, prefixed with —}
+
+Suggested changes:
+1. {specific, actionable change}
+2. {specific, actionable change}
+…
+{If nothing worth changing: "No changes recommended."}
+
+════════════════════════════════════════════
+```
+
+Then offer to implement any changes to `agent_spec.md`.
+
+---
+
+## 2. Coding an AI Agent
+
+**On Windows: coding is not supported here. Tell the user to use another IDE (Claude Code, Cursor, VS Code, etc.).**
+
+### Pre-coding Checklist
+
+1. Check if `agent_spec.md` exists — if so, **read it first**
+2. Check if `AGENTS.md` exists in the template directory (default: current working directory)
+3. If `AGENTS.md` does **not** exist, prepare the template with these steps in order. ALWAYS follow the steps in order and do not skip any, even if they seem redundant. This is critical for ensuring the template is properly set up and avoiding wasted effort coding on a broken foundation.
+   a. **Check the working directory** — if it contains files other than `agent_spec.md`, warn the user and ask them to clear it before proceeding
+   b. **Clone the template**: Run the helper script:
+   ```
+   python <skill_scripts_dir>/clone_template.py
+   ```
+   c. **Select the agentic framework**:
+
+   **STOP. Do NOT proceed until the user has replied with their framework choice.**
+
+   Ask the user (exact message):
+   > Which agentic framework would you like to use?
+   > 1. LangGraph
+   > 2. CrewAI
+   > 3. LlamaIndex
+   > 4. NeMo Agent Toolkit (NAT)
+   > 5. Base
+
+   Wait for the user's reply. Do not assume or default to any framework. Once the user replies, map their choice to the corresponding value (`langgraph`, `crewai`, `llamaindex`, `nat`, `base`) and run:
+   ```
+   python <skill_scripts_dir>/select_framework.py \
+     --target-dir . \
+     --framework <value>
+   ```
+
+   d. **Validate the template**: Run `dr dependency check`. If it fails, return the error message to the user DO NOT proceed. If it succeeds, continue to the next step.
+   e. **Setup the template**: Run the helper script:
+   ```
+   python <skill_scripts_dir>/setup_template.py \
+     --llm-model <model-name> \
+     --target-dir .
+   ```
+
+   **CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
+
+   f. **Re-read `AGENTS.md`** now that the template is ready
+4. Recreate the TODO list based on the `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool
+
+
+### Coding Rules
+
+- Implement by adapting the template code — do not write from scratch
+- Modify files only inside the current directory and its subdirectories
+- Do not view `.env` files (`.env.template` files are OK)
+- Do not add code comments unless asked
+- Do not mock tool implementations unless they would be complex to implement
+- For tasks with 3+ steps, use the TodoWrite tool to manage your work
+- Keep text responses **concise (1–3 sentences)** while coding — skip preamble and postamble
+
+### File Write/Edit Discipline
+
+- Always explain **why** the change is needed (purpose and impact) in 1–2 sentences before writing or editing a file
+- Invoke at most **one shell command per response** — wait for the result before invoking another
+
+### After Coding
+
+1. **Proactively test the agent code locally** — read `AGENTS.md` and follow its local testing instructions to validate the implementation. Attempt this before suggesting next steps.
+
+2. **If the user asks for help testing locally**:
+   - Read `AGENTS.md` to find the exact shell command(s) required to run the agent locally
+   - Display the command(s) in a code block
+   - Tell the user to run the command in a **new terminal** in the current directory
+   - Do **not** run the command yourself
+
+3. After completing code generation and testing, present next steps:
+   - Testing the agent locally
+   - Revising aspects of the implementation
+   - Deploying to DataRobot
+
+---
+
+## 3. Deploying an AI Agent
+
+- Read `AGENTS.md` for deployment instructions
+- Follow the instructions **strictly**
+- Do not deviate without user confirmation
+
+---
+
+## Helper Scripts
+
+### list_llm_models.py
+
+Lists available LLM models from DataRobot LLM Gateway.
+
+Fetches and displays active models from the DataRobot LLM Gateway catalog:
+```bash
+python <scripts_dir>/list_llm_models.py \
+  --json
+```
+
+Requires env vars: `DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`
+
+### clone_template.py
+
+Clones the DataRobot agent application template repository.
+
+Clones the template to the current directory (repository URL and branch are hardcoded):
+```bash
+python <scripts_dir>/clone_template.py
+```
+
+Clone to a specific directory:
+```bash
+python <scripts_dir>/clone_template.py \
+  --target-dir ./my-project
+```
+
+### setup_template.py
+
+Sets up a template repository for initializing a new agent project.
+
+```bash
+python <scripts_dir>/setup_template.py \
+  --llm-model <model-name> \
+  --target-dir .
+```
+
+### select_framework.py
+
+Saves the chosen agentic framework to `.datarobot/answers/agent-agent.yml`
+(field `agent_template_framework`). Preserves all other fields in the file.
+
+```bash
+python <scripts_dir>/select_framework.py \
+  --framework langgraph \
+  --target-dir .
+```
+
+Valid `--framework` values: `langgraph`, `crewai`, `llamaindex`, `nat`, `base`
+
+
+## Error Handling
+
+- If a tool returns an error, read the error message carefully before responding
+- For template-prep **warnings**: try to resolve yourself
+- For template-prep **errors**: return the message to the user and ask how to proceed
+- On unexpected errors, ask the user if they want to retry
+
+---
+
+## agent_spec.md Schema
+
+Write specs in YAML to `agent_spec.md` in the working directory. Fields are optional when the spec is still evolving.
+
+```yaml
+model: "anthropic/claude-sonnet-4-5-20250929"   # DataRobot LLM Gateway model ID
+system_prompt: "Your agent's instructions..."
+tools:
+  - function_name: tool_name
+    inputs:
+      - arg_name: input_arg
+        type: str         # one of: str, int, float, bool, list, dict
+        object_schema: "(optional: schema of dict/list contents)"
+    out:
+      - arg_name: output_arg
+        type: str
+    auth_spec:
+      service_name: "External API Service"
+      auth_method: api_key   # api_key | oauth2 | basic_auth | bearer_token | service_account | other
+examples:
+  - "Example user query 1"
+  - "Example user query 2"
+frontend:
+  type: "chat"              # chat | multi-page | custom
+  pages:
+    - "Analytics - shows search history and top topics"
+  requirements: "(optional additional UI requirements)"
+```
+
+When tools require external service auth, note that credentials must be configured as **runtime parameters** in the infrastructure code (see `AGENTS.md` for the pattern).
+
+See [references/agent-spec-examples.md](references/agent-spec-examples.md) for complete worked examples.
+
+---
+
+## Tool/Helper Scripts Timeouts
+
+- Allow up to 10 minutes for any helper script to complete before timing out and returning an error
+- Allow up to 5 minutes for any tool to return a response before timing out and returning an error
+- Allow up to 30 minutes for deployment-related shell commands to complete before timing out and returning an error
+
+---
+
+
+## Tool Mapping
+
+Claude's built-in tools replace the plugin's custom Python tools:
+
+| Plugin Tool | Claude Tool |
+|---|---|
+| `read_file` | Read |
+| `write_file` | Write |
+| `edit_file` | Edit |
+| `shell` | Bash |
+| `list_dir` | Glob or Bash (`ls`) |
+| `grep_files` | Grep |
+| `glob` | Glob |
+| `web_search` | WebSearch |
+| `get_web_page` | WebFetch |
+| `write_todos` / `read_todos` | TodoWrite |
+| `show_agent_spec` | Write to `agent_spec.md` + display as YAML |
+| `prepare_to_code` | Bash (`git clone` + `dr start`) |
+| `list_available_models` | WebFetch (DataRobot API) |
+| `code_research` | Agent (Explore subagent) |
+| Agent simulation (dress rehearsal) | [Dress Rehearsal](#dress-rehearsal) + `<skill_scripts_dir>/rehearsal.py` in this skill directory |
+
+---
+
+## Behavioral Rules
+
+- If it is unclear whether the request falls into one of the three categories, ask a clarifying question
+- If the user insists on a task outside these three categories, politely decline
+- If a user asks to code before designing, strongly encourage designing first
+- During **coding**: keep responses to 1–3 sentences; no introductions or conclusions
+- During **design**: be conversational and thorough
+
+---
+
+## DataRobot CLI Setup
+
+The DataRobot CLI (`dr`) is required for managing DataRobot custom applications.
+
+### Verify Installation
+
+Check if the CLI is installed:
+
+```bash
+dr --version
+```
+
+Expected output: `DataRobot CLI version: v0.2.64` (or similar)
+
+### Install DataRobot CLI
+
+If not installed, run:
+
+**macOS/Linux:**
+```bash
+curl https://cli.datarobot.com/install | sh
+```
+
+**Windows:**
+```powershell
+irm https://cli.datarobot.com/winstall | iex
+```
+
+### Upgrade CLI
+
+If the CLI version is too old, run to upgrade:
+
+```bash
+dr self update --force
+```
+
+### Check Authentication Status
+
+Verify the CLI is authenticated:
+
+```bash
+dr auth check
+```
+
+### Authenticate
+
+If not authenticated, run:
+
+```bash
+dr auth login
+```
+
+This will guide the user through the authentication process interactively.
+=======

--- a/skills/datarobot-agent-assist/references/agent-spec-examples.md
+++ b/skills/datarobot-agent-assist/references/agent-spec-examples.md
@@ -1,0 +1,129 @@
+# agent_spec.md Examples
+
+## Example 1: Weather Agent (Simple)
+
+```yaml
+model: anthropic/claude-3-5-haiku-20241022
+system_prompt: You are a helpful weather assistant that provides current weather conditions
+  for any location worldwide. When a user asks about weather, search for current weather
+  information and present the results in a clear, conversational way. Focus on current
+  conditions like temperature, weather description, and other relevant details.
+tools:
+  - function_name: search_weather
+    inputs:
+      - arg_name: location
+        type: str
+    out:
+      - arg_name: search_results
+        type: str
+    auth_spec:
+      service_name: Perplexity API
+      auth_method: api_key
+examples:
+  - What's the weather like in New York?
+  - How's the weather in Tokyo today?
+  - Current conditions in London
+frontend:
+  type: chat
+```
+
+---
+
+## Example 2: Multi-tool Research Agent (with Auth)
+
+```yaml
+model: anthropic/claude-sonnet-4-5-20250929
+system_prompt: You are a research assistant that helps users find and summarize
+  information from internal documents and the web. Always cite your sources.
+tools:
+  - function_name: search_internal_docs
+    inputs:
+      - arg_name: query
+        type: str
+      - arg_name: top_k
+        type: int
+    out:
+      - arg_name: documents
+        type: list
+        object_schema: "list of {title: str, content: str, url: str}"
+    auth_spec:
+      service_name: Internal Knowledge Base API
+      auth_method: bearer_token
+  - function_name: web_search
+    inputs:
+      - arg_name: query
+        type: str
+    out:
+      - arg_name: results
+        type: str
+examples:
+  - Find recent papers on LLM hallucination
+  - What does our internal policy say about data retention?
+  - Summarize the latest news on AI regulation
+frontend:
+  type: chat
+```
+
+---
+
+## Example 3: Multi-page Dashboard Agent
+
+```yaml
+model: google/gemini-2.5-pro-preview-05-06
+system_prompt: You are a sales analytics assistant. Help users understand their
+  pipeline, forecast revenue, and identify at-risk deals. Always ground your
+  answers in the data returned by tools.
+tools:
+  - function_name: get_pipeline_data
+    inputs:
+      - arg_name: date_range
+        type: str
+        object_schema: "ISO 8601 date range, e.g. '2024-01-01/2024-03-31'"
+    out:
+      - arg_name: deals
+        type: list
+        object_schema: "list of {deal_id: str, stage: str, value: float, close_date: str, owner: str}"
+    auth_spec:
+      service_name: Salesforce CRM
+      auth_method: oauth2
+  - function_name: forecast_revenue
+    inputs:
+      - arg_name: period
+        type: str
+    out:
+      - arg_name: forecast
+        type: dict
+        object_schema: "{expected: float, low: float, high: float, confidence: float}"
+examples:
+  - What's our Q2 pipeline look like?
+  - Which deals are at risk of slipping?
+  - Forecast revenue for next quarter
+frontend:
+  type: multi-page
+  pages:
+    - "Pipeline Overview - shows all deals by stage with filtering"
+    - "Revenue Forecast - charts expected vs actual with confidence bands"
+    - "At-Risk Deals - highlights deals with low probability or stalled activity"
+  requirements: "Charts should use a dark theme. Pipeline table must be sortable and filterable by owner and stage."
+```
+
+---
+
+## Auth Method Reference
+
+| `auth_method` | When to use |
+|---|---|
+| `api_key` | Static key passed in header or query param (e.g. OpenAI, Perplexity, SendGrid) |
+| `oauth2` | User-delegated access with token refresh (e.g. Salesforce, Google, GitHub) |
+| `basic_auth` | Username + password (e.g. legacy internal APIs) |
+| `bearer_token` | Static bearer token (e.g. DataRobot API, internal services) |
+| `service_account` | Non-human identity with key file or IAM role (e.g. GCP, AWS) |
+| `other` | Anything that doesn't fit the above |
+
+## Frontend Type Reference
+
+| `type` | When to use |
+|---|---|
+| `chat` | Default — single chat window, no additional pages needed |
+| `multi-page` | Multiple distinct pages (dashboard tabs, admin panel, etc.) |
+| `custom` | Fully custom UI that requires bespoke layout beyond pages |

--- a/skills/datarobot-agent-assist/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/scripts/clone_template.py
@@ -31,24 +31,22 @@ def cleanup_git_dir(target_dir: Path) -> None:
     if git_dir.exists():
         print(f"Cleaning up .git directory in {target_dir}")
         import shutil
+
         shutil.rmtree(git_dir)
 
 
 def run_git_command(
-    command: list[str],
-    description: str,
-    target_dir: Path,
-    timeout: int = 10
+    command: list[str], description: str, target_dir: Path, timeout: int = 10
 ) -> tuple[bool, str]:
     """
     Run a git command and return success status and output.
-    
+
     Args:
         command: Git command as list of strings
         description: Description of the operation
         target_dir: Target directory for the operation
         timeout: Timeout in seconds
-        
+
     Returns:
         Tuple of (success, output)
     """
@@ -60,16 +58,16 @@ def run_git_command(
             capture_output=True,
             text=True,
             timeout=timeout,
-            check=False
+            check=False,
         )
-        
+
         output = result.stdout + result.stderr
-        
+
         if result.returncode != 0:
             return False, output
-        
+
         return True, output
-        
+
     except subprocess.TimeoutExpired:
         return False, f"Command timed out after {timeout} seconds"
     except Exception as e:
@@ -79,41 +77,42 @@ def run_git_command(
 def check_guardrails(target_dir: Path) -> tuple[bool, Optional[str]]:
     """
     Check guardrails before cloning.
-    
+
     Returns:
         Tuple of (passed, error_message)
     """
     print("Running guardrail checks...")
-    
+
     # Check for existing git repository
     git_dir = target_dir / ".git"
     if git_dir.exists():
-        return False, f"Git repository already initialized in {target_dir}\n  Found: {git_dir}\n  Aborting to prevent overwriting existing repository"
-    
+        return (
+            False,
+            f"Git repository already initialized in {target_dir}\n  Found: {git_dir}\n  Aborting to prevent overwriting existing repository",
+        )
+
     # Check for AGENTS.md
     agents_file = target_dir / "AGENTS.md"
     if agents_file.exists():
-        return False, f"AGENTS.md file already exists in {target_dir}\n  Aborting to prevent overwriting existing configuration"
-    
+        return (
+            False,
+            f"AGENTS.md file already exists in {target_dir}\n  Aborting to prevent overwriting existing configuration",
+        )
+
     print("✓ Guardrail checks passed")
     return True, None
 
 
-def clone_repository(
-    repo_url: str,
-    ref: str,
-    ref_type: str,
-    target_dir: Path
-) -> int:
+def clone_repository(repo_url: str, ref: str, ref_type: str, target_dir: Path) -> int:
     """
     Clone a git repository using init, remote add, fetch, and checkout.
-    
+
     Args:
         repo_url: Git repository URL
         ref: Tag or branch name
         ref_type: Either "tag" or "branch"
         target_dir: Target directory for cloning
-        
+
     Returns:
         Exit code (0 for success, 1 for failure)
     """
@@ -122,82 +121,79 @@ def clone_repository(
     print(f"Reference: {ref}")
     print(f"Target directory: {target_dir}")
     print()
-    
+
     # Run guardrail checks
     passed, error_msg = check_guardrails(target_dir)
     if not passed:
         print(f"Error: {error_msg}")
         return 1
-    
+
     print()
-    
+
     # Ensure target directory exists
     target_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Step 1: Initialize git repository
     success, output = run_git_command(
         ["git", "init"],
         f"Initializing git repository in {target_dir}",
         target_dir,
-        timeout=10
+        timeout=10,
     )
-    
+
     if not success:
         print(f"Error: Failed to initialize git repository: {output}")
         return 1
-    
+
     # Step 2: Add remote
     success, output = run_git_command(
         ["git", "remote", "add", "origin", repo_url],
         f"Adding remote origin {repo_url}",
         target_dir,
-        timeout=10
+        timeout=10,
     )
-    
+
     if not success:
         print(f"Error: Failed to add remote: {output}")
         cleanup_git_dir(target_dir)
         return 1
-    
+
     # Step 3: Fetch from remote
     success, output = run_git_command(
         ["git", "fetch", "origin"],
         "Fetching from remote repository",
         target_dir,
-        timeout=60
+        timeout=60,
     )
-    
+
     if not success:
         print(f"Error: Failed to fetch from remote: {output}")
         cleanup_git_dir(target_dir)
         return 1
-    
+
     # Step 4: Checkout branch or tag
     if ref_type == "tag":
         success, output = run_git_command(
-            ["git", "checkout", ref],
-            f"Checking out tag {ref}",
-            target_dir,
-            timeout=10
+            ["git", "checkout", ref], f"Checking out tag {ref}", target_dir, timeout=10
         )
     else:
         success, output = run_git_command(
             ["git", "checkout", "-t", f"origin/{ref}"],
             f"Checking out and tracking branch {ref}",
             target_dir,
-            timeout=10
+            timeout=10,
         )
-    
+
     if not success:
         print(f"Error: Failed to checkout {ref_type} {ref}: {output}")
         cleanup_git_dir(target_dir)
         return 1
-    
+
     print()
     print("✓ Repository cloned successfully!")
     print(f"  Location: {target_dir}")
     print(f"  Checked out: {ref_type} '{ref}'")
-    
+
     return 0
 
 
@@ -213,31 +209,31 @@ def main() -> int:
     else:
         print("Error: Either TAG or BRANCH must be set in the script configuration")
         return 1
-    
+
     parser = argparse.ArgumentParser(
         description=f"Clone the DataRobot agent application template from {REPO_URL}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
 Repository: {REPO_URL}
-Tag: {TAG if TAG else 'Not set'}
-Branch: {BRANCH if BRANCH else 'Not set'}
+Tag: {TAG if TAG else "Not set"}
+Branch: {BRANCH if BRANCH else "Not set"}
 
 Example:
   %(prog)s
   %(prog)s --target-dir ./my-project
-        """
+        """,
     )
-    
+
     parser.add_argument(
         "--target-dir",
         default=".",
-        help="Target directory (default: current directory)"
+        help="Target directory (default: current directory)",
     )
-    
+
     args = parser.parse_args()
-    
+
     target_dir = Path(args.target_dir).resolve()
-    
+
     return clone_repository(REPO_URL, ref, ref_type, target_dir)
 
 

--- a/skills/datarobot-agent-assist/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/scripts/clone_template.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from typing import Optional
 
 REPO_URL = "https://github.com/datarobot-community/datarobot-agent-application.git"
-BRANCH = None
-TAG = "11.9.2"
+BRANCH: str | None = None
+TAG: str | None = "11.9.2"
 
 
 def cleanup_git_dir(target_dir: Path) -> None:

--- a/skills/datarobot-agent-assist/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/scripts/clone_template.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 REPO_URL = "https://github.com/datarobot-community/datarobot-agent-application.git"
 BRANCH = None
-TAG = "11.9.1"
+TAG = "11.9.2"
 
 
 def cleanup_git_dir(target_dir: Path) -> None:
@@ -63,10 +63,7 @@ def run_git_command(
 
         output = result.stdout + result.stderr
 
-        if result.returncode != 0:
-            return False, output
-
-        return True, output
+        return bool(not result.returncode), output
 
     except subprocess.TimeoutExpired:
         return False, f"Command timed out after {timeout} seconds"
@@ -88,7 +85,7 @@ def check_guardrails(target_dir: Path) -> tuple[bool, Optional[str]]:
     if git_dir.exists():
         return (
             False,
-            f"Git repository already initialized in {target_dir}\n  Found: {git_dir}\n  Aborting to prevent overwriting existing repository",
+            f"Git repository already initialized in {target_dir}\n\tFound: {git_dir}\n\tAborting to prevent overwriting existing repository",
         )
 
     # Check for AGENTS.md
@@ -96,7 +93,7 @@ def check_guardrails(target_dir: Path) -> tuple[bool, Optional[str]]:
     if agents_file.exists():
         return (
             False,
-            f"AGENTS.md file already exists in {target_dir}\n  Aborting to prevent overwriting existing configuration",
+            f"AGENTS.md file already exists in {target_dir}\n\tAborting to prevent overwriting existing configuration",
         )
 
     print("✓ Guardrail checks passed")

--- a/skills/datarobot-agent-assist/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/scripts/clone_template.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Clone the DataRobot agent application template repository.
+
+This script clones the DataRobot agent application template from a hardcoded
+GitHub repository URL and branch. It performs guardrail checks to prevent
+overwriting existing repositories or configurations, then uses git init, remote
+add, fetch, and checkout to clone the template into the target directory.
+
+Usage:
+    python clone_template.py [--target-dir <directory>]
+
+The repository URL and branch/tag are hardcoded in the script constants REPO_URL,
+BRANCH, and TAG at the top of this file. TAG takes priority over BRANCH if both
+are set.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+REPO_URL = "https://github.com/datarobot-community/datarobot-agent-application.git"
+BRANCH = None
+TAG = "11.9.1"
+
+
+def cleanup_git_dir(target_dir: Path) -> None:
+    """Clean up .git directory on failure."""
+    git_dir = target_dir / ".git"
+    if git_dir.exists():
+        print(f"Cleaning up .git directory in {target_dir}")
+        import shutil
+        shutil.rmtree(git_dir)
+
+
+def run_git_command(
+    command: list[str],
+    description: str,
+    target_dir: Path,
+    timeout: int = 10
+) -> tuple[bool, str]:
+    """
+    Run a git command and return success status and output.
+    
+    Args:
+        command: Git command as list of strings
+        description: Description of the operation
+        target_dir: Target directory for the operation
+        timeout: Timeout in seconds
+        
+    Returns:
+        Tuple of (success, output)
+    """
+    print(f"{description}...")
+    try:
+        result = subprocess.run(
+            command,
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False
+        )
+        
+        output = result.stdout + result.stderr
+        
+        if result.returncode != 0:
+            return False, output
+        
+        return True, output
+        
+    except subprocess.TimeoutExpired:
+        return False, f"Command timed out after {timeout} seconds"
+    except Exception as e:
+        return False, str(e)
+
+
+def check_guardrails(target_dir: Path) -> tuple[bool, Optional[str]]:
+    """
+    Check guardrails before cloning.
+    
+    Returns:
+        Tuple of (passed, error_message)
+    """
+    print("Running guardrail checks...")
+    
+    # Check for existing git repository
+    git_dir = target_dir / ".git"
+    if git_dir.exists():
+        return False, f"Git repository already initialized in {target_dir}\n  Found: {git_dir}\n  Aborting to prevent overwriting existing repository"
+    
+    # Check for AGENTS.md
+    agents_file = target_dir / "AGENTS.md"
+    if agents_file.exists():
+        return False, f"AGENTS.md file already exists in {target_dir}\n  Aborting to prevent overwriting existing configuration"
+    
+    print("✓ Guardrail checks passed")
+    return True, None
+
+
+def clone_repository(
+    repo_url: str,
+    ref: str,
+    ref_type: str,
+    target_dir: Path
+) -> int:
+    """
+    Clone a git repository using init, remote add, fetch, and checkout.
+    
+    Args:
+        repo_url: Git repository URL
+        ref: Tag or branch name
+        ref_type: Either "tag" or "branch"
+        target_dir: Target directory for cloning
+        
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    print(f"Cloning repository: {repo_url}")
+    print(f"Reference type: {ref_type}")
+    print(f"Reference: {ref}")
+    print(f"Target directory: {target_dir}")
+    print()
+    
+    # Run guardrail checks
+    passed, error_msg = check_guardrails(target_dir)
+    if not passed:
+        print(f"Error: {error_msg}")
+        return 1
+    
+    print()
+    
+    # Ensure target directory exists
+    target_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Step 1: Initialize git repository
+    success, output = run_git_command(
+        ["git", "init"],
+        f"Initializing git repository in {target_dir}",
+        target_dir,
+        timeout=10
+    )
+    
+    if not success:
+        print(f"Error: Failed to initialize git repository: {output}")
+        return 1
+    
+    # Step 2: Add remote
+    success, output = run_git_command(
+        ["git", "remote", "add", "origin", repo_url],
+        f"Adding remote origin {repo_url}",
+        target_dir,
+        timeout=10
+    )
+    
+    if not success:
+        print(f"Error: Failed to add remote: {output}")
+        cleanup_git_dir(target_dir)
+        return 1
+    
+    # Step 3: Fetch from remote
+    success, output = run_git_command(
+        ["git", "fetch", "origin"],
+        "Fetching from remote repository",
+        target_dir,
+        timeout=60
+    )
+    
+    if not success:
+        print(f"Error: Failed to fetch from remote: {output}")
+        cleanup_git_dir(target_dir)
+        return 1
+    
+    # Step 4: Checkout branch or tag
+    if ref_type == "tag":
+        success, output = run_git_command(
+            ["git", "checkout", ref],
+            f"Checking out tag {ref}",
+            target_dir,
+            timeout=10
+        )
+    else:
+        success, output = run_git_command(
+            ["git", "checkout", "-t", f"origin/{ref}"],
+            f"Checking out and tracking branch {ref}",
+            target_dir,
+            timeout=10
+        )
+    
+    if not success:
+        print(f"Error: Failed to checkout {ref_type} {ref}: {output}")
+        cleanup_git_dir(target_dir)
+        return 1
+    
+    print()
+    print("✓ Repository cloned successfully!")
+    print(f"  Location: {target_dir}")
+    print(f"  Checked out: {ref_type} '{ref}'")
+    
+    return 0
+
+
+def main() -> int:
+    """Main entry point."""
+    # Determine which ref to use (TAG takes priority over BRANCH)
+    if TAG:
+        ref_type = "tag"
+        ref = TAG
+    elif BRANCH:
+        ref_type = "branch"
+        ref = BRANCH
+    else:
+        print("Error: Either TAG or BRANCH must be set in the script configuration")
+        return 1
+    
+    parser = argparse.ArgumentParser(
+        description=f"Clone the DataRobot agent application template from {REPO_URL}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Repository: {REPO_URL}
+Tag: {TAG if TAG else 'Not set'}
+Branch: {BRANCH if BRANCH else 'Not set'}
+
+Example:
+  %(prog)s
+  %(prog)s --target-dir ./my-project
+        """
+    )
+    
+    parser.add_argument(
+        "--target-dir",
+        default=".",
+        help="Target directory (default: current directory)"
+    )
+    
+    args = parser.parse_args()
+    
+    target_dir = Path(args.target_dir).resolve()
+    
+    return clone_repository(REPO_URL, ref, ref_type, target_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/datarobot-agent-assist/scripts/env_utils.py
+++ b/skills/datarobot-agent-assist/scripts/env_utils.py
@@ -9,41 +9,42 @@ from pathlib import Path
 def read_env_variable(env_file: Path, variable_name: str) -> str:
     """
     Read a variable value from a .env file.
-    
+
     Args:
         env_file: Path to the .env file
         variable_name: Name of the variable to read
-        
+
     Returns:
         The variable value (stripped of quotes if present)
-        
+
     Raises:
         FileNotFoundError: If the .env file doesn't exist
         ValueError: If the variable is not found in the file
     """
     if not env_file.exists():
         raise FileNotFoundError(f".env file not found: {env_file}")
-    
-    with open(env_file, 'r') as f:
+
+    with open(env_file, "r") as f:
         for line in f:
             line = line.strip()
             # Skip empty lines and comments
-            if not line or line.startswith('#'):
+            if not line or line.startswith("#"):
                 continue
-            
+
             # Split on first = sign
-            if '=' in line:
-                key, value = line.split('=', 1)
+            if "=" in line:
+                key, value = line.split("=", 1)
                 key = key.strip()
                 value = value.strip()
-                
+
                 if key == variable_name:
                     # Remove surrounding quotes if present
-                    if (value.startswith('"') and value.endswith('"')) or \
-                       (value.startswith("'") and value.endswith("'")):
+                    if (value.startswith('"') and value.endswith('"')) or (
+                        value.startswith("'") and value.endswith("'")
+                    ):
                         value = value[1:-1]
                     return value
-    
+
     raise ValueError(f"Variable '{variable_name}' not found in {env_file}")
 
 
@@ -64,12 +65,16 @@ def ensure_env_file(env_file: Path = Path(".env")) -> None:
                 ["dr", "dotenv", "setup", "--yes", "--output", "."],
                 check=True,
                 capture_output=True,
-                text=True
+                text=True,
             )
             print(result.stdout)
         except subprocess.CalledProcessError as e:
-            print(f"Warning: Failed to run 'dr dotenv setup': {e.stderr}", file=sys.stderr)
+            print(
+                f"Warning: Failed to run 'dr dotenv setup': {e.stderr}", file=sys.stderr
+            )
             print("Falling back to environment variables...", file=sys.stderr)
         except FileNotFoundError:
-            print("Warning: 'dr' command not found. Falling back to environment variables...", file=sys.stderr)
-
+            print(
+                "Warning: 'dr' command not found. Falling back to environment variables...",
+                file=sys.stderr,
+            )

--- a/skills/datarobot-agent-assist/scripts/env_utils.py
+++ b/skills/datarobot-agent-assist/scripts/env_utils.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Utility functions for working with .env files."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def read_env_variable(env_file: Path, variable_name: str) -> str:
+    """
+    Read a variable value from a .env file.
+    
+    Args:
+        env_file: Path to the .env file
+        variable_name: Name of the variable to read
+        
+    Returns:
+        The variable value (stripped of quotes if present)
+        
+    Raises:
+        FileNotFoundError: If the .env file doesn't exist
+        ValueError: If the variable is not found in the file
+    """
+    if not env_file.exists():
+        raise FileNotFoundError(f".env file not found: {env_file}")
+    
+    with open(env_file, 'r') as f:
+        for line in f:
+            line = line.strip()
+            # Skip empty lines and comments
+            if not line or line.startswith('#'):
+                continue
+            
+            # Split on first = sign
+            if '=' in line:
+                key, value = line.split('=', 1)
+                key = key.strip()
+                value = value.strip()
+                
+                if key == variable_name:
+                    # Remove surrounding quotes if present
+                    if (value.startswith('"') and value.endswith('"')) or \
+                       (value.startswith("'") and value.endswith("'")):
+                        value = value[1:-1]
+                    return value
+    
+    raise ValueError(f"Variable '{variable_name}' not found in {env_file}")
+
+
+def ensure_env_file(env_file: Path = Path(".env")) -> None:
+    """
+    Ensure .env file exists, creating it via 'dr dotenv setup' if needed.
+
+    If .env file doesn't exist, attempts to run 'dr dotenv setup --yes --output .'
+    to create it. Prints warnings to stderr if setup fails but does not raise an error.
+
+    Args:
+        env_file: Path to the .env file (default: .env in current directory)
+    """
+    if not env_file.exists():
+        try:
+            print("No .env file found. Running 'dr dotenv setup --yes --output .'...")
+            result = subprocess.run(
+                ["dr", "dotenv", "setup", "--yes", "--output", "."],
+                check=True,
+                capture_output=True,
+                text=True
+            )
+            print(result.stdout)
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to run 'dr dotenv setup': {e.stderr}", file=sys.stderr)
+            print("Falling back to environment variables...", file=sys.stderr)
+        except FileNotFoundError:
+            print("Warning: 'dr' command not found. Falling back to environment variables...", file=sys.stderr)
+

--- a/skills/datarobot-agent-assist/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/scripts/list_llm_models.py
@@ -68,13 +68,15 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
             # Ensure model name has datarobot/ prefix
             if model_name and not model_name.startswith("datarobot/"):
                 model_name = f"datarobot/{model_name}"
-            
-            result.append({
-                "name": model_name,
-                "description": m.get("description", ""),
-                "provider": m.get("provider", "Unknown"),
-                "context_size": m.get("contextSize", 0),
-            })
+
+            result.append(
+                {
+                    "name": model_name,
+                    "description": m.get("description", ""),
+                    "provider": m.get("provider", "Unknown"),
+                    "context_size": m.get("contextSize", 0),
+                }
+            )
 
         return result
 
@@ -115,8 +117,14 @@ def format_as_table(models: list[dict]) -> str:
         name = m["name"]
         provider = m["provider"]
         context = str(m["context_size"])
-        description = m["description"][:80] + "..." if len(m["description"]) > 80 else m["description"]
-        lines.append(f"{name:<{name_width}} | {provider:<{provider_width}} | {context:>{context_width}} | {description}")
+        description = (
+            m["description"][:80] + "..."
+            if len(m["description"]) > 80
+            else m["description"]
+        )
+        lines.append(
+            f"{name:<{name_width}} | {provider:<{provider_width}} | {context:>{context_width}} | {description}"
+        )
 
     return "\n".join(lines)
 
@@ -168,7 +176,9 @@ def main():
 
     if not endpoint and not api_token:
         print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
-        print("Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr)
+        print(
+            "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
+        )
         sys.exit(1)
 
     if not endpoint:
@@ -176,7 +186,9 @@ def main():
         sys.exit(1)
 
     if not api_token:
-        print("Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr)
+        print(
+            "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
+        )
         sys.exit(1)
 
     try:

--- a/skills/datarobot-agent-assist/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/scripts/list_llm_models.py
@@ -17,13 +17,21 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import TypedDict
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from env_utils import ensure_env_file, read_env_variable
 
 
-def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
+class LLMModel(TypedDict):
+    name: str
+    description: str
+    provider: str
+    context_size: int
+
+
+def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
     """Fetch active LLM models from DataRobot Gateway.
 
     Args:
@@ -31,7 +39,7 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
         api_token: DataRobot API token for authentication
 
     Returns:
-        List of active model dictionaries with name, description, provider, and context_size
+        List of active LLMModel dictionaries with name, description, provider, and context_size
 
     Raises:
         RuntimeError: If the API request fails
@@ -55,14 +63,14 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
         else:
             raise RuntimeError(f"Unexpected response format: {type(data)}")
 
-        # Client-side filtering for active models (server-side activeOnly param is broken)
+        # Client-side filtering for active models
         active_models = [m for m in models_list if m.get("isActive", False)]
 
         if not active_models:
             raise RuntimeError("No active models found in catalog")
 
         # Extract key information
-        result = []
+        result: list[LLMModel] = []
         for m in active_models:
             model_name = m.get("model", "")
             # Ensure model name has datarobot/ prefix
@@ -86,7 +94,7 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
         raise RuntimeError(f"Failed to parse model catalog response: {e}") from e
 
 
-def format_as_table(models: list[dict]) -> str:
+def format_as_table(models: list[LLMModel]) -> str:
     """Format models as a readable table.
 
     Args:
@@ -99,12 +107,12 @@ def format_as_table(models: list[dict]) -> str:
         return "No models available"
 
     # Calculate column widths
-    name_width = max(len(m["name"]) for m in models)
-    name_width = max(name_width, len("Model Name"))
-    provider_width = max(len(m["provider"]) for m in models)
-    provider_width = max(provider_width, len("Provider"))
-    context_width = max(len(str(m["context_size"])) for m in models)
-    context_width = max(context_width, len("Context Size"))
+    models_name_width = max(len(m["name"]) for m in models)
+    name_width = max(models_name_width, len("Model Name"))
+    models_provider_width = max(len(m["provider"]) for m in models)
+    provider_width = max(models_provider_width, len("Provider"))
+    models_context_width = max(len(str(m["context_size"])) for m in models)
+    context_width = max(models_context_width, len("Context Size"))
 
     # Build table
     lines = []
@@ -129,7 +137,7 @@ def format_as_table(models: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def main():
+def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
         description="List available LLM models from DataRobot LLM Gateway"
@@ -179,17 +187,17 @@ def main():
         print(
             "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
         )
-        sys.exit(1)
+        return 1
 
     if not endpoint:
         print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     if not api_token:
         print(
             "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
         )
-        sys.exit(1)
+        return 1
 
     try:
         models = fetch_llm_models(endpoint, api_token)
@@ -205,11 +213,13 @@ def main():
 
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1
     except Exception as e:
         print(f"Unexpected error: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/datarobot-agent-assist/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/scripts/list_llm_models.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""List available LLM models from DataRobot LLM Gateway.
+
+This script fetches and displays active models from the DataRobot LLM Gateway catalog.
+Designed to be used by AI agents to discover available LLM models.
+
+Usage:
+    python list_llm_models.py [--json|--table]
+
+Environment Variables:
+    DATAROBOT_ENDPOINT: DataRobot API endpoint URL
+    DATAROBOT_API_TOKEN: DataRobot API authentication token
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from env_utils import ensure_env_file, read_env_variable
+
+
+def fetch_llm_models(endpoint: str, api_token: str) -> list[dict]:
+    """Fetch active LLM models from DataRobot Gateway.
+
+    Args:
+        endpoint: DataRobot API endpoint URL
+        api_token: DataRobot API token for authentication
+
+    Returns:
+        List of active model dictionaries with name, description, provider, and context_size
+
+    Raises:
+        RuntimeError: If the API request fails
+    """
+    endpoint = endpoint.rstrip("/")
+    url = f"{endpoint}/genai/llmgw/catalog/"
+
+    try:
+        request = Request(
+            url,
+            headers={"Authorization": f"Bearer {api_token}"},
+        )
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - trusted DataRobot endpoint
+            data = json.loads(response.read().decode("utf-8"))
+
+        # Handle both list and dict responses
+        if isinstance(data, dict) and "data" in data:
+            models_list = data["data"]
+        elif isinstance(data, list):
+            models_list = data
+        else:
+            raise RuntimeError(f"Unexpected response format: {type(data)}")
+
+        # Client-side filtering for active models (server-side activeOnly param is broken)
+        active_models = [m for m in models_list if m.get("isActive", False)]
+
+        if not active_models:
+            raise RuntimeError("No active models found in catalog")
+
+        # Extract key information
+        result = []
+        for m in active_models:
+            model_name = m.get("model", "")
+            # Ensure model name has datarobot/ prefix
+            if model_name and not model_name.startswith("datarobot/"):
+                model_name = f"datarobot/{model_name}"
+            
+            result.append({
+                "name": model_name,
+                "description": m.get("description", ""),
+                "provider": m.get("provider", "Unknown"),
+                "context_size": m.get("contextSize", 0),
+            })
+
+        return result
+
+    except (HTTPError, URLError) as e:
+        raise RuntimeError(f"Failed to fetch model catalog: {e}") from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to parse model catalog response: {e}") from e
+
+
+def format_as_table(models: list[dict]) -> str:
+    """Format models as a readable table.
+
+    Args:
+        models: List of model dictionaries
+
+    Returns:
+        Formatted table string
+    """
+    if not models:
+        return "No models available"
+
+    # Calculate column widths
+    name_width = max(len(m["name"]) for m in models)
+    name_width = max(name_width, len("Model Name"))
+    provider_width = max(len(m["provider"]) for m in models)
+    provider_width = max(provider_width, len("Provider"))
+    context_width = max(len(str(m["context_size"])) for m in models)
+    context_width = max(context_width, len("Context Size"))
+
+    # Build table
+    lines = []
+    header = f"{'Model Name':<{name_width}} | {'Provider':<{provider_width}} | {'Context Size':>{context_width}} | Description"
+    separator = "-" * len(header)
+    lines.append(header)
+    lines.append(separator)
+
+    for m in models:
+        name = m["name"]
+        provider = m["provider"]
+        context = str(m["context_size"])
+        description = m["description"][:80] + "..." if len(m["description"]) > 80 else m["description"]
+        lines.append(f"{name:<{name_width}} | {provider:<{provider_width}} | {context:>{context_width}} | {description}")
+
+    return "\n".join(lines)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="List available LLM models from DataRobot LLM Gateway"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format (default: table)",
+    )
+    parser.add_argument(
+        "--table",
+        action="store_true",
+        help="Output in table format (default)",
+    )
+    args = parser.parse_args()
+
+    # Try to get credentials from .env file first, then fall back to environment
+    env_file = Path(".env")
+
+    # Ensure .env file exists (run dr dotenv setup if needed)
+    ensure_env_file(env_file)
+
+    endpoint = None
+    api_token = None
+
+    # Try .env file first
+    if env_file.exists():
+        try:
+            endpoint = read_env_variable(env_file, "DATAROBOT_ENDPOINT")
+        except ValueError:
+            pass  # Variable not in .env, will try environment
+
+        try:
+            api_token = read_env_variable(env_file, "DATAROBOT_API_TOKEN")
+        except ValueError:
+            pass  # Variable not in .env, will try environment
+
+    # Fall back to environment variables if not found in .env
+    if not endpoint:
+        endpoint = os.getenv("DATAROBOT_ENDPOINT")
+
+    if not api_token:
+        api_token = os.getenv("DATAROBOT_API_TOKEN")
+
+    if not endpoint and not api_token:
+        print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
+        print("Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr)
+        sys.exit(1)
+
+    if not endpoint:
+        print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
+        sys.exit(1)
+
+    if not api_token:
+        print("Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        models = fetch_llm_models(endpoint, api_token)
+
+        if args.json:
+            # JSON output
+            print(json.dumps(models, indent=2))
+        else:
+            # Table output (default)
+            print(f"\nFound {len(models)} active LLM models:\n")
+            print(format_as_table(models))
+            print()
+
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/datarobot-agent-assist/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/scripts/rehearsal.py
@@ -24,6 +24,7 @@ import urllib.request
 import urllib.error
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any, cast
 
 from env_utils import ensure_env_file, read_env_variable
 
@@ -165,7 +166,7 @@ _UNSUPPORTED_PARAMS: dict[str, set[str]] = {
 }
 
 
-def _model_params(model: str, **kwargs) -> dict:
+def _model_params(model: str, **kwargs: Any) -> dict[str, Any]:
     """Return kwargs filtered to params supported by the given model."""
     unsupported: set[str] = set()
     for pattern, fields in _UNSUPPORTED_PARAMS.items():
@@ -250,10 +251,10 @@ def llm_call(
     token: str,
     endpoint: str,
     model: str,
-    messages: list[dict],
-    tools: list[dict] | None = None,
-    tool_choice: str | dict = "auto",
-) -> dict:
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] = "auto",
+) -> dict[str, Any]:
     url = f"{endpoint.rstrip('/')}/genai/llmgw/chat/completions"
     payload = {
         "model": model,
@@ -274,14 +275,14 @@ def llm_call(
     )
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
-            return json.loads(resp.read())
+            return cast(dict[str, Any], json.loads(resp.read()))
     except urllib.error.HTTPError as e:
         body = e.read().decode()
         print(f"API error {e.code}: {body}", file=sys.stderr)
         sys.exit(1)
 
 
-def build_tool_definitions(tools: list[dict]) -> list[dict]:
+def build_tool_definitions(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     defs = []
     for tool in tools:
         props = {}
@@ -324,9 +325,9 @@ def simulate_tool_return(
     token: str,
     endpoint: str,
     tool_name: str,
-    arguments: dict,
-    spec_tools: list[dict],
-) -> dict:
+    arguments: dict[str, Any],
+    spec_tools: list[dict[str, Any]],
+) -> dict[str, Any]:
     spec_tool = next((t for t in spec_tools if t["function_name"] == tool_name), None)
     if spec_tool:
         out_schema = ", ".join(
@@ -359,7 +360,7 @@ def simulate_tool_return(
 
     content = strip_code_fence(resp["choices"][0]["message"]["content"].strip())
     try:
-        return json.loads(content)
+        return cast(dict[str, Any], json.loads(content))
     except json.JSONDecodeError:
         return {"result": content}
 
@@ -367,7 +368,7 @@ def simulate_tool_return(
 # ── session management ────────────────────────────────────────────────────────
 
 
-def load_session(session_dir: str) -> tuple[dict, list[dict], str]:
+def load_session(session_dir: str) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
     config_file = os.path.join(session_dir, "config.json")
     state_file = os.path.join(session_dir, "messages.json")
     if not os.path.exists(config_file) or not os.path.exists(state_file):
@@ -469,13 +470,13 @@ def cmd_init(spec_path: str, session_dir: str) -> None:
 
 
 def run_tool_call(
-    tc: dict,
+    tc: dict[str, Any],
     token: str,
     endpoint: str,
-    spec_tools: list[dict],
+    spec_tools: list[dict[str, Any]],
     stats: TurnProgress,
     lock: threading.Lock,
-) -> dict:
+) -> dict[str, Any]:
     """Execute one tool call cycle: dispatch → simulate → return tool message."""
     fn = tc["function"]["name"]
     try:

--- a/skills/datarobot-agent-assist/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/scripts/rehearsal.py
@@ -29,10 +29,13 @@ from env_utils import ensure_env_file, read_env_variable
 
 # Model used for spec extraction and tool simulation.
 # The agent's own model (from the spec) is used for the main turn loop.
-SIMULATION_MODEL = os.environ.get("DR_SIMULATION_MODEL", "bedrock/anthropic.claude-sonnet-4-6")
+SIMULATION_MODEL = os.environ.get(
+    "DR_SIMULATION_MODEL", "bedrock/anthropic.claude-sonnet-4-6"
+)
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
+
 
 def progress(msg):
     print(f"[rehearsal] {msg}", file=sys.stderr, flush=True)
@@ -69,13 +72,18 @@ def get_credentials():
 
     # Fall back to environment variables if not found in .env
     if not endpoint:
-        endpoint = os.environ.get("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")
+        endpoint = os.environ.get(
+            "DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2"
+        )
 
     if not api_token:
         api_token = os.environ.get("DATAROBOT_API_TOKEN")
 
     if not api_token:
-        print("Error: DATAROBOT_API_TOKEN not found in .env file or environment variables", file=sys.stderr)
+        print(
+            "Error: DATAROBOT_API_TOKEN not found in .env file or environment variables",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     return (api_token, endpoint)
@@ -83,7 +91,7 @@ def get_credentials():
 
 def strip_model_prefix(model):
     while model.startswith("datarobot/"):
-        model = model[len("datarobot/"):]
+        model = model[len("datarobot/") :]
     return model
 
 
@@ -98,7 +106,9 @@ def strip_code_fence(text):
 @contextlib.contextmanager
 def capture_output(session_dir):
     """Redirect stdout to a new temp file inside session_dir; yield the file path."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, dir=session_dir) as out:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False, dir=session_dir
+    ) as out:
         path = out.name
         sys.stdout = out
         try:
@@ -108,6 +118,7 @@ def capture_output(session_dir):
 
 
 # ── turn progress tracking ────────────────────────────────────────────────────
+
 
 class TurnProgress:
     """Tracks per-turn LLM stats and emits progress lines to stderr."""
@@ -134,9 +145,15 @@ class TurnProgress:
         progress(f"simulated {fn}  {elapsed:.1f}s")
 
     def summary(self, wall_elapsed):
-        tok = f"  {self.agent_in_tok}→{self.agent_out_tok} tok" if (self.agent_in_tok or self.agent_out_tok) else ""
+        tok = (
+            f"  {self.agent_in_tok}→{self.agent_out_tok} tok"
+            if (self.agent_in_tok or self.agent_out_tok)
+            else ""
+        )
         sims = f"  {self.n_sims} simulations" if self.n_sims else ""
-        progress(f"total  wall {wall_elapsed:.1f}s  {self.n_agent} LLM calls{tok}{sims}")
+        progress(
+            f"total  wall {wall_elapsed:.1f}s  {self.n_agent} LLM calls{tok}{sims}"
+        )
 
 
 # ── LLM interface ─────────────────────────────────────────────────────────────
@@ -160,12 +177,12 @@ def _model_params(model: str, **kwargs) -> dict:
 
 
 TYPE_MAP = {
-    "str":   "string",
-    "int":   "integer",
+    "str": "string",
+    "int": "integer",
     "float": "number",
-    "bool":  "boolean",
-    "list":  "array",
-    "dict":  "object",
+    "bool": "boolean",
+    "list": "array",
+    "dict": "object",
 }
 
 # Tool definition used to extract structured fields from the spec file
@@ -190,8 +207,8 @@ EXTRACT_TOOL = {
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "arg_name":      {"type": "string"},
-                                        "type":          {"type": "string"},
+                                        "arg_name": {"type": "string"},
+                                        "type": {"type": "string"},
                                         "object_schema": {"type": "string"},
                                     },
                                     "required": ["arg_name", "type"],
@@ -202,8 +219,8 @@ EXTRACT_TOOL = {
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "arg_name":      {"type": "string"},
-                                        "type":          {"type": "string"},
+                                        "arg_name": {"type": "string"},
+                                        "type": {"type": "string"},
                                         "object_schema": {"type": "string"},
                                     },
                                     "required": ["arg_name", "type"],
@@ -213,7 +230,7 @@ EXTRACT_TOOL = {
                                 "type": "object",
                                 "properties": {
                                     "service_name": {"type": "string"},
-                                    "auth_method":  {"type": "string"},
+                                    "auth_method": {"type": "string"},
                                 },
                             },
                         },
@@ -230,7 +247,11 @@ EXTRACT_TOOL = {
 
 def llm_call(token, endpoint, model, messages, tools=None, tool_choice="auto"):
     url = f"{endpoint.rstrip('/')}/genai/llmgw/chat/completions"
-    payload = {"model": model, "messages": messages, **_model_params(model, temperature=0.0)}
+    payload = {
+        "model": model,
+        "messages": messages,
+        **_model_params(model, temperature=0.0),
+    }
     if tools:
         payload["tools"] = tools
         payload["tool_choice"] = tool_choice
@@ -274,14 +295,20 @@ def build_tool_definitions(tools):
         if auth:
             desc += f" | Requires {auth['service_name']} {auth['auth_method']}"
 
-        defs.append({
-            "type": "function",
-            "function": {
-                "name": tool["function_name"],
-                "description": desc,
-                "parameters": {"type": "object", "properties": props, "required": required},
-            },
-        })
+        defs.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["function_name"],
+                    "description": desc,
+                    "parameters": {
+                        "type": "object",
+                        "properties": props,
+                        "required": required,
+                    },
+                },
+            }
+        )
     return defs
 
 
@@ -296,20 +323,25 @@ def simulate_tool_return(token, endpoint, tool_name, arguments, spec_tools):
     else:
         out_schema = "result (string)"
 
-    resp = llm_call(token, endpoint, SIMULATION_MODEL, [
-        {
-            "role": "system",
-            "content": (
-                "Generate a realistic return value for the following tool call. "
-                "Return ONLY valid JSON — no explanation, no markdown, no code fences. "
-                "The JSON must contain exactly the output fields listed."
-            ),
-        },
-        {
-            "role": "user",
-            "content": f"Tool: {tool_name}\nArguments: {json.dumps(arguments)}\nOutput fields: {out_schema}",
-        },
-    ])
+    resp = llm_call(
+        token,
+        endpoint,
+        SIMULATION_MODEL,
+        [
+            {
+                "role": "system",
+                "content": (
+                    "Generate a realistic return value for the following tool call. "
+                    "Return ONLY valid JSON — no explanation, no markdown, no code fences. "
+                    "The JSON must contain exactly the output fields listed."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Tool: {tool_name}\nArguments: {json.dumps(arguments)}\nOutput fields: {out_schema}",
+            },
+        ],
+    )
 
     content = strip_code_fence(resp["choices"][0]["message"]["content"].strip())
     try:
@@ -320,11 +352,15 @@ def simulate_tool_return(token, endpoint, tool_name, arguments, spec_tools):
 
 # ── session management ────────────────────────────────────────────────────────
 
+
 def load_session(session_dir):
     config_file = os.path.join(session_dir, "config.json")
-    state_file  = os.path.join(session_dir, "messages.json")
+    state_file = os.path.join(session_dir, "messages.json")
     if not os.path.exists(config_file) or not os.path.exists(state_file):
-        print(f"Error: session not found at {session_dir}. Run with --init first.", file=sys.stderr)
+        print(
+            f"Error: session not found at {session_dir}. Run with --init first.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     with open(config_file) as f:
         config = json.load(f)
@@ -334,6 +370,7 @@ def load_session(session_dir):
 
 
 # ── commands ──────────────────────────────────────────────────────────────────
+
 
 def cmd_init(spec_path, session_dir):
     if not os.path.exists(spec_path):
@@ -346,38 +383,51 @@ def cmd_init(spec_path, session_dir):
         content = f.read()
 
     progress("extracting spec...")
-    t0   = time.monotonic()
+    t0 = time.monotonic()
     resp = llm_call(
-        token, endpoint, SIMULATION_MODEL,
+        token,
+        endpoint,
+        SIMULATION_MODEL,
         messages=[
-            {"role": "system", "content": "Extract the structured fields from the agent spec provided by the user."},
+            {
+                "role": "system",
+                "content": "Extract the structured fields from the agent spec provided by the user.",
+            },
             {"role": "user", "content": content},
         ],
         tools=[EXTRACT_TOOL],
         tool_choice={"type": "function", "function": {"name": "extract_spec"}},
     )
     elapsed = time.monotonic() - t0
-    usage   = resp.get("usage", {})
-    progress(f"extract spec  {elapsed:.1f}s  {usage.get('prompt_tokens', '?')}→{usage.get('completion_tokens', '?')} tok")
+    usage = resp.get("usage", {})
+    progress(
+        f"extract spec  {elapsed:.1f}s  {usage.get('prompt_tokens', '?')}→{usage.get('completion_tokens', '?')} tok"
+    )
 
     tool_calls = resp["choices"][0]["message"].get("tool_calls")
     if not tool_calls:
-        print("Error: spec extraction failed — model did not return structured data", file=sys.stderr)
+        print(
+            "Error: spec extraction failed — model did not return structured data",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    spec          = json.loads(tool_calls[0]["function"]["arguments"])
-    model         = strip_model_prefix(spec["model"])
+    spec = json.loads(tool_calls[0]["function"]["arguments"])
+    model = strip_model_prefix(spec["model"])
     system_prompt = spec["system_prompt"]
-    tools         = spec.get("tools", [])
-    examples      = spec.get("examples", [])
+    tools = spec.get("tools", [])
+    examples = spec.get("examples", [])
 
     with open(os.path.join(session_dir, "config.json"), "w") as f:
-        json.dump({
-            "model":            model,
-            "system_prompt":    system_prompt,
-            "tool_definitions": build_tool_definitions(tools),
-            "spec_tools":       tools,
-            "examples":         examples,
-        }, f)
+        json.dump(
+            {
+                "model": model,
+                "system_prompt": system_prompt,
+                "tool_definitions": build_tool_definitions(tools),
+                "spec_tools": tools,
+                "examples": examples,
+            },
+            f,
+        )
 
     with open(os.path.join(session_dir, "messages.json"), "w") as f:
         json.dump([{"role": "system", "content": system_prompt}], f)
@@ -419,9 +469,9 @@ def run_tool_call(tc, token, endpoint, spec_tools, stats, lock):
         print(json.dumps(args, indent=2))
         print()
 
-    t0        = time.monotonic()
+    t0 = time.monotonic()
     simulated = simulate_tool_return(token, endpoint, fn, args, spec_tools)
-    elapsed   = time.monotonic() - t0
+    elapsed = time.monotonic() - t0
 
     with lock:
         stats.sim_done(fn, elapsed)
@@ -436,8 +486,8 @@ def cmd_turn(session_dir, message):
     token, endpoint = get_credentials()
     config, messages, state_file = load_session(session_dir)
 
-    model      = config["model"]
-    tool_defs  = config["tool_definitions"]
+    model = config["model"]
+    tool_defs = config["tool_definitions"]
     spec_tools = config["spec_tools"]
 
     messages.append({"role": "user", "content": message})
@@ -446,23 +496,29 @@ def cmd_turn(session_dir, message):
     t_wall = time.monotonic()
 
     while True:
-        t0      = time.monotonic()
-        resp    = llm_call(token, endpoint, model, messages, tool_defs or None)
+        t0 = time.monotonic()
+        resp = llm_call(token, endpoint, model, messages, tool_defs or None)
         elapsed = time.monotonic() - t0
-        usage   = resp.get("usage", {})
-        stats.agent_done(elapsed, usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0))
+        usage = resp.get("usage", {})
+        stats.agent_done(
+            elapsed, usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0)
+        )
 
-        msg           = resp["choices"][0]["message"]
+        msg = resp["choices"][0]["message"]
         finish_reason = resp["choices"][0]["finish_reason"]
 
         if finish_reason == "tool_calls" or msg.get("tool_calls"):
             messages.append(msg)
             lock = threading.Lock()
             with concurrent.futures.ThreadPoolExecutor() as executor:
-                tool_messages = list(executor.map(
-                    lambda tc: run_tool_call(tc, token, endpoint, spec_tools, stats, lock),
-                    msg["tool_calls"],
-                ))
+                tool_messages = list(
+                    executor.map(
+                        lambda tc: run_tool_call(
+                            tc, token, endpoint, spec_tools, stats, lock
+                        ),
+                        msg["tool_calls"],
+                    )
+                )
             messages.extend(tool_messages)
         else:
             content = msg.get("content", "")
@@ -480,12 +536,13 @@ def cmd_turn(session_dir, message):
 
 # ── entry point ───────────────────────────────────────────────────────────────
 
+
 def main():
     parser = argparse.ArgumentParser(description="DataRobot Dress Rehearsal")
-    parser.add_argument("--init",    action="store_true")
-    parser.add_argument("--spec",    default="agent_spec.md")
+    parser.add_argument("--init", action="store_true")
+    parser.add_argument("--spec", default="agent_spec.md")
     parser.add_argument("--session", metavar="DIR")
-    parser.add_argument("message",   nargs="?")
+    parser.add_argument("message", nargs="?")
     args = parser.parse_args()
 
     if args.init:

--- a/skills/datarobot-agent-assist/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/scripts/rehearsal.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.request
 import urllib.error
+from collections.abc import Iterator
 from pathlib import Path
 
 from env_utils import ensure_env_file, read_env_variable
@@ -37,11 +38,11 @@ SIMULATION_MODEL = os.environ.get(
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def progress(msg):
+def progress(msg: str) -> None:
     print(f"[rehearsal] {msg}", file=sys.stderr, flush=True)
 
 
-def get_credentials():
+def get_credentials() -> tuple[str, str]:
     """Get DataRobot credentials from .env file or environment variables.
 
     If .env file doesn't exist, attempts to run 'dr dotenv setup'.
@@ -89,13 +90,13 @@ def get_credentials():
     return (api_token, endpoint)
 
 
-def strip_model_prefix(model):
+def strip_model_prefix(model: str) -> str:
     while model.startswith("datarobot/"):
         model = model[len("datarobot/") :]
     return model
 
 
-def strip_code_fence(text):
+def strip_code_fence(text: str) -> str:
     if not text.startswith("```"):
         return text
     lines = text.split("\n")
@@ -104,7 +105,7 @@ def strip_code_fence(text):
 
 
 @contextlib.contextmanager
-def capture_output(session_dir):
+def capture_output(session_dir: str) -> Iterator[str]:
     """Redirect stdout to a new temp file inside session_dir; yield the file path."""
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".txt", delete=False, dir=session_dir
@@ -123,28 +124,28 @@ def capture_output(session_dir):
 class TurnProgress:
     """Tracks per-turn LLM stats and emits progress lines to stderr."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.n_agent = 0
         self.n_sims = 0
         self.agent_elapsed = 0.0
         self.agent_in_tok = 0
         self.agent_out_tok = 0
 
-    def agent_done(self, elapsed, in_tok, out_tok):
+    def agent_done(self, elapsed: float, in_tok: int, out_tok: int) -> None:
         self.n_agent += 1
         self.agent_elapsed += elapsed
         self.agent_in_tok += in_tok
         self.agent_out_tok += out_tok
         progress(f"agent responded  {elapsed:.1f}s  {in_tok}→{out_tok} tok")
 
-    def tool_dispatched(self, fn, arg_keys):
+    def tool_dispatched(self, fn: str, arg_keys: list[str]) -> None:
         progress(f"tool: {fn}({', '.join(arg_keys)})")
 
-    def sim_done(self, fn, elapsed):
+    def sim_done(self, fn: str, elapsed: float) -> None:
         self.n_sims += 1
         progress(f"simulated {fn}  {elapsed:.1f}s")
 
-    def summary(self, wall_elapsed):
+    def summary(self, wall_elapsed: float) -> None:
         tok = (
             f"  {self.agent_in_tok}→{self.agent_out_tok} tok"
             if (self.agent_in_tok or self.agent_out_tok)
@@ -245,7 +246,14 @@ EXTRACT_TOOL = {
 }
 
 
-def llm_call(token, endpoint, model, messages, tools=None, tool_choice="auto"):
+def llm_call(
+    token: str,
+    endpoint: str,
+    model: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    tool_choice: str | dict = "auto",
+) -> dict:
     url = f"{endpoint.rstrip('/')}/genai/llmgw/chat/completions"
     payload = {
         "model": model,
@@ -273,7 +281,7 @@ def llm_call(token, endpoint, model, messages, tools=None, tool_choice="auto"):
         sys.exit(1)
 
 
-def build_tool_definitions(tools):
+def build_tool_definitions(tools: list[dict]) -> list[dict]:
     defs = []
     for tool in tools:
         props = {}
@@ -312,7 +320,13 @@ def build_tool_definitions(tools):
     return defs
 
 
-def simulate_tool_return(token, endpoint, tool_name, arguments, spec_tools):
+def simulate_tool_return(
+    token: str,
+    endpoint: str,
+    tool_name: str,
+    arguments: dict,
+    spec_tools: list[dict],
+) -> dict:
     spec_tool = next((t for t in spec_tools if t["function_name"] == tool_name), None)
     if spec_tool:
         out_schema = ", ".join(
@@ -353,7 +367,7 @@ def simulate_tool_return(token, endpoint, tool_name, arguments, spec_tools):
 # ── session management ────────────────────────────────────────────────────────
 
 
-def load_session(session_dir):
+def load_session(session_dir: str) -> tuple[dict, list[dict], str]:
     config_file = os.path.join(session_dir, "config.json")
     state_file = os.path.join(session_dir, "messages.json")
     if not os.path.exists(config_file) or not os.path.exists(state_file):
@@ -372,7 +386,7 @@ def load_session(session_dir):
 # ── commands ──────────────────────────────────────────────────────────────────
 
 
-def cmd_init(spec_path, session_dir):
+def cmd_init(spec_path: str, session_dir: str) -> None:
     if not os.path.exists(spec_path):
         print(f"Error: spec file not found: {spec_path}", file=sys.stderr)
         sys.exit(1)
@@ -454,7 +468,14 @@ def cmd_init(spec_path, session_dir):
     print("════════════════════════════════════════════")
 
 
-def run_tool_call(tc, token, endpoint, spec_tools, stats, lock):
+def run_tool_call(
+    tc: dict,
+    token: str,
+    endpoint: str,
+    spec_tools: list[dict],
+    stats: TurnProgress,
+    lock: threading.Lock,
+) -> dict:
     """Execute one tool call cycle: dispatch → simulate → return tool message."""
     fn = tc["function"]["name"]
     try:
@@ -482,7 +503,7 @@ def run_tool_call(tc, token, endpoint, spec_tools, stats, lock):
     return {"role": "tool", "tool_call_id": tc["id"], "content": json.dumps(simulated)}
 
 
-def cmd_turn(session_dir, message):
+def cmd_turn(session_dir: str, message: str) -> None:
     token, endpoint = get_credentials()
     config, messages, state_file = load_session(session_dir)
 
@@ -543,7 +564,7 @@ def cmd_turn(session_dir, message):
 # ── entry point ───────────────────────────────────────────────────────────────
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="DataRobot Dress Rehearsal")
     parser.add_argument("--init", action="store_true")
     parser.add_argument("--spec", default="agent_spec.md")
@@ -561,15 +582,17 @@ def main():
     elif args.message:
         if not args.session:
             print("Error: --session DIR is required", file=sys.stderr)
-            sys.exit(1)
+            return 1
         with capture_output(args.session) as output_path:
             cmd_turn(args.session, args.message)
         print(f"output={output_path}")
 
     else:
         parser.print_help()
-        sys.exit(1)
+        return 1
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/datarobot-agent-assist/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/scripts/rehearsal.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""
+DataRobot Dress Rehearsal engine (datarobot-agent-assist skill)
+
+Init:  python3 rehearsal.py --init [--spec agent_spec.md]
+         stdout: session=<session_dir>  output=<output_file>
+Turn:  python3 rehearsal.py --session <session_dir> "user message"
+         stdout: output=<output_file>
+
+From repository root, use:
+  python3 skills/datarobot-agent-assist/rehearsal.py ...
+"""
+
+import argparse
+import concurrent.futures
+import contextlib
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from env_utils import ensure_env_file, read_env_variable
+
+
+# Model used for spec extraction and tool simulation.
+# The agent's own model (from the spec) is used for the main turn loop.
+SIMULATION_MODEL = os.environ.get("DR_SIMULATION_MODEL", "bedrock/anthropic.claude-sonnet-4-6")
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def progress(msg):
+    print(f"[rehearsal] {msg}", file=sys.stderr, flush=True)
+
+
+def get_credentials():
+    """Get DataRobot credentials from .env file or environment variables.
+
+    If .env file doesn't exist, attempts to run 'dr dotenv setup'.
+    Falls back to environment variables if .env is not available.
+
+    Returns:
+        tuple: (api_token, endpoint)
+    """
+    env_file = Path(".env")
+
+    # Ensure .env file exists (run dr dotenv setup if needed)
+    ensure_env_file(env_file)
+
+    endpoint = None
+    api_token = None
+
+    # Try .env file first
+    if env_file.exists():
+        try:
+            endpoint = read_env_variable(env_file, "DATAROBOT_ENDPOINT")
+        except ValueError:
+            pass  # Variable not in .env, will try environment
+
+        try:
+            api_token = read_env_variable(env_file, "DATAROBOT_API_TOKEN")
+        except ValueError:
+            pass  # Variable not in .env, will try environment
+
+    # Fall back to environment variables if not found in .env
+    if not endpoint:
+        endpoint = os.environ.get("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")
+
+    if not api_token:
+        api_token = os.environ.get("DATAROBOT_API_TOKEN")
+
+    if not api_token:
+        print("Error: DATAROBOT_API_TOKEN not found in .env file or environment variables", file=sys.stderr)
+        sys.exit(1)
+
+    return (api_token, endpoint)
+
+
+def strip_model_prefix(model):
+    while model.startswith("datarobot/"):
+        model = model[len("datarobot/"):]
+    return model
+
+
+def strip_code_fence(text):
+    if not text.startswith("```"):
+        return text
+    lines = text.split("\n")
+    end = -1 if lines[-1].startswith("```") else len(lines)
+    return "\n".join(lines[1:end])
+
+
+@contextlib.contextmanager
+def capture_output(session_dir):
+    """Redirect stdout to a new temp file inside session_dir; yield the file path."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, dir=session_dir) as out:
+        path = out.name
+        sys.stdout = out
+        try:
+            yield path
+        finally:
+            sys.stdout = sys.__stdout__
+
+
+# ── turn progress tracking ────────────────────────────────────────────────────
+
+class TurnProgress:
+    """Tracks per-turn LLM stats and emits progress lines to stderr."""
+
+    def __init__(self):
+        self.n_agent = 0
+        self.n_sims = 0
+        self.agent_elapsed = 0.0
+        self.agent_in_tok = 0
+        self.agent_out_tok = 0
+
+    def agent_done(self, elapsed, in_tok, out_tok):
+        self.n_agent += 1
+        self.agent_elapsed += elapsed
+        self.agent_in_tok += in_tok
+        self.agent_out_tok += out_tok
+        progress(f"agent responded  {elapsed:.1f}s  {in_tok}→{out_tok} tok")
+
+    def tool_dispatched(self, fn, arg_keys):
+        progress(f"tool: {fn}({', '.join(arg_keys)})")
+
+    def sim_done(self, fn, elapsed):
+        self.n_sims += 1
+        progress(f"simulated {fn}  {elapsed:.1f}s")
+
+    def summary(self, wall_elapsed):
+        tok = f"  {self.agent_in_tok}→{self.agent_out_tok} tok" if (self.agent_in_tok or self.agent_out_tok) else ""
+        sims = f"  {self.n_sims} simulations" if self.n_sims else ""
+        progress(f"total  wall {wall_elapsed:.1f}s  {self.n_agent} LLM calls{tok}{sims}")
+
+
+# ── LLM interface ─────────────────────────────────────────────────────────────
+
+# Parameters unsupported by specific models (matched by substring)
+_UNSUPPORTED_PARAMS: dict[str, set[str]] = {
+    "claude-opus-4": {"temperature"},
+}
+
+
+def _model_params(model: str, **kwargs) -> dict:
+    """Return kwargs filtered to params supported by the given model."""
+    unsupported: set[str] = set()
+    for pattern, fields in _UNSUPPORTED_PARAMS.items():
+        if pattern in model:
+            unsupported |= fields
+    dropped = unsupported & set(kwargs)
+    if dropped:
+        progress(f"note: dropped unsupported params {dropped} for model '{model}'")
+    return {k: v for k, v in kwargs.items() if k not in unsupported}
+
+
+TYPE_MAP = {
+    "str":   "string",
+    "int":   "integer",
+    "float": "number",
+    "bool":  "boolean",
+    "list":  "array",
+    "dict":  "object",
+}
+
+# Tool definition used to extract structured fields from the spec file
+EXTRACT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "extract_spec",
+        "description": "Extract structured fields from an agent spec file",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "model": {"type": "string"},
+                "system_prompt": {"type": "string"},
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "function_name": {"type": "string"},
+                            "inputs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "arg_name":      {"type": "string"},
+                                        "type":          {"type": "string"},
+                                        "object_schema": {"type": "string"},
+                                    },
+                                    "required": ["arg_name", "type"],
+                                },
+                            },
+                            "out": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "arg_name":      {"type": "string"},
+                                        "type":          {"type": "string"},
+                                        "object_schema": {"type": "string"},
+                                    },
+                                    "required": ["arg_name", "type"],
+                                },
+                            },
+                            "auth_spec": {
+                                "type": "object",
+                                "properties": {
+                                    "service_name": {"type": "string"},
+                                    "auth_method":  {"type": "string"},
+                                },
+                            },
+                        },
+                        "required": ["function_name", "inputs", "out"],
+                    },
+                },
+                "examples": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["model", "system_prompt", "tools", "examples"],
+        },
+    },
+}
+
+
+def llm_call(token, endpoint, model, messages, tools=None, tool_choice="auto"):
+    url = f"{endpoint.rstrip('/')}/genai/llmgw/chat/completions"
+    payload = {"model": model, "messages": messages, **_model_params(model, temperature=0.0)}
+    if tools:
+        payload["tools"] = tools
+        payload["tool_choice"] = tool_choice
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"API error {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def build_tool_definitions(tools):
+    defs = []
+    for tool in tools:
+        props = {}
+        required = []
+        for inp in tool.get("inputs", []):
+            name = inp["arg_name"]
+            prop = {"type": TYPE_MAP.get(inp["type"], "string")}
+            if "object_schema" in inp:
+                prop["description"] = inp["object_schema"]
+            props[name] = prop
+            required.append(name)
+
+        out_parts = [
+            f"{o['arg_name']} ({TYPE_MAP.get(o['type'], o['type'])})"
+            for o in tool.get("out", [])
+        ]
+        desc = "Returns: " + ", ".join(out_parts) if out_parts else ""
+        auth = tool.get("auth_spec")
+        if auth:
+            desc += f" | Requires {auth['service_name']} {auth['auth_method']}"
+
+        defs.append({
+            "type": "function",
+            "function": {
+                "name": tool["function_name"],
+                "description": desc,
+                "parameters": {"type": "object", "properties": props, "required": required},
+            },
+        })
+    return defs
+
+
+def simulate_tool_return(token, endpoint, tool_name, arguments, spec_tools):
+    spec_tool = next((t for t in spec_tools if t["function_name"] == tool_name), None)
+    if spec_tool:
+        out_schema = ", ".join(
+            f"{o['arg_name']} ({TYPE_MAP.get(o['type'], o['type'])})"
+            + (f": {o['object_schema']}" if "object_schema" in o else "")
+            for o in spec_tool.get("out", [])
+        )
+    else:
+        out_schema = "result (string)"
+
+    resp = llm_call(token, endpoint, SIMULATION_MODEL, [
+        {
+            "role": "system",
+            "content": (
+                "Generate a realistic return value for the following tool call. "
+                "Return ONLY valid JSON — no explanation, no markdown, no code fences. "
+                "The JSON must contain exactly the output fields listed."
+            ),
+        },
+        {
+            "role": "user",
+            "content": f"Tool: {tool_name}\nArguments: {json.dumps(arguments)}\nOutput fields: {out_schema}",
+        },
+    ])
+
+    content = strip_code_fence(resp["choices"][0]["message"]["content"].strip())
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return {"result": content}
+
+
+# ── session management ────────────────────────────────────────────────────────
+
+def load_session(session_dir):
+    config_file = os.path.join(session_dir, "config.json")
+    state_file  = os.path.join(session_dir, "messages.json")
+    if not os.path.exists(config_file) or not os.path.exists(state_file):
+        print(f"Error: session not found at {session_dir}. Run with --init first.", file=sys.stderr)
+        sys.exit(1)
+    with open(config_file) as f:
+        config = json.load(f)
+    with open(state_file) as f:
+        messages = json.load(f)
+    return config, messages, state_file
+
+
+# ── commands ──────────────────────────────────────────────────────────────────
+
+def cmd_init(spec_path, session_dir):
+    if not os.path.exists(spec_path):
+        print(f"Error: spec file not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    token, endpoint = get_credentials()
+
+    with open(spec_path) as f:
+        content = f.read()
+
+    progress("extracting spec...")
+    t0   = time.monotonic()
+    resp = llm_call(
+        token, endpoint, SIMULATION_MODEL,
+        messages=[
+            {"role": "system", "content": "Extract the structured fields from the agent spec provided by the user."},
+            {"role": "user", "content": content},
+        ],
+        tools=[EXTRACT_TOOL],
+        tool_choice={"type": "function", "function": {"name": "extract_spec"}},
+    )
+    elapsed = time.monotonic() - t0
+    usage   = resp.get("usage", {})
+    progress(f"extract spec  {elapsed:.1f}s  {usage.get('prompt_tokens', '?')}→{usage.get('completion_tokens', '?')} tok")
+
+    tool_calls = resp["choices"][0]["message"].get("tool_calls")
+    if not tool_calls:
+        print("Error: spec extraction failed — model did not return structured data", file=sys.stderr)
+        sys.exit(1)
+    spec          = json.loads(tool_calls[0]["function"]["arguments"])
+    model         = strip_model_prefix(spec["model"])
+    system_prompt = spec["system_prompt"]
+    tools         = spec.get("tools", [])
+    examples      = spec.get("examples", [])
+
+    with open(os.path.join(session_dir, "config.json"), "w") as f:
+        json.dump({
+            "model":            model,
+            "system_prompt":    system_prompt,
+            "tool_definitions": build_tool_definitions(tools),
+            "spec_tools":       tools,
+            "examples":         examples,
+        }, f)
+
+    with open(os.path.join(session_dir, "messages.json"), "w") as f:
+        json.dump([{"role": "system", "content": system_prompt}], f)
+
+    tool_sigs = [
+        f"  - {t['function_name']}"
+        f"({', '.join(i['arg_name'] + ': ' + i['type'] for i in t.get('inputs', []))})"
+        f" → {', '.join(o['arg_name'] + ': ' + o['type'] for o in t.get('out', []))}"
+        for t in tools
+    ]
+    prompt_preview = system_prompt[:200] + ("…" if len(system_prompt) > 200 else "")
+
+    print("════════════════════════════════════════════")
+    print("  AGENT DRESS REHEARSAL")
+    print("════════════════════════════════════════════")
+    print(f"Model:          {model}")
+    print(f"System Prompt:  {prompt_preview}")
+    print()
+    print(f"Tools ({len(tools)}):")
+    print("\n".join(tool_sigs) if tool_sigs else "  (none)")
+    print()
+    print("Examples:")
+    print("\n".join(f"  - {e}" for e in examples) if examples else "  (none)")
+    print("════════════════════════════════════════════")
+
+
+def run_tool_call(tc, token, endpoint, spec_tools, stats, lock):
+    """Execute one tool call cycle: dispatch → simulate → return tool message."""
+    fn = tc["function"]["name"]
+    try:
+        args = json.loads(tc["function"]["arguments"])
+    except json.JSONDecodeError as e:
+        print(f"Error: malformed arguments for tool {fn}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    with lock:
+        stats.tool_dispatched(fn, list(args.keys()))
+        print(f"[TOOL CALL] {fn}")
+        print(json.dumps(args, indent=2))
+        print()
+
+    t0        = time.monotonic()
+    simulated = simulate_tool_return(token, endpoint, fn, args, spec_tools)
+    elapsed   = time.monotonic() - t0
+
+    with lock:
+        stats.sim_done(fn, elapsed)
+        print(f"[SIMULATED RETURN] {fn}")
+        print(json.dumps(simulated, indent=2))
+        print()
+
+    return {"role": "tool", "tool_call_id": tc["id"], "content": json.dumps(simulated)}
+
+
+def cmd_turn(session_dir, message):
+    token, endpoint = get_credentials()
+    config, messages, state_file = load_session(session_dir)
+
+    model      = config["model"]
+    tool_defs  = config["tool_definitions"]
+    spec_tools = config["spec_tools"]
+
+    messages.append({"role": "user", "content": message})
+
+    stats = TurnProgress()
+    t_wall = time.monotonic()
+
+    while True:
+        t0      = time.monotonic()
+        resp    = llm_call(token, endpoint, model, messages, tool_defs or None)
+        elapsed = time.monotonic() - t0
+        usage   = resp.get("usage", {})
+        stats.agent_done(elapsed, usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0))
+
+        msg           = resp["choices"][0]["message"]
+        finish_reason = resp["choices"][0]["finish_reason"]
+
+        if finish_reason == "tool_calls" or msg.get("tool_calls"):
+            messages.append(msg)
+            lock = threading.Lock()
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                tool_messages = list(executor.map(
+                    lambda tc: run_tool_call(tc, token, endpoint, spec_tools, stats, lock),
+                    msg["tool_calls"],
+                ))
+            messages.extend(tool_messages)
+        else:
+            content = msg.get("content", "")
+            messages.append({"role": "assistant", "content": content})
+            print(f"[Agent]: {content}")
+            break
+
+    stats.summary(time.monotonic() - t_wall)
+
+    tmp = state_file + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(messages, f)
+    os.replace(tmp, state_file)
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="DataRobot Dress Rehearsal")
+    parser.add_argument("--init",    action="store_true")
+    parser.add_argument("--spec",    default="agent_spec.md")
+    parser.add_argument("--session", metavar="DIR")
+    parser.add_argument("message",   nargs="?")
+    args = parser.parse_args()
+
+    if args.init:
+        session_dir = tempfile.mkdtemp(prefix="dr_rehearsal_")
+        with capture_output(session_dir) as output_path:
+            cmd_init(args.spec, session_dir)
+        print(f"session={session_dir}")
+        print(f"output={output_path}")
+
+    elif args.message:
+        if not args.session:
+            print("Error: --session DIR is required", file=sys.stderr)
+            sys.exit(1)
+        with capture_output(args.session) as output_path:
+            cmd_turn(args.session, args.message)
+        print(f"output={output_path}")
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/datarobot-agent-assist/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/scripts/rehearsal.py
@@ -495,7 +495,8 @@ def cmd_turn(session_dir, message):
     stats = TurnProgress()
     t_wall = time.monotonic()
 
-    while True:
+    max_tool_rounds = 20
+    for _round in range(max_tool_rounds):
         t0 = time.monotonic()
         resp = llm_call(token, endpoint, model, messages, tool_defs or None)
         elapsed = time.monotonic() - t0
@@ -525,6 +526,11 @@ def cmd_turn(session_dir, message):
             messages.append({"role": "assistant", "content": content})
             print(f"[Agent]: {content}")
             break
+    else:
+        progress(
+            f"Warning: reached maximum tool-call rounds ({max_tool_rounds}) without a final response. "
+            "The agent may be stuck in a tool-call loop."
+        )
 
     stats.summary(time.monotonic() - t_wall)
 

--- a/skills/datarobot-agent-assist/scripts/select_framework.py
+++ b/skills/datarobot-agent-assist/scripts/select_framework.py
@@ -51,7 +51,9 @@ def save_framework(target_dir: Path, framework_value: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Save the agentic framework for a DataRobot agent project.")
+    parser = argparse.ArgumentParser(
+        description="Save the agentic framework for a DataRobot agent project."
+    )
     parser.add_argument(
         "--framework",
         required=True,

--- a/skills/datarobot-agent-assist/scripts/select_framework.py
+++ b/skills/datarobot-agent-assist/scripts/select_framework.py
@@ -50,7 +50,7 @@ def save_framework(target_dir: Path, framework_value: str) -> None:
     print(f"\n✓ Saved '{framework_value}' to {answers_path}")
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Save the agentic framework for a DataRobot agent project."
     )
@@ -71,10 +71,11 @@ def main() -> None:
     target_dir = Path(args.target_dir).resolve()
     if not target_dir.is_dir():
         print(f"Error: target directory does not exist: {target_dir}", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     save_framework(target_dir, args.framework)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/datarobot-agent-assist/scripts/select_framework.py
+++ b/skills/datarobot-agent-assist/scripts/select_framework.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Save the chosen agentic framework for a DataRobot agent project.
+
+Writes agent_template_framework to .datarobot/answers/agent-agent.yml,
+preserving all other fields in the file.
+
+Usage:
+    python select_framework.py --framework <value> [--target-dir <directory>]
+
+Framework values: langgraph, crewai, llamaindex, nat, base
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+FRAMEWORKS = ["langgraph", "crewai", "llamaindex", "nat", "base"]
+
+ANSWERS_FILE = Path(".datarobot") / "answers" / "agent-agent.yml"
+FIELD_NAME = "agent_template_framework"
+
+
+def save_framework(target_dir: Path, framework_value: str) -> None:
+    """Write agent_template_framework to the answers YAML file.
+
+    Preserves all existing lines; only updates or appends agent_template_framework.
+
+    Args:
+        target_dir: Project root directory.
+        framework_value: Framework identifier to save.
+    """
+    answers_path = target_dir / ANSWERS_FILE
+    answers_path.parent.mkdir(parents=True, exist_ok=True)
+
+    new_line = f"{FIELD_NAME}: {framework_value}\n"
+    prefix = f"{FIELD_NAME}:"
+
+    if answers_path.exists():
+        lines = answers_path.read_text().splitlines(keepends=True)
+        for i, line in enumerate(lines):
+            if line.startswith(prefix):
+                lines[i] = new_line
+                break
+        else:
+            lines.append(new_line)
+        answers_path.write_text("".join(lines))
+    else:
+        answers_path.write_text(new_line)
+
+    print(f"\n✓ Saved '{framework_value}' to {answers_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Save the agentic framework for a DataRobot agent project.")
+    parser.add_argument(
+        "--framework",
+        required=True,
+        choices=FRAMEWORKS,
+        metavar="FRAMEWORK",
+        help="Framework to save ({})".format(", ".join(FRAMEWORKS)),
+    )
+    parser.add_argument(
+        "--target-dir",
+        default=".",
+        help="Project root directory (default: current working directory)",
+    )
+    args = parser.parse_args()
+
+    target_dir = Path(args.target_dir).resolve()
+    if not target_dir.is_dir():
+        print(f"Error: target directory does not exist: {target_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    save_framework(target_dir, args.framework)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/datarobot-agent-assist/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/scripts/setup_template.py
@@ -24,45 +24,47 @@ from typing import Tuple
 
 from env_utils import read_env_variable
 
+
 def generate_random_secret(length: int = 32) -> str:
     """
     Generate a cryptographically random base64-encoded secret.
-    
+
     Args:
         length: Desired length of the final secret string
-        
+
     Returns:
         A base64 URL-safe encoded string truncated to specified length
     """
     random_bytes = secrets.token_bytes(length)
-    encoded = base64.urlsafe_b64encode(random_bytes).decode('ascii')
+    encoded = base64.urlsafe_b64encode(random_bytes).decode("ascii")
     return encoded[:length]
+
 
 def create_env_file(target_dir: Path, llm_default_model: str) -> Tuple[bool, str]:
     """
     Create .env file with LLM_DEFAULT_MODEL configuration.
-    
+
     Args:
         target_dir: Directory where .env file should be created
         llm_default_model: Value for LLM_DEFAULT_MODEL
-        
+
     Returns:
         Tuple of (success, message)
     """
     env_file = target_dir / ".env"
-    
+
     try:
         print(f"Creating .env file in {target_dir}")
-        
+
         # Write the .env file
         with open(env_file, "w") as f:
-            f.write('DATAROBOT_ENDPOINT=\n')
-            f.write('DATAROBOT_API_TOKEN=\n')
+            f.write("DATAROBOT_ENDPOINT=\n")
+            f.write("DATAROBOT_API_TOKEN=\n")
             f.write(f'LLM_DEFAULT_MODEL="{llm_default_model}"\n')
-        
-        print(f"✓ Created .env file with LLM_DEFAULT_MODEL=\"{llm_default_model}\"")
+
+        print(f'✓ Created .env file with LLM_DEFAULT_MODEL="{llm_default_model}"')
         return True, f"Created {env_file}"
-        
+
     except Exception as e:
         error_msg = f"Failed to create .env file: {str(e)}"
         print(f"Error: {error_msg}")
@@ -70,23 +72,22 @@ def create_env_file(target_dir: Path, llm_default_model: str) -> Tuple[bool, str
 
 
 def initialize_pulumi(
-    target_dir: Path,
-    pulumi_passphrase: str = ""
+    target_dir: Path, pulumi_passphrase: str = ""
 ) -> Tuple[bool, str]:
     """
     Initialize Pulumi stack with a passphrase from .env or generated.
-    
+
     Args:
         target_dir: Directory where Pulumi command should be executed
         pulumi_passphrase: Optional passphrase for Pulumi config encryption
-        
+
     Returns:
         Tuple of (success, output)
     """
     # Check if infra subdirectory exists
     infra_dir = target_dir / "infra"
     work_dir = infra_dir if infra_dir.exists() else target_dir
-    
+
     # Try to read PULUMI_CONFIG_PASSPHRASE from .env file, fall back to provided or generated passphrase
     env_file = target_dir / ".env"
     passphrase = pulumi_passphrase
@@ -99,23 +100,26 @@ def initialize_pulumi(
             # Variable not in .env, use the provided passphrase or generate one
             if not passphrase:
                 passphrase = generate_random_secret()
-            print("PULUMI_CONFIG_PASSPHRASE not found in .env, using generated passphrase")
+            print(
+                "PULUMI_CONFIG_PASSPHRASE not found in .env, using generated passphrase"
+            )
 
     # Generate random string for stack name
     random_suffix = generate_random_secret(8)
     stack_name = f"dev-agent-assist-{random_suffix}"
     command = f"pulumi stack init {stack_name}"
-    
+
     print(f"\nInitializing Pulumi stack in {work_dir}:")
     print(f"  Stack name: {stack_name}")
     print()
-    
+
     # Set environment variables
     import os
+
     env = os.environ.copy()
-    env['DATAROBOT_CLI_NON_INTERACTIVE'] = 'True'
-    env['PULUMI_CONFIG_PASSPHRASE'] = passphrase
-    
+    env["DATAROBOT_CLI_NON_INTERACTIVE"] = "True"
+    env["PULUMI_CONFIG_PASSPHRASE"] = passphrase
+
     try:
         result = subprocess.run(
             command,
@@ -125,27 +129,27 @@ def initialize_pulumi(
             text=True,
             timeout=300,
             check=False,
-            env=env
+            env=env,
         )
-        
+
         # Combine stdout and stderr
         output = result.stdout
         if result.stderr:
             output += "\n" + result.stderr
-        
+
         # Print the output
         print("Command output:")
         print("-" * 80)
         print(output)
         print("-" * 80)
-        
+
         if result.returncode != 0:
             print(f"\n⚠ Command exited with code {result.returncode}")
             return False, output
-        
+
         print("\n✓ Pulumi stack initialized successfully")
         return True, output
-        
+
     except subprocess.TimeoutExpired:
         error_msg = "Pulumi initialization timed out after 300 seconds"
         print(f"Error: {error_msg}")
@@ -156,31 +160,28 @@ def initialize_pulumi(
         return False, error_msg
 
 
-def run_command(
-    command: str,
-    target_dir: Path,
-    timeout: int = 300
-) -> Tuple[bool, str]:
+def run_command(command: str, target_dir: Path, timeout: int = 300) -> Tuple[bool, str]:
     """
     Run a shell command and capture its output.
-    
+
     Args:
         command: Shell command to execute
         target_dir: Directory where command should be executed
         timeout: Timeout in seconds (default: 300)
-        
+
     Returns:
         Tuple of (success, output)
     """
     print(f"\nExecuting command in {target_dir}:")
     print(f"  {command}")
     print()
-    
+
     # Set environment variables
     import os
+
     env = os.environ.copy()
-    env['DATAROBOT_CLI_NON_INTERACTIVE'] = 'True'
-    
+    env["DATAROBOT_CLI_NON_INTERACTIVE"] = "True"
+
     try:
         result = subprocess.run(
             command,
@@ -190,27 +191,27 @@ def run_command(
             text=True,
             timeout=timeout,
             check=False,
-            env=env
+            env=env,
         )
-        
+
         # Combine stdout and stderr
         output = result.stdout
         if result.stderr:
             output += "\n" + result.stderr
-        
+
         # Print the output
         print("Command output:")
         print("-" * 80)
         print(output)
         print("-" * 80)
-        
+
         if result.returncode != 0:
             print(f"\n⚠ Command exited with code {result.returncode}")
             return False, output
-        
+
         print("\n✓ Command completed successfully")
         return True, output
-        
+
     except subprocess.TimeoutExpired:
         error_msg = f"Command timed out after {timeout} seconds"
         print(f"Error: {error_msg}")
@@ -221,17 +222,14 @@ def run_command(
         return False, error_msg
 
 
-def setup_and_run(
-    llm_default_model: str,
-    target_dir: Path
-) -> int:
+def setup_and_run(llm_default_model: str, target_dir: Path) -> int:
     """
     Create .env file and run required setup commands.
-    
+
     Args:
         llm_default_model: Value for LLM_DEFAULT_MODEL in .env file
         target_dir: Target directory for operations
-        
+
     Returns:
         Exit code (0 for success, 1 for failure)
     """
@@ -241,43 +239,43 @@ def setup_and_run(
     print(f"Target directory: {target_dir}")
     print(f"LLM model: {llm_default_model}")
     print()
-    
+
     # Ensure target directory exists
     if not target_dir.exists():
         print(f"Error: Target directory does not exist: {target_dir}")
         return 1
-    
+
     # Step 1: Create .env file
     success, message = create_env_file(target_dir, llm_default_model)
     if not success:
         return 1
-    
+
     # Step 2: Run dr dotenv setup
-    success, output = run_command('dr dotenv setup --yes', target_dir)
+    success, output = run_command("dr dotenv setup --yes", target_dir)
     if not success:
         # TODO: DR CLI non-interactive mode MUST be supported for this to work
         print("\n⚠ Command 'dr dotenv setup --yes' failed")
         print("See output above for details")
         return 1
-    
+
     # Step 3: Initialize Pulumi stack
     success, output = initialize_pulumi(target_dir)
     if not success:
         print("\n⚠ Pulumi initialization failed")
         print("See output above for details")
         return 1
-    
+
     # Step 4: Run task start-non-interactive
-    success, output = run_command('task start-non-interactive', target_dir)
+    success, output = run_command("task start-non-interactive", target_dir)
     if not success:
         print("\n⚠ Command 'task start-non-interactive' failed")
         print("See output above for details")
         return 1
-    
+
     print("\n" + "=" * 80)
     print("✓ All operations successful!")
     print("=" * 80)
-    
+
     return 0
 
 
@@ -286,23 +284,21 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Create .env file and run setup commands"
     )
-    
+
     parser.add_argument(
-        "--llm-model",
-        required=True,
-        help="LLM model to set in .env file"
+        "--llm-model", required=True, help="LLM model to set in .env file"
     )
-    
+
     parser.add_argument(
         "--target-dir",
         default=".",
-        help="Target directory for operations (default: current directory)"
+        help="Target directory for operations (default: current directory)",
     )
-    
+
     args = parser.parse_args()
-    
+
     target_dir = Path(args.target_dir).resolve()
-    
+
     return setup_and_run(args.llm_model, target_dir)
 
 

--- a/skills/datarobot-agent-assist/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/scripts/setup_template.py
@@ -14,6 +14,7 @@ The script generates cryptographically secure random secrets for session
 management and Pulumi configuration encryption.
 """
 
+import os
 import sys
 import argparse
 import subprocess
@@ -72,7 +73,7 @@ def create_env_file(target_dir: Path, llm_default_model: str) -> Tuple[bool, str
 
 
 def initialize_pulumi(
-    target_dir: Path, pulumi_passphrase: str = ""
+    target_dir: Path, pulumi_passphrase: str = "", timeout: int = 300
 ) -> Tuple[bool, str]:
     """
     Initialize Pulumi stack with a passphrase from .env or generated.
@@ -113,9 +114,6 @@ def initialize_pulumi(
     print(f"  Stack name: {stack_name}")
     print()
 
-    # Set environment variables
-    import os
-
     env = os.environ.copy()
     env["DATAROBOT_CLI_NON_INTERACTIVE"] = "True"
     env["PULUMI_CONFIG_PASSPHRASE"] = passphrase
@@ -127,7 +125,7 @@ def initialize_pulumi(
             shell=True,
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=timeout,
             check=False,
             env=env,
         )
@@ -151,7 +149,7 @@ def initialize_pulumi(
         return True, output
 
     except subprocess.TimeoutExpired:
-        error_msg = "Pulumi initialization timed out after 300 seconds"
+        error_msg = f"Pulumi initialization timed out after {timeout} seconds"
         print(f"Error: {error_msg}")
         return False, error_msg
     except Exception as e:
@@ -175,9 +173,6 @@ def run_command(command: str, target_dir: Path, timeout: int = 300) -> Tuple[boo
     print(f"\nExecuting command in {target_dir}:")
     print(f"  {command}")
     print()
-
-    # Set environment variables
-    import os
 
     env = os.environ.copy()
     env["DATAROBOT_CLI_NON_INTERACTIVE"] = "True"

--- a/skills/datarobot-agent-assist/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/scripts/setup_template.py
@@ -94,12 +94,12 @@ def initialize_pulumi(
     if env_file.exists():
         try:
             passphrase = read_env_variable(env_file, "PULUMI_CONFIG_PASSPHRASE")
-            print(f"Using PULUMI_CONFIG_PASSPHRASE from .env file")
+            print("Using PULUMI_CONFIG_PASSPHRASE from .env file")
         except ValueError:
             # Variable not in .env, use the provided passphrase or generate one
             if not passphrase:
                 passphrase = generate_random_secret()
-            print(f"PULUMI_CONFIG_PASSPHRASE not found in .env, using generated passphrase")
+            print("PULUMI_CONFIG_PASSPHRASE not found in .env, using generated passphrase")
 
     # Generate random string for stack name
     random_suffix = generate_random_secret(8)

--- a/skills/datarobot-agent-assist/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/scripts/setup_template.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Setup and initialize a DataRobot agent application template.
+
+This script performs initial setup for a DataRobot agent application template by:
+1. Running: 'dr dotenv setup --yes' to generate a .env file with the specified LLM model and secrets
+   Note: 'dr dotenv setup --yes' is supposed to run in non-interactive mode and generate the .env file with the required variables
+2. Initializing a Pulumi stack with the generated passphrase
+3. Running the template's start-non-interactive task
+
+Usage:
+    python setup_template.py --llm-model <model-name> [--target-dir <directory>]
+
+The script generates cryptographically secure random secrets for session
+management and Pulumi configuration encryption.
+"""
+
+import sys
+import argparse
+import subprocess
+import secrets
+import base64
+from pathlib import Path
+from typing import Tuple
+
+from env_utils import read_env_variable
+
+def generate_random_secret(length: int = 32) -> str:
+    """
+    Generate a cryptographically random base64-encoded secret.
+    
+    Args:
+        length: Desired length of the final secret string
+        
+    Returns:
+        A base64 URL-safe encoded string truncated to specified length
+    """
+    random_bytes = secrets.token_bytes(length)
+    encoded = base64.urlsafe_b64encode(random_bytes).decode('ascii')
+    return encoded[:length]
+
+def create_env_file(target_dir: Path, llm_default_model: str) -> Tuple[bool, str]:
+    """
+    Create .env file with LLM_DEFAULT_MODEL configuration.
+    
+    Args:
+        target_dir: Directory where .env file should be created
+        llm_default_model: Value for LLM_DEFAULT_MODEL
+        
+    Returns:
+        Tuple of (success, message)
+    """
+    env_file = target_dir / ".env"
+    
+    try:
+        print(f"Creating .env file in {target_dir}")
+        
+        # Write the .env file
+        with open(env_file, "w") as f:
+            f.write('DATAROBOT_ENDPOINT=\n')
+            f.write('DATAROBOT_API_TOKEN=\n')
+            f.write(f'LLM_DEFAULT_MODEL="{llm_default_model}"\n')
+        
+        print(f"✓ Created .env file with LLM_DEFAULT_MODEL=\"{llm_default_model}\"")
+        return True, f"Created {env_file}"
+        
+    except Exception as e:
+        error_msg = f"Failed to create .env file: {str(e)}"
+        print(f"Error: {error_msg}")
+        return False, error_msg
+
+
+def initialize_pulumi(
+    target_dir: Path,
+    pulumi_passphrase: str = ""
+) -> Tuple[bool, str]:
+    """
+    Initialize Pulumi stack with a passphrase from .env or generated.
+    
+    Args:
+        target_dir: Directory where Pulumi command should be executed
+        pulumi_passphrase: Optional passphrase for Pulumi config encryption
+        
+    Returns:
+        Tuple of (success, output)
+    """
+    # Check if infra subdirectory exists
+    infra_dir = target_dir / "infra"
+    work_dir = infra_dir if infra_dir.exists() else target_dir
+    
+    # Try to read PULUMI_CONFIG_PASSPHRASE from .env file, fall back to provided or generated passphrase
+    env_file = target_dir / ".env"
+    passphrase = pulumi_passphrase
+
+    if env_file.exists():
+        try:
+            passphrase = read_env_variable(env_file, "PULUMI_CONFIG_PASSPHRASE")
+            print(f"Using PULUMI_CONFIG_PASSPHRASE from .env file")
+        except ValueError:
+            # Variable not in .env, use the provided passphrase or generate one
+            if not passphrase:
+                passphrase = generate_random_secret()
+            print(f"PULUMI_CONFIG_PASSPHRASE not found in .env, using generated passphrase")
+
+    # Generate random string for stack name
+    random_suffix = generate_random_secret(8)
+    stack_name = f"dev-agent-assist-{random_suffix}"
+    command = f"pulumi stack init {stack_name}"
+    
+    print(f"\nInitializing Pulumi stack in {work_dir}:")
+    print(f"  Stack name: {stack_name}")
+    print()
+    
+    # Set environment variables
+    import os
+    env = os.environ.copy()
+    env['DATAROBOT_CLI_NON_INTERACTIVE'] = 'True'
+    env['PULUMI_CONFIG_PASSPHRASE'] = passphrase
+    
+    try:
+        result = subprocess.run(
+            command,
+            cwd=work_dir,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+            env=env
+        )
+        
+        # Combine stdout and stderr
+        output = result.stdout
+        if result.stderr:
+            output += "\n" + result.stderr
+        
+        # Print the output
+        print("Command output:")
+        print("-" * 80)
+        print(output)
+        print("-" * 80)
+        
+        if result.returncode != 0:
+            print(f"\n⚠ Command exited with code {result.returncode}")
+            return False, output
+        
+        print("\n✓ Pulumi stack initialized successfully")
+        return True, output
+        
+    except subprocess.TimeoutExpired:
+        error_msg = "Pulumi initialization timed out after 300 seconds"
+        print(f"Error: {error_msg}")
+        return False, error_msg
+    except Exception as e:
+        error_msg = f"Failed to initialize Pulumi: {str(e)}"
+        print(f"Error: {error_msg}")
+        return False, error_msg
+
+
+def run_command(
+    command: str,
+    target_dir: Path,
+    timeout: int = 300
+) -> Tuple[bool, str]:
+    """
+    Run a shell command and capture its output.
+    
+    Args:
+        command: Shell command to execute
+        target_dir: Directory where command should be executed
+        timeout: Timeout in seconds (default: 300)
+        
+    Returns:
+        Tuple of (success, output)
+    """
+    print(f"\nExecuting command in {target_dir}:")
+    print(f"  {command}")
+    print()
+    
+    # Set environment variables
+    import os
+    env = os.environ.copy()
+    env['DATAROBOT_CLI_NON_INTERACTIVE'] = 'True'
+    
+    try:
+        result = subprocess.run(
+            command,
+            cwd=target_dir,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env
+        )
+        
+        # Combine stdout and stderr
+        output = result.stdout
+        if result.stderr:
+            output += "\n" + result.stderr
+        
+        # Print the output
+        print("Command output:")
+        print("-" * 80)
+        print(output)
+        print("-" * 80)
+        
+        if result.returncode != 0:
+            print(f"\n⚠ Command exited with code {result.returncode}")
+            return False, output
+        
+        print("\n✓ Command completed successfully")
+        return True, output
+        
+    except subprocess.TimeoutExpired:
+        error_msg = f"Command timed out after {timeout} seconds"
+        print(f"Error: {error_msg}")
+        return False, error_msg
+    except Exception as e:
+        error_msg = f"Failed to execute command: {str(e)}"
+        print(f"Error: {error_msg}")
+        return False, error_msg
+
+
+def setup_and_run(
+    llm_default_model: str,
+    target_dir: Path
+) -> int:
+    """
+    Create .env file and run required setup commands.
+    
+    Args:
+        llm_default_model: Value for LLM_DEFAULT_MODEL in .env file
+        target_dir: Target directory for operations
+        
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    print("=" * 80)
+    print("Setup and Run Script")
+    print("=" * 80)
+    print(f"Target directory: {target_dir}")
+    print(f"LLM model: {llm_default_model}")
+    print()
+    
+    # Ensure target directory exists
+    if not target_dir.exists():
+        print(f"Error: Target directory does not exist: {target_dir}")
+        return 1
+    
+    # Step 1: Create .env file
+    success, message = create_env_file(target_dir, llm_default_model)
+    if not success:
+        return 1
+    
+    # Step 2: Run dr dotenv setup
+    success, output = run_command('dr dotenv setup --yes', target_dir)
+    if not success:
+        # TODO: DR CLI non-interactive mode MUST be supported for this to work
+        print("\n⚠ Command 'dr dotenv setup --yes' failed")
+        print("See output above for details")
+        return 1
+    
+    # Step 3: Initialize Pulumi stack
+    success, output = initialize_pulumi(target_dir)
+    if not success:
+        print("\n⚠ Pulumi initialization failed")
+        print("See output above for details")
+        return 1
+    
+    # Step 4: Run task start-non-interactive
+    success, output = run_command('task start-non-interactive', target_dir)
+    if not success:
+        print("\n⚠ Command 'task start-non-interactive' failed")
+        print("See output above for details")
+        return 1
+    
+    print("\n" + "=" * 80)
+    print("✓ All operations successful!")
+    print("=" * 80)
+    
+    return 0
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Create .env file and run setup commands"
+    )
+    
+    parser.add_argument(
+        "--llm-model",
+        required=True,
+        help="LLM model to set in .env file"
+    )
+    
+    parser.add_argument(
+        "--target-dir",
+        default=".",
+        help="Target directory for operations (default: current directory)"
+    )
+    
+    args = parser.parse_args()
+    
+    target_dir = Path(args.target_dir).resolve()
+    
+    return setup_and_run(args.llm_model, target_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -158,6 +162,46 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -291,6 +335,9 @@ version = "0.0.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+]
 e2e = [
     { name = "datarobot-agent-tester" },
     { name = "pytest" },
@@ -301,6 +348,7 @@ e2e = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+dev = [{ name = "mypy", specifier = ">=1.10" }]
 e2e = [
     { name = "datarobot-agent-tester", git = "https://github.com/datarobot/datarobot-agent-tester?rev=main" },
     { name = "pytest" },
@@ -746,6 +794,79 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
+    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
@@ -981,6 +1102,66 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,6 +1187,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`datarobot-agent-assist` is the skill designed to build AI agents and deploy them to DataRobot. Supports building LangGraph, CrewAI, LlamaIndex, NAT and Base agents. Created agents can be bundled with MCP server, backend APIs & React frontend.

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new skill with executable helper scripts that call the DataRobot LLM Gateway and run local subprocesses (git/`dr`/Pulumi), so failures or unsafe defaults could impact developer environments when invoked.
> 
> **Overview**
> Introduces a new `datarobot-agent-assist` skill that guides users through **designing**, **coding**, and **deploying** DataRobot agents, including a prescribed `agent_spec.md` schema and an optional *dress rehearsal* simulation workflow.
> 
> Adds helper scripts to support the workflow: cloning a pinned agent app template (`clone_template.py`), selecting an agent framework (`select_framework.py`), bootstrapping env/Pulumi/task setup (`setup_template.py`), listing available LLM Gateway models (`list_llm_models.py`), shared `.env` handling (`env_utils.py`), and a rehearsal engine (`rehearsal.py`) that runs chat turns and simulates tool returns via the LLM Gateway.
> 
> Updates `AGENTS.md` and `README.md` to register the new skill and list its helper scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5009579145366980a2b60eca9b61d5816ded51f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->