### PR TITLE
Set up CODEOWNERS with per-skill ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,13 @@
 # Find the appropriate team in https://github.com/orgs/datarobot-oss/teams and grant it write permissions to the repository
-* @datarobot/agentic-assistant
+
+# Default owner for repo scaffolding, CI, docs, and anything outside skills/
+* @datarobot-oss/datarobot-agent-skills
+
+# All skills default to core-modeling (overrides the wildcard above for skills/)
+/skills/ @datarobot/core-modeling
+
+# App framework skills are owned by the Applications team
+/skills/datarobot-app-framework-*/ @datarobot/applications
+
+# External agent monitoring is owned by vitali93
+/skills/datarobot-external-agent-monitoring/ @vitali93

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,17 @@
 # Default owner for repo scaffolding, CI, docs, and anything outside skills/
 * @datarobot-oss/datarobot-agent-skills
 
-# All skills default to core-modeling (overrides the wildcard above for skills/)
-/skills/ @datarobot/core-modeling
+# Agent assist is owned by agentic-assistant
+/skills/datarobot-agent-assist/ @datarobot/agentic-assistant
+
+# Skills owned by core-modeling
+/skills/datarobot-data-preparation/ @datarobot/core-modeling
+/skills/datarobot-feature-engineering/ @datarobot/core-modeling
+/skills/datarobot-model-deployment/ @datarobot/core-modeling
+/skills/datarobot-model-explainability/ @datarobot/core-modeling
+/skills/datarobot-model-monitoring/ @datarobot/core-modeling
+/skills/datarobot-model-training/ @datarobot/core-modeling
+/skills/datarobot-predictions/ @datarobot/core-modeling
 
 # App framework skills are owned by the Applications team
 /skills/datarobot-app-framework-*/ @datarobot/applications

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ integration = [
     "datarobot-genai",
     "python-frontmatter>=1.1",
     "pytest>=8.0",
+    "codeowners>=0.8.0",
 ]
 e2e = [
     "datarobot-agent-tester @ git+https://github.com/datarobot/datarobot-agent-tester@main",

--- a/tests/integration/test_codeowners.py
+++ b/tests/integration/test_codeowners.py
@@ -1,0 +1,78 @@
+"""
+Validate CODEOWNERS rules for the skills/ directory:
+- No skill directory should be owned by @datarobot-oss/datarobot-agent-skills
+  (that team owns repo scaffolding only, not individual skills)
+"""
+
+import fnmatch
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CODEOWNERS_FILE = REPO_ROOT / ".github" / "CODEOWNERS"
+SKILLS_DIR = REPO_ROOT / "skills"
+DEFAULT_OWNER = "@datarobot-oss/datarobot-agent-skills"
+
+
+def parse_codeowners() -> list[tuple[str, list[str]]]:
+    """Parse CODEOWNERS into a list of (pattern, owners) tuples, in file order."""
+    rules: list[tuple[str, list[str]]] = []
+    with open(CODEOWNERS_FILE, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            pattern, owners = parts[0], parts[1:]
+            if owners:
+                rules.append((pattern, owners))
+    return rules
+
+
+def effective_owners(path: str, rules: list[tuple[str, list[str]]]) -> list[str]:
+    """Return the owners for *path* by applying CODEOWNERS last-match-wins semantics."""
+    matched_owners: list[str] = []
+    for pattern, owners in rules:
+        # Strip leading slash for matching — CODEOWNERS anchors patterns with /
+        pat = pattern.lstrip("/")
+        # A pattern ending in / applies to everything under that directory
+        if pat.endswith("/"):
+            pat = pat + "**"
+        if fnmatch.fnmatch(path, pat) or fnmatch.fnmatch(path, pat + "/**"):
+            matched_owners = owners
+    return matched_owners
+
+
+def skill_dirs() -> list[Path]:
+    return [
+        item
+        for item in SKILLS_DIR.iterdir()
+        if item.is_dir() and (item / "SKILL.md").exists()
+    ]
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "skill_dir" in metafunc.fixturenames:
+        dirs = skill_dirs()
+        metafunc.parametrize("skill_dir", dirs, ids=[d.name for d in dirs])
+
+
+def test_codeowners_file_exists() -> None:
+    assert CODEOWNERS_FILE.exists(), ".github/CODEOWNERS not found"
+
+
+def test_skill_not_owned_by_default_team(skill_dir: Path) -> None:
+    """Each skill must have an explicit owner that is not the default repo team."""
+    rules = parse_codeowners()
+    # Use the skill dir path relative to repo root, with trailing slash
+    rel_path = str(skill_dir.relative_to(REPO_ROOT)) + "/"
+    owners = effective_owners(rel_path, rules)
+    assert owners, (
+        f"Skill '{skill_dir.name}' has no CODEOWNERS entry — add an explicit rule"
+    )
+    assert DEFAULT_OWNER not in owners, (
+        f"Skill '{skill_dir.name}' is owned by {DEFAULT_OWNER}, "
+        "which should only own repo scaffolding. "
+        "Add a specific team or user to CODEOWNERS for this skill."
+    )

--- a/tests/integration/test_codeowners.py
+++ b/tests/integration/test_codeowners.py
@@ -4,44 +4,15 @@ Validate CODEOWNERS rules for the skills/ directory:
   (that team owns repo scaffolding only, not individual skills)
 """
 
-import fnmatch
 from pathlib import Path
 
 import pytest
+from codeowners import CodeOwners
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 CODEOWNERS_FILE = REPO_ROOT / ".github" / "CODEOWNERS"
 SKILLS_DIR = REPO_ROOT / "skills"
 DEFAULT_OWNER = "@datarobot-oss/datarobot-agent-skills"
-
-
-def parse_codeowners() -> list[tuple[str, list[str]]]:
-    """Parse CODEOWNERS into a list of (pattern, owners) tuples, in file order."""
-    rules: list[tuple[str, list[str]]] = []
-    with open(CODEOWNERS_FILE, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            parts = line.split()
-            pattern, owners = parts[0], parts[1:]
-            if owners:
-                rules.append((pattern, owners))
-    return rules
-
-
-def effective_owners(path: str, rules: list[tuple[str, list[str]]]) -> list[str]:
-    """Return the owners for *path* by applying CODEOWNERS last-match-wins semantics."""
-    matched_owners: list[str] = []
-    for pattern, owners in rules:
-        # Strip leading slash for matching — CODEOWNERS anchors patterns with /
-        pat = pattern.lstrip("/")
-        # A pattern ending in / applies to everything under that directory
-        if pat.endswith("/"):
-            pat = pat + "**"
-        if fnmatch.fnmatch(path, pat) or fnmatch.fnmatch(path, pat + "/**"):
-            matched_owners = owners
-    return matched_owners
 
 
 def skill_dirs() -> list[Path]:
@@ -64,10 +35,11 @@ def test_codeowners_file_exists() -> None:
 
 def test_skill_not_owned_by_default_team(skill_dir: Path) -> None:
     """Each skill must have an explicit owner that is not the default repo team."""
-    rules = parse_codeowners()
-    # Use the skill dir path relative to repo root, with trailing slash
-    rel_path = str(skill_dir.relative_to(REPO_ROOT)) + "/"
-    owners = effective_owners(rel_path, rules)
+    text = CODEOWNERS_FILE.read_text(encoding="utf-8")
+    co = CodeOwners(text)
+    # Use a representative file inside the skill dir for ownership lookup
+    rel_path = str((skill_dir / "SKILL.md").relative_to(REPO_ROOT))
+    owners = [owner for (_kind, owner) in co.of(rel_path)]
     assert owners, (
         f"Skill '{skill_dir.name}' has no CODEOWNERS entry — add an explicit rule"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -321,6 +321,18 @@ wheels = [
 ]
 
 [[package]]
+name = "codeowners"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/98/590929c83f921a75a3153bff3328e143ae900f757dffc722656b58003ba1/codeowners-0.8.0.tar.gz", hash = "sha256:6505727574b67db4832a3d0d5e41c0f7eb80f8858ee27996e85b1e046f9266f8", size = 7749, upload-time = "2025-04-26T02:20:37.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/e5/ae08304853f5c6184292e9c679458623c937a2e33d98730ce30fa8f4a8b5/codeowners-0.8.0-py3-none-any.whl", hash = "sha256:b92ce6f6c36dd9de5295c4dc285b2a3b14c81cae8b5eb3b05f0cfdbc4d93995a", size = 8786, upload-time = "2025-04-26T02:20:36.214Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -345,6 +357,7 @@ e2e = [
     { name = "python-dotenv" },
 ]
 integration = [
+    { name = "codeowners" },
     { name = "datarobot-genai" },
     { name = "pytest" },
     { name = "python-frontmatter" },
@@ -361,6 +374,7 @@ e2e = [
     { name = "python-dotenv", specifier = ">=1.0" },
 ]
 integration = [
+    { name = "codeowners", specifier = ">=0.8.0" },
     { name = "datarobot-genai" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "python-frontmatter", specifier = ">=1.1" },


### PR DESCRIPTION
## Summary

Sets up proper CODEOWNERS rules for the repository with per-skill ownership and an integration test that enforces the rules.


## Stacked on

This PR is stacked on #27 (Add Automated Integration Tests). The new `test_codeowners.py` relies on the pytest test infrastructure added there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only repository ownership metadata and adds a CI/integration test that may fail future PRs until new skills get explicit CODEOWNERS entries.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` scheme where the repo defaults to `@datarobot-oss/datarobot-agent-skills`, while `skills/` is owned by `@datarobot/core-modeling` with more specific overrides for app-framework skills and `datarobot-external-agent-monitoring`.
> 
> Introduces `tests/integration/test_codeowners.py` to parse CODEOWNERS with *last-match-wins* semantics and fail CI if any skill directory (detected via `skills/*/SKILL.md`) has no explicit match or is still owned by the default repo team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94747e14b7be4002ac8a744b414fcf520f0361c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->