### PR TITLE
fix(ci): pin npm to 11.15.0 so `npm stage publish` works

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,5 +28,10 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
+      # npm stage publish requires npm >= 11.15.0, newer than the npm bundled with Node 24.
+      # Remove this step once setup-node's default Node ships npm >= 11.15.0.
+      - name: Pin npm with staged-publishing support
+        run: npm install -g npm@11.15.0
+
       - name: Publish
         run: npm stage publish --access public


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pin npm to 11.15.0 in the `publish` job of `.github/workflows/publish-npm.yml`, before the `npm stage publish` step.

## Rationale
`npm stage publish` (staged publishing, shipped 2026-05-22) requires npm 11.15.0 or newer. `actions/setup-node` installs the npm bundled with the runner's Node, and Node 24 ships npm 11.13.0, so the publish job fails at the `npm stage publish` step on the next release. Upgrading npm in the same job before staging fixes it. The step can be removed once setup-node's default Node bundles npm 11.15.0 or newer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins the npm CLI version in the publish workflow; main risk is potential incompatibility with future npm behavior during releases.
> 
> **Overview**
> Updates the npm publish GitHub Action to **install npm `11.15.0`** before running `npm stage publish`, ensuring staged publishing works even though Node 24’s bundled npm is older.
> 
> Adds a short comment noting this is temporary and can be removed once `actions/setup-node` ships a Node/npm combo with `npm >= 11.15.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23bff81addfe18ac1f00bd1a64e515ce29064fad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->