### PR TITLE
feat(datarobot-predictions): add prediction explanations (SHAP/XEMP)

### DIFF
--- a/skills/datarobot-predictions/SKILL.md
+++ b/skills/datarobot-predictions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datarobot-predictions
-description: Tools and guidance for making predictions with DataRobot models, including real-time predictions, batch scoring, and prediction dataset generation. Use when making predictions, running batch scoring, or generating prediction datasets.
+description: Tools and guidance for making predictions with DataRobot deployments, including real-time predictions, batch scoring, prediction dataset generation, and prediction explanations (SHAP/XEMP). Use when making predictions, running batch scoring, generating prediction datasets, or explaining individual predictions from a deployment.
 ---
 
 # DataRobot Predictions Skill
@@ -17,15 +17,23 @@ This skill provides comprehensive guidance for working with DataRobot prediction
 
 **Example**: "Generate a prediction dataset template for deployment abc123 with 10 rows"
 
+**To also explain predictions**: pass `--max-explanations N` to `make_prediction.py` (or the
+`max_explanations=N` kwarg in code). See [Prediction Explanations](#prediction-explanations) below.
+
 ## When to use this skill
 
 Use this skill when you need to:
 - Make predictions from deployed DataRobot models
+- Explain individual predictions from a deployment (SHAP or XEMP, per-row)
 - Generate prediction dataset templates
 - Validate prediction data before scoring
 - Understand deployment feature requirements
 - Perform batch predictions on large datasets
 - Get sample training data to understand expected formats
+
+> For post-hoc explanations against a **training project / leaderboard model** (not a deployment),
+> use the `datarobot-model-explainability` skill instead. This skill covers deployment-time
+> explanations returned alongside scoring.
 
 ## Key capabilities
 
@@ -119,6 +127,80 @@ Use these DataRobot SDK methods to work with predictions:
 
 See the [Common Patterns](#common-patterns) section below for complete examples.
 
+## Prediction Explanations
+
+Deployments can return per-row explanations (top feature contributions) alongside predictions.
+Two algorithms are available depending on how the deployment was configured:
+
+- **SHAP** (`shap`): SHapley Additive exPlanations. Available on tree-based models when SHAP was
+  enabled at deployment time. Returns signed contributions in the model's score space.
+- **XEMP** (`xemp`): DataRobot's eXplainable AI for the eXact Model Prediction. Default when SHAP
+  is not enabled. Returns top-N strongest features with a qualitative strength (`+++`, `--`, etc.).
+
+If you omit `explanation_algorithm`, the deployment's default is used.
+
+### How to request explanations
+
+Pass `max_explanations=N` (and any optional filters) when calling `datarobot_predict.deployment.predict`:
+
+```python
+import datarobot as dr
+import pandas as pd
+from datarobot_predict.deployment import predict as dr_predict
+
+dr.Client(token=..., endpoint=...)
+deployment = dr.Deployment.get("abc123")
+
+result = dr_predict(
+    deployment=deployment,
+    data_frame=pd.DataFrame([{"feature1": 10, "feature2": 20}]),
+    max_explanations=3,                  # top 3 contributors per row
+    explanation_algorithm="shap",        # or "xemp"; omit for deployment default
+    # threshold_high=0.8,                # optional: only explain rows scoring > 0.8
+    # threshold_low=0.2,                 # optional: only explain rows scoring < 0.2
+    # passthrough_columns="all",         # optional: echo input columns through to output
+)
+print(result.dataframe.to_dict(orient="records"))
+```
+
+The result DataFrame includes columns like `EXPLANATION_1_FEATURE_NAME`,
+`EXPLANATION_1_ACTUAL_VALUE`, `EXPLANATION_1_STRENGTH`, `EXPLANATION_1_QUALITATIVE_STRENGTH` for
+each of the top-N contributors.
+
+### Parameter reference
+
+| Parameter | Purpose |
+|-----------|---------|
+| `max_explanations` | Top-N contributors per row. `0` (default) disables explanations. |
+| `max_ngram_explanations` | Text models only: cap text-segment explanations per row. |
+| `threshold_high` | Only explain rows with prediction probability **above** this (0–1). |
+| `threshold_low` | Only explain rows with prediction probability **below** this (0–1). |
+| `explanation_algorithm` | `"shap"` or `"xemp"`; omit to use deployment default. |
+| `passthrough_columns` | `"all"` or set of input column names to echo through to output. |
+
+### CLI shortcut
+
+```bash
+python scripts/make_prediction.py abc123 '{"feature1": 10, "feature2": 20}' \
+    --max-explanations 3 --explanation-algorithm shap
+```
+
+### When to use which threshold
+
+- `threshold_high` is useful when only positive (high-risk / fraud / churn-likely) predictions need
+  explaining — saves compute on a large batch.
+- `threshold_low` is the mirror image for low-probability rows.
+- Setting both restricts explanations to rows outside the `[low, high]` band.
+
+### Common errors
+
+- **"Prediction explanations not enabled"**: the deployment was created without explanations support.
+  Re-deploy the model with explanations enabled, or use a deployment that has them.
+- **`max_explanations` ignored / no explanation columns in output**: confirm you're calling
+  `datarobot_predict.deployment.predict(...)` and that the deployment has explanations enabled.
+  The `deployment.predict_batch()` convenience wrapper on the SDK is intended for plain scoring;
+  use `datarobot_predict.deployment.predict` when you need explanation kwargs.
+
 ## Helper Scripts
 
 This skill includes executable helper scripts that Claude can run directly:
@@ -141,6 +223,10 @@ python scripts/validate_prediction_data.py abc123 prediction_data.csv
 
 # Make prediction
 python scripts/make_prediction.py abc123 '{"feature1": 10, "feature2": 20}'
+
+# Make prediction with top-3 SHAP explanations
+python scripts/make_prediction.py abc123 '{"feature1": 10, "feature2": 20}' \
+    --max-explanations 3 --explanation-algorithm shap
 ```
 
 Claude can run these scripts directly or use them as reference when writing code.
@@ -155,37 +241,35 @@ Claude can run these scripts directly or use them as reference when writing code
 
 ## Common patterns
 
-### Pattern 1: Get deployment features and make single prediction
+### Pattern 1: Get deployment features and make single prediction (optionally with explanations)
 ```python
 import datarobot as dr
 import os
 import pandas as pd
+from datarobot_predict.deployment import predict as dr_predict
 
 # Initialize client
-client = dr.Client(
+dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT")
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 
-# Get deployment (and optionally model metadata)
 deployment = dr.Deployment.get("abc123")
-model = dr.Model.get(deployment.model['id'])
 
-# Get feature information
-features = model.get_features()
-feature_importance = model.get_feature_impact()
-
-# Create prediction data
 prediction_data = {
     "feature1": value1,
     "feature2": value2,
     # ... all required features (excluding target)
 }
 
-# Make prediction (single-row batch prediction)
-df = pd.DataFrame([prediction_data])
-predictions_df = deployment.predict_batch(df)
-print(predictions_df)
+# Score one row. Add max_explanations=N to get top-N explanations per row.
+result = dr_predict(
+    deployment=deployment,
+    data_frame=pd.DataFrame([prediction_data]),
+    max_explanations=3,                # optional; 0/omit to disable explanations
+    explanation_algorithm="shap",      # optional; omit to use deployment default
+)
+print(result.dataframe.to_dict(orient="records"))
 ```
 
 ### Pattern 2: Generate template and batch predictions

--- a/skills/datarobot-predictions/scripts/make_prediction.py
+++ b/skills/datarobot-predictions/scripts/make_prediction.py
@@ -3,72 +3,136 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Make a prediction from a deployment using the SDK-supported batch API.
+Make a prediction from a deployment, optionally with prediction explanations.
 
 Usage:
-    python make_prediction.py <deployment_id> <data_json>
+    python make_prediction.py <deployment_id> <data_json> [options]
 
-Where data_json is a JSON object with feature values.
+Where <data_json> is either:
+    - a JSON object with feature values (single row), or
+    - a JSON array of objects (multiple rows).
+
+Options:
+    --max-explanations N        Number of top explanations per row (0 disables, default 0).
+    --max-ngram-explanations N  Cap text-segment explanations per row (text models only).
+    --threshold-high X          Only explain rows with prediction probability above X (0-1).
+    --threshold-low X           Only explain rows with prediction probability below X (0-1).
+    --explanation-algorithm A   'shap' or 'xemp' (omit to use deployment default).
+    --passthrough-columns COLS  'all' or comma-separated input columns to copy through.
+
+Examples:
+    # Plain prediction
+    python make_prediction.py abc123 '{"feature1": 10, "feature2": 20}'
+
+    # Top-3 SHAP explanations per row
+    python make_prediction.py abc123 '{"feature1": 10}' --max-explanations 3 \\
+        --explanation-algorithm shap
+
+When --max-explanations > 0, each row in the output includes an `explanations` list
+of {feature, value, strength, qualitative_strength} entries describing why the model
+produced that prediction.
 """
 
-import sys
+import argparse
 import json
 import os
+import sys
+
 import datarobot as dr
 import pandas as pd
+from datarobot_predict.deployment import predict as dr_predict
 
 
-def make_prediction(deployment_id: str, data: dict) -> dict:
-    """
-    Make a prediction (single-row batch prediction).
-
-    Args:
-        deployment_id: The deployment ID
-        data: Dictionary with feature values
-
-    Returns:
-        Prediction results
-    """
-    # Initialize client
-    _client = dr.Client(
+def make_prediction(
+    deployment_id: str,
+    data,
+    *,
+    max_explanations: int = 0,
+    max_ngram_explanations: int | None = None,
+    threshold_high: float | None = None,
+    threshold_low: float | None = None,
+    explanation_algorithm: str | None = None,
+    passthrough_columns: str | None = None,
+) -> dict:
+    """Score `data` against `deployment_id`, optionally returning prediction explanations."""
+    dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
         endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
     )
 
     deployment = dr.Deployment.get(deployment_id)
 
-    # SDK v3.10.0 does not expose Deployment.predict(); use predict_batch with a 1-row DataFrame.
-    df = pd.DataFrame([data])
-    predictions_df = deployment.predict_batch(df)
+    rows = data if isinstance(data, list) else [data]
+    df = pd.DataFrame(rows)
+
+    predict_kwargs = {"deployment": deployment, "data_frame": df}
+    if max_explanations and max_explanations > 0:
+        predict_kwargs["max_explanations"] = max_explanations
+    if max_ngram_explanations is not None:
+        predict_kwargs["max_ngram_explanations"] = max_ngram_explanations
+    if threshold_high is not None:
+        predict_kwargs["threshold_high"] = threshold_high
+    if threshold_low is not None:
+        predict_kwargs["threshold_low"] = threshold_low
+    if explanation_algorithm is not None:
+        predict_kwargs["explanation_algorithm"] = explanation_algorithm
+    if passthrough_columns is not None:
+        predict_kwargs["passthrough_columns"] = (
+            "all"
+            if passthrough_columns == "all"
+            else {c.strip() for c in passthrough_columns.split(",")}
+        )
+
+    result = dr_predict(**predict_kwargs)
+    predictions_df = result.dataframe
 
     return {
         "deployment_id": deployment_id,
+        "row_count": len(predictions_df),
         "predictions": predictions_df.to_dict(orient="records"),
     }
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        print(
-            "Usage: python make_prediction.py <deployment_id> <data_json>",
-            file=sys.stderr,
-        )
-        print(
-            'Example: python make_prediction.py abc123 \'{"feature1": 10, "feature2": 20}\'',
-            file=sys.stderr,
-        )
-        sys.exit(1)
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument("deployment_id")
+    parser.add_argument(
+        "data_json", help="JSON object (single row) or JSON array (multiple rows)"
+    )
+    parser.add_argument("--max-explanations", type=int, default=0)
+    parser.add_argument("--max-ngram-explanations", type=int, default=None)
+    parser.add_argument("--threshold-high", type=float, default=None)
+    parser.add_argument("--threshold-low", type=float, default=None)
+    parser.add_argument(
+        "--explanation-algorithm", choices=["shap", "xemp"], default=None
+    )
+    parser.add_argument("--passthrough-columns", default=None)
+    return parser.parse_args()
 
-    deployment_id = sys.argv[1]
-    data_json = sys.argv[2]
+
+if __name__ == "__main__":
+    args = _parse_args()
 
     try:
-        data = json.loads(data_json)
-        result = make_prediction(deployment_id, data)
-        print(json.dumps(result, indent=2))
+        data = json.loads(args.data_json)
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON: {e}", file=sys.stderr)
         sys.exit(1)
+
+    try:
+        result = make_prediction(
+            args.deployment_id,
+            data,
+            max_explanations=args.max_explanations,
+            max_ngram_explanations=args.max_ngram_explanations,
+            threshold_high=args.threshold_high,
+            threshold_low=args.threshold_low,
+            explanation_algorithm=args.explanation_algorithm,
+            passthrough_columns=args.passthrough_columns,
+        )
+        print(json.dumps(result, indent=2, default=str))
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

Adds deployment-time prediction explanations to the `datarobot-predictions` skill, addressing Olga Shpyrko's request in #datarobot-agent-skills.

- `SKILL.md` — new **Prediction Explanations** section with parameter reference, SHAP vs XEMP guidance, CLI shortcut, common errors, and a cross-link to `datarobot-model-explainability` for post-hoc/project-level analysis.
- `scripts/make_prediction.py` — switched from `deployment.predict_batch()` to `datarobot_predict.deployment.predict()` so explanation kwargs flow through. New flags: `--max-explanations`, `--max-ngram-explanations`, `--threshold-high`, `--threshold-low`, `--explanation-algorithm {shap,xemp}`, `--passthrough-columns`. Script now also accepts a JSON array of rows for batches.

### Why extend `datarobot-predictions` rather than add a new skill?
- The user request was literally to add explanations to this skill.
- Three overlapping skills (predictions / model-explainability / new prediction-explanations) is one extra disambiguation step for code-assistant LLMs. Keeping explanations next to the predict workflow means a single skill match covers "predict and tell me why."
- The existing `datarobot-model-explainability` skill covers the project/leaderboard SHAP path (`dr.PredictionExplanations.create`) — semantically different from deployment scoring. SKILL.md now cross-links between the two.

## Verification

End-to-end run against a live deployment (`Churn Binary Classification`, XGBoost binary classifier, 7 features, SHAP-enabled). Plain prediction returns the score; `--max-explanations 3 --explanation-algorithm shap` returns the score plus `EXPLANATION_1..3_{FEATURE_NAME,STRENGTH,ACTUAL_VALUE,QUALITATIVE_STRENGTH}` and `SHAP_BASE_VALUE` / `SHAP_REMAINING_TOTAL`. Top contributor matched intuition (`HEALTH_SUMMARY_FLAG="Red"` strength +0.91 → 0.59 churn probability).

An asciinema cast and text transcript of the run are attached locally (`/tmp/datarobot-predictions-explanations.cast`, `/tmp/demo_explanations.txt`).

## Test plan

- [x] `task lint` — ruff format + check pass; existing failures (`gemini` CLI missing locally, `license:check` env issue) are pre-existing and unrelated to this PR
- [x] Plain prediction still works against the same deployment
- [x] `--max-explanations 3 --explanation-algorithm shap` returns expected explanation columns
- [ ] Reviewer: confirm SKILL.md additions read well in Claude Code / Cursor surfaces
- [ ] Reviewer: try `--explanation-algorithm xemp` against an XEMP-enabled deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the prediction helper to use `datarobot_predict.deployment.predict()` and introduces new CLI flags/behaviors, which could affect scoring output shape and require deployments configured for explanations.
> 
> **Overview**
> Adds **deployment-time prediction explanations** guidance to `SKILL.md`, including SHAP vs XEMP usage, parameters, thresholds, CLI examples, and a cross-link for project-level explainability.
> 
> Updates `scripts/make_prediction.py` to accept single-row or multi-row JSON input and to route scoring through `datarobot_predict.deployment.predict()` so explanation-related kwargs (e.g., `--max-explanations`, `--explanation-algorithm`, thresholds, passthrough columns) are supported, returning row counts and enriched per-row outputs when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 443bd81c8c630c354a5ad08170c88363fc1d9203. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->