### PR TITLE
fix(agent-assist): address skill quality judge feedback

### DIFF
--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -36,7 +36,17 @@ What would you like to do?
   3. Deploy an AI agent     → Deploy an implemented agent to DataRobot
 ```
 
-After the user selects an option, and before proceeding, run through the **[Pre-requisite Check](#pre-requisite-check)** section below.
+Show this menu first. After the user selects an option (`1`, `2`, or `3`), run the **[Pre-requisite Check](#pre-requisite-check)** and then the **[Script Path Resolution](#script-path-resolution)** before doing anything else for that option.
+
+---
+
+## Script Path Resolution
+
+Before invoking any helper script, resolve `<skill_scripts_dir>` once for the session:
+
+- `<skill_scripts_dir>` is the `scripts/` subdirectory of the directory containing this `SKILL.md` file.
+- Confirm it exists with `ls <path_to_this_skill_dir>/scripts/`. If the directory is missing, tell the user the skill installation is incomplete and stop.
+- Use the resolved absolute path for every `<skill_scripts_dir>/...` reference in this skill.
 
 ---
 
@@ -77,6 +87,7 @@ Run in order before proceeding:
   **CRITICAL**: In case the script fails due to any reason, do **not** proceed. Instead, return the error message to the user and ask how they want to proceed.
 
 - Recommend a `gpt-5`, `claude-4-5`, or `gemini-2.5` model from the list unless the user specifies cost or other constraints.
+- If none of those preferred families appear in the catalog, pick the highest-capability available model by name — prefer ones containing `large`, `pro`, `opus`, or `sonnet` over `mini`, `haiku`, or `flash`.
 - Only display the full model catalog when the user **explicitly** asks to browse models.
 - If the user's desired model is unavailable, suggest starting with an available one and updating after implementation.
 
@@ -99,11 +110,13 @@ Then update the spec accordingly:
 
 ### Agent Simulation (Before Coding)
 
-Always offer to simulate the agent before coding it. **Run simulation** by following [Dress Rehearsal](#dress-rehearsal) in this skill end to end: initialize with `rehearsal.py --init`, drive turns with `--session`, handle `NOTE:` / `DONE`, and produce the dress rehearsal feedback report. Do not substitute improvised role-play or manual mock tool traces for this flow.
+Before transitioning to coding, ask the user (exact wording):
 
-Script path (from project root):
+> "Would you like to run a dress rehearsal simulation first? (recommended)"
 
-`python <skill_scripts_dir>/rehearsal.py ...`
+Wait for their reply. If they say yes, follow **[Dress Rehearsal](#dress-rehearsal)** end to end: initialize with `rehearsal.py --init`, drive turns with `--session`, handle `NOTE:` / `DONE`, and produce the feedback report. Do not substitute improvised role-play or manual mock tool traces. If they decline or skip, proceed directly to coding — do not simulate without explicit confirmation.
+
+Script path: `python <skill_scripts_dir>/rehearsal.py ...`
 
 ---
 
@@ -190,17 +203,29 @@ Then offer to implement any changes to `agent_spec.md`.
 
 **On Windows: coding is not supported. STOP and do NOT proceed with the next steps!**
 
+### Before Coding Begins
+
+Verify `agent_spec.md` contains at minimum:
+
+- `model` — a valid LLM Gateway model ID
+- `system_prompt` — non-empty
+- `tools` — at least one tool defined (or explicit confirmation from the user that no tools are needed)
+- `frontend.type` — set
+
+If `agent_spec.md` does not exist, inform the user and offer to run the Design phase (option 1) first. If any required field above is missing, surface the gap and update the spec before continuing. Do not start coding against an incomplete spec.
+
 ### Pre-coding Checklist
 
-1. Check if `agent_spec.md` exists — if so, **read it first**
-2. Check if `AGENTS.md` exists in the template directory (default: current working directory)
+1. **Read `agent_spec.md`** — it must exist (see gate above).
+2. Check if `AGENTS.md` exists in the template directory (default: current working directory).
 3. If `AGENTS.md` does **not** exist, prepare the template with these steps in order. ALWAYS follow the steps in order and do not skip any, even if they seem redundant. This is critical for ensuring the template is properly set up and avoiding wasted effort coding on a broken foundation.
-   a. **Check the working directory** — if it contains files other than `agent_spec.md`, warn the user and ask them to clear it before proceeding
-   b. **Clone the template**: Run the helper script:
+   a. **Check the working directory** — if it contains files other than `agent_spec.md`, warn the user and ask them to clear it before proceeding.
+   b. **Move `agent_spec.md` aside if present** — if the file exists in the working directory, move it to a temp location (e.g. `/tmp/agent_spec.md.bak`) before cloning so it isn't overwritten. Restore it after cloning completes.
+   c. **Clone the template**: Run the helper script:
    ```
    python <skill_scripts_dir>/clone_template.py
    ```
-   c. **Select the agentic framework**:
+   d. **Select the agentic framework**:
 
    **STOP. Do NOT proceed until the user has replied with their framework choice.**
 
@@ -212,15 +237,15 @@ Then offer to implement any changes to `agent_spec.md`.
    > 4. NeMo Agent Toolkit (NAT)
    > 5. Base
 
-   Wait for the user's reply. Do not assume or default to any framework. Once the user replies, map their choice to the corresponding value (`langgraph`, `crewai`, `llamaindex`, `nat`, `base`) and run:
+   Wait for the user's reply. Do not assume or default to any framework. If their next message is not a framework choice (silence, unrelated text), re-display the options and wait again — do not proceed with any other coding step. Once the user replies, map their choice to the corresponding value (`langgraph`, `crewai`, `llamaindex`, `nat`, `base`) and run:
    ```
    python <skill_scripts_dir>/select_framework.py \
      --target-dir . \
      --framework <value>
    ```
 
-   d. **Validate the template**: Run `dr dependency check`. If it fails, return the error message to the user DO NOT proceed. If it succeeds, continue to the next step.
-   e. **Setup the template**: Run the helper script:
+   e. **Validate the template**: Run `dr dependency check`. Treat any non-zero exit as a hard error — do not attempt to resolve it automatically. Return the full output to the user and stop.
+   f. **Setup the template**: Run the helper script. Use the `model` field from `agent_spec.md` as `--llm-model`; if absent, use the model selected during the design phase.
    ```
    python <skill_scripts_dir>/setup_template.py \
      --llm-model <model-name> \
@@ -229,8 +254,8 @@ Then offer to implement any changes to `agent_spec.md`.
 
    **CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
 
-   f. **Re-read `AGENTS.md`** now that the template is ready
-4. Recreate the TODO list based on the `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool
+   g. **Re-read `AGENTS.md`** now that the template is ready.
+4. Recreate the TODO list based on `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool.
 
 
 ### Coding Rules
@@ -250,18 +275,11 @@ Then offer to implement any changes to `agent_spec.md`.
 
 ### After Coding
 
-1. **Proactively test the agent code locally** — read `AGENTS.md` and follow its local testing instructions to validate the implementation. Attempt this before suggesting next steps.
-
-2. **If the user asks for help testing locally**:
-   - Read `AGENTS.md` to find the exact shell command(s) required to run the agent locally
-   - Display the command(s) in a code block
-   - Tell the user to run the command in a **new terminal** in the current directory
-   - Do **not** run the command yourself
-
-3. After completing code generation and testing, present next steps:
-   - Testing the agent locally
-   - Revising aspects of the implementation
-   - Deploying to DataRobot
+1. Read `AGENTS.md` to find the local test command.
+2. Display the command in a code block.
+3. Tell the user: "Run this command in a **new terminal** in the current directory to test the agent locally."
+4. Do **not** run the command yourself.
+5. Present next steps: revise the implementation, or deploy to DataRobot.
 
 ---
 
@@ -468,4 +486,3 @@ dr auth login
 ```
 
 This will guide the user through the authentication process interactively.
-=======

--- a/tests/e2e/skill_hashes.json
+++ b/tests/e2e/skill_hashes.json
@@ -1,3 +1,1 @@
-{
-  "skills/datarobot-agent-assist/SKILL.md": "fabaaa28b3c039b9929c090df5d5f54d"
-}
+{}


### PR DESCRIPTION
## Summary
Follow-up to #22, which pre-seeded a hash to skip the e2e LLM judge for `datarobot-agent-assist`. This PR actually addresses the judge's NEEDS WORK feedback so the skill passes evaluation on its own merits, and clears the seeded hash so CI re-runs the judge against the new content.

## Changes to \`skills/datarobot-agent-assist/SKILL.md\`
Each bullet maps to a numbered issue from the judge's report:

1. **Script path resolution** — new \"Script Path Resolution\" section explains how the agent should resolve \`<skill_scripts_dir>\` once per session.
2. **Activation ordering** — reworded so the welcome menu is shown first, with the pre-requisite check + script-path resolution running after the user selects an option.
3. **Model selection fallback** — added a rule for when \`gpt-5\` / \`claude-4-5\` / \`gemini-2.5\` families are not in the catalog (prefer \`large\`/\`pro\`/\`opus\`/\`sonnet\` over \`mini\`/\`haiku\`/\`flash\`).
4. **Template clone vs. existing spec** — added a step to move \`agent_spec.md\` aside before cloning so it isn't overwritten.
5. **Silent-user recovery** — framework selection now re-displays the options on any non-framework reply.
6. **\`dr dependency check\` handling** — non-zero exit is now a hard error; removed the inconsistency with the general warning/error guidance.
7. **\"Proactively test\" contradiction** — rewrote \"After Coding\" per suggestion B so the agent only ever displays the test command and instructs the user; never runs it.
8. **Dress Rehearsal trigger** — replaced \"always offer to simulate\" with an explicit ask + wait, so simulation only runs on user confirmation.
9. **\`setup_template.py\` model source** — specified that \`--llm-model\` comes from the spec's \`model\` field.
10. **Missing spec during coding** — new \"Before Coding Begins\" gate plus explicit instruction to offer the design phase if \`agent_spec.md\` is absent.

Also dropped a stray \`=======\` merge marker at the end of the file.

## Hash cache
\`tests/e2e/skill_hashes.json\` reset to \`{}\` so CI re-runs the LLM judge against the updated content. If the judge passes, the cache action will store the new hash for subsequent runs.

## Test plan
- [ ] CI \"Skill quality evaluation\" passes (LLM judge returns COMPLETE / no NEEDS WORK)
- [ ] Lint passes (yamlfmt, ruff, license, integration)
- [ ] Token count for SKILL.md stays under the 5,000-token hard limit (currently ~5,914 estimated, under the 6,700-token raw cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to skill instructions (`SKILL.md`) and resetting the e2e skill-hash cache, with no production code or runtime logic modifications.
> 
> **Overview**
> Updates `skills/datarobot-agent-assist/SKILL.md` to address evaluation feedback by tightening the guided workflow: resolves `<skill_scripts_dir>` once per session, enforces menu-first activation ordering, adds a model-selection fallback, and gates coding on a complete `agent_spec.md`.
> 
> Refines template/coding steps (protect `agent_spec.md` during template clone, re-prompt on non-selection during framework choice, treat `dr dependency check` failures as hard stops, and source `setup_template.py --llm-model` from the spec) and changes dress rehearsal to run *only* after explicit user confirmation. Resets `tests/e2e/skill_hashes.json` to `{}` so CI re-runs the skill quality judge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe5b3d07c4fbce052e2949331f8172f4c8313c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->