### PR TITLE
Added OpenCode Plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,9 @@
 # All App Framework skills are owned by the Applications team
 /skills/datarobot-app-framework-*/ @datarobot/applications
 
+# OpenCode plugin (theme, install scripts, metadata)
+/.opencode-plugin/ @datarobot-oss/datarobot-agent-skills
+
 # Individual Contributor skills
 /skills/datarobot-external-agent-monitoring/ @vitali93
 /skills/datarobot-setup/ @amberb617

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
       - name: Publish

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v0.1.0). Defaults to the version in package.json."
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,10 +25,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Publish
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm stage publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ Thumbs.db
 !.claude-plugin/marketplace.json
 !.claude-plugin/plugin.json
 !tests/e2e/skill_hashes.json
+!package.json
+!.opencode-plugin/themes/*.json
 
 # Environment variables
 .env

--- a/.opencode-plugin/index.ts
+++ b/.opencode-plugin/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin"
-import { cpSync, mkdirSync, readdirSync } from "fs"
+import { cpSync, existsSync, mkdirSync, readdirSync } from "fs"
+import { homedir } from "os"
 import { dirname, join, resolve } from "path"
 import { fileURLToPath } from "url"
 
@@ -8,8 +9,10 @@ const BUNDLED_SKILLS = resolve(__dirname, "..", "skills")
 const BUNDLED_THEME = resolve(__dirname, "themes", "datarobot.json")
 
 function getConfigDir(): string {
-  const xdg = process.env.XDG_CONFIG_HOME
-  return xdg || join(process.env.HOME || "~", ".config")
+  if (process.env.XDG_CONFIG_HOME) {
+    return process.env.XDG_CONFIG_HOME
+  }
+  return join(homedir(), ".config")
 }
 
 function installSkills(configDir: string): number {
@@ -28,6 +31,9 @@ function installSkills(configDir: string): number {
 }
 
 function installTheme(configDir: string): boolean {
+  if (!existsSync(BUNDLED_THEME)) {
+    return false
+  }
   const themesDir = join(configDir, "opencode", "themes")
   const target = join(themesDir, "datarobot.json")
   mkdirSync(themesDir, { recursive: true })

--- a/.opencode-plugin/index.ts
+++ b/.opencode-plugin/index.ts
@@ -1,0 +1,55 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { cpSync, mkdirSync, readdirSync } from "fs"
+import { dirname, join, resolve } from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BUNDLED_SKILLS = resolve(__dirname, "..", "skills")
+const BUNDLED_THEME = resolve(__dirname, "themes", "datarobot.json")
+
+function getConfigDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME
+  return xdg || join(process.env.HOME || "~", ".config")
+}
+
+function installSkills(configDir: string): number {
+  const targetDir = join(configDir, "opencode", "skills")
+  mkdirSync(targetDir, { recursive: true })
+
+  const skills = readdirSync(BUNDLED_SKILLS, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+  let installed = 0
+  for (const skill of skills) {
+    const dest = join(targetDir, skill.name)
+    cpSync(join(BUNDLED_SKILLS, skill.name), dest, { recursive: true, force: true })
+    installed++
+  }
+  return installed
+}
+
+function installTheme(configDir: string): boolean {
+  const themesDir = join(configDir, "opencode", "themes")
+  const target = join(themesDir, "datarobot.json")
+  mkdirSync(themesDir, { recursive: true })
+  cpSync(BUNDLED_THEME, target)
+  return true
+}
+
+export const DataRobotSkillsPlugin: Plugin = async ({ client }) => {
+  const configDir = getConfigDir()
+  const skillsInstalled = installSkills(configDir)
+  const themeInstalled = installTheme(configDir)
+
+  if (skillsInstalled > 0 || themeInstalled) {
+    await client.app.log({
+      body: {
+        service: "opencode-datarobot-skills",
+        level: "info",
+        message: `Installed ${skillsInstalled} skills${themeInstalled ? " and DataRobot theme" : ""}`,
+      },
+    })
+  }
+
+  return {}
+}
+

--- a/.opencode-plugin/themes/datarobot.json
+++ b/.opencode-plugin/themes/datarobot.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "drGreen": "#81FBA5",
+    "drBlack": "#0B0B0B",
+    "drWhite": "#FFFFFF",
+    "drGrey": "#E4E4E4",
+    "drPurple": "#A6B0FF",
+    "drIndigo": "#5C41FF",
+    "drBlue": "#44BFFC",
+    "drYellow": "#FFFF54",
+    "drDarkPanel": "#1A1A1A",
+    "drDarkElement": "#252525",
+    "drDarkBorder": "#1E3D2A",
+    "drDarkBorderActive": "#81FBA5",
+    "drDarkMuted": "#777777",
+    "drLightPanel": "#F5F5F5",
+    "drLightElement": "#E8E8E8",
+    "drLightBorder": "#AADCBA",
+    "drLightBorderActive": "#5C41FF",
+    "drLightMuted": "#666666",
+    "drError": "#E85D6C",
+    "drWarningDark": "#FFFF54",
+    "drWarningLight": "#B8A600",
+    "drSuccess": "#81FBA5",
+    "drGreenDeep": "#2E8B47"
+  },
+  "theme": {
+    "primary": {
+      "dark": "drGreen",
+      "light": "drIndigo"
+    },
+    "secondary": {
+      "dark": "drGreen",
+      "light": "drIndigo"
+    },
+    "accent": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "error": {
+      "dark": "drError",
+      "light": "drError"
+    },
+    "warning": {
+      "dark": "drWarningDark",
+      "light": "drWarningLight"
+    },
+    "success": {
+      "dark": "drSuccess",
+      "light": "drGreenDeep"
+    },
+    "info": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "text": {
+      "dark": "drGrey",
+      "light": "drBlack"
+    },
+    "textMuted": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "background": {
+      "dark": "drBlack",
+      "light": "drWhite"
+    },
+    "backgroundPanel": {
+      "dark": "drDarkPanel",
+      "light": "drLightPanel"
+    },
+    "backgroundElement": {
+      "dark": "drDarkElement",
+      "light": "drLightElement"
+    },
+    "border": {
+      "dark": "drDarkBorder",
+      "light": "drLightBorder"
+    },
+    "borderActive": {
+      "dark": "drDarkBorderActive",
+      "light": "drLightBorderActive"
+    },
+    "borderSubtle": {
+      "dark": "drDarkBorder",
+      "light": "drLightBorder"
+    },
+    "diffAdded": {
+      "dark": "drGreen",
+      "light": "drGreenDeep"
+    },
+    "diffRemoved": {
+      "dark": "drError",
+      "light": "drError"
+    },
+    "diffContext": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "diffHunkHeader": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "diffHighlightAdded": {
+      "dark": "drGreen",
+      "light": "drGreenDeep"
+    },
+    "diffHighlightRemoved": {
+      "dark": "drError",
+      "light": "drError"
+    },
+    "diffAddedBg": {
+      "dark": "drDarkPanel",
+      "light": "drLightPanel"
+    },
+    "diffRemovedBg": {
+      "dark": "drDarkPanel",
+      "light": "drLightPanel"
+    },
+    "diffContextBg": {
+      "dark": "drDarkElement",
+      "light": "drLightElement"
+    },
+    "diffLineNumber": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "drDarkPanel",
+      "light": "drLightPanel"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "drDarkPanel",
+      "light": "drLightPanel"
+    },
+    "markdownText": {
+      "dark": "drGrey",
+      "light": "drBlack"
+    },
+    "markdownHeading": {
+      "dark": "drGreen",
+      "light": "drIndigo"
+    },
+    "markdownLink": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "markdownLinkText": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "markdownCode": {
+      "dark": "drGreen",
+      "light": "drGreenDeep"
+    },
+    "markdownBlockQuote": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "markdownEmph": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "markdownStrong": {
+      "dark": "drYellow",
+      "light": "drWarningLight"
+    },
+    "markdownHorizontalRule": {
+      "dark": "drDarkBorder",
+      "light": "drLightBorder"
+    },
+    "markdownListItem": {
+      "dark": "drGreen",
+      "light": "drIndigo"
+    },
+    "markdownListEnumeration": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "markdownImage": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "markdownImageText": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "markdownCodeBlock": {
+      "dark": "drGrey",
+      "light": "drBlack"
+    },
+    "syntaxComment": {
+      "dark": "drDarkMuted",
+      "light": "drLightMuted"
+    },
+    "syntaxKeyword": {
+      "dark": "drIndigo",
+      "light": "drIndigo"
+    },
+    "syntaxFunction": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "syntaxVariable": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "syntaxString": {
+      "dark": "drGreen",
+      "light": "drGreenDeep"
+    },
+    "syntaxNumber": {
+      "dark": "drYellow",
+      "light": "drWarningLight"
+    },
+    "syntaxType": {
+      "dark": "drPurple",
+      "light": "drIndigo"
+    },
+    "syntaxOperator": {
+      "dark": "drBlue",
+      "light": "drBlue"
+    },
+    "syntaxPunctuation": {
+      "dark": "drGrey",
+      "light": "drBlack"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Install and test the skills after prompting the user for the trigger phrase you 
 
 ### Plugin version management
 
-Several plugins: Claude (.claude/*.json), Cursor (.cursor/plugin.json), Gemini (gemini-extension.json) have version strings. Be sure to bump them appropritately depending on the change using SemVer rules along with the change.
+Several plugins: Claude (.claude-plugin/*.json), Cursor (.cursor-plugin/plugin.json), Gemini (gemini-extension.json), OpenCode (.opencode-plugin/) have version strings. Be sure to bump them appropriately depending on the change using SemVer rules along with the change.
 
 
 ## SDK usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,18 @@ datarobot-my-skill/
       ---
 ```
 
+## Testing the OpenCode plugin locally
+
+The `opencode-datarobot-skills` npm package is defined by `package.json` at the repo root. To test it locally before publishing, point OpenCode at the local clone using a `file:` reference in `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "plugin": ["file:/absolute/path/to/datarobot-agent-skills"]
+}
+```
+
+OpenCode (via Bun) resolves `file:` paths and loads the plugin directly from disk, so edits to `.opencode-plugin/index.ts` or the skill files are picked up on the next OpenCode restart without any reinstall step.
+
 ## Continuous integration
 
 This repository uses GitHub Actions for automated checks:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ In Copilot Chat, reference skills naturally:
 
 </details>
 
+<details><summary><strong>OpenCode</strong></summary>
+
+Add to your `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "plugin": ["opencode-datarobot-skills"]
+}
+```
+
+OpenCode automatically installs the plugin on startup. The plugin also includes a DataRobot-branded theme with full dark and light variants. To activate it, add `"theme": "datarobot"` to your `opencode.json`.
+
+</details>
+
 ## Skills
 
 This repository contains skills for common DataRobot workflows. You can also contribute your own skills.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "skills/"
   ],
   "dependencies": {
-    "@opencode-ai/plugin": "latest"
+    "@opencode-ai/plugin": "1.15.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "opencode-datarobot-skills",
+  "version": "0.1.0",
+  "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
+  "type": "module",
+  "main": ".opencode-plugin/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datarobot-oss/datarobot-agent-skills.git"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "datarobot",
+    "machine-learning",
+    "mlops",
+    "automl",
+    "agent-skills"
+  ],
+  "author": {
+    "name": "DataRobot",
+    "url": "https://github.com/datarobot-oss/datarobot-agent-skills"
+  },
+  "license": "Apache-2.0",
+  "files": [
+    ".opencode-plugin/index.ts",
+    ".opencode-plugin/themes/",
+    "skills/"
+  ],
+  "dependencies": {
+    "@opencode-ai/plugin": "latest"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",


### PR DESCRIPTION
## Summary
Adds an OpenCode Plugin

The plugin brings in the skills and cool new DataRobot Theme!

### Dark Mode
<img width="1169" height="805" alt="image" src="https://github.com/user-attachments/assets/136ec3af-4036-4fcf-986f-1b3216741c13" />

### Light Mode
<img width="1174" height="802" alt="image" src="https://github.com/user-attachments/assets/98262d5d-fef7-488b-8f2f-46491ca3826c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new npm-distributed plugin that copies repository skill directories into the user’s OpenCode config and installs a theme, plus introduces an automated release-to-npm workflow; publishing/install behavior and filesystem writes are the main risk areas.
> 
> **Overview**
> Adds an **OpenCode plugin** (`opencode-datarobot-skills`) that, on load, copies bundled `skills/` into `~/.config/opencode/skills` (or `XDG_CONFIG_HOME`) and installs a DataRobot-branded theme (`.opencode-plugin/themes/datarobot.json`), logging installation via the OpenCode client.
> 
> Introduces npm packaging and release automation: a new root `package.json` (with `@opencode-ai/plugin` dependency and published files list), updates `.gitignore`/`CODEOWNERS` for the new plugin assets, adds documentation for OpenCode setup/testing, and adds a `publish-npm.yml` GitHub Action to publish to npm on GitHub release (or manually by tag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8908b8cf5e2119d7bffd2fe02fc0a806a39d682. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->