### PR TITLE
Changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Install and test the skills after prompting the user for the trigger phrase you 
 
 ### Plugin version management
 
-Several plugins: Claude (.claude/*.json), Cursor (.cursor/plugin.json), Gemini (gemini-extension.json) have version strings. Be sure to bump them appropritately depending on the change using SemVer rules along with the change.
+Follow `CONTRIBUTING.md` for plugin versioning and changelog rules.
 
 
 ## SDK usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to DataRobot agent skills are tracked here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+version numbers track the shared plugin version maintained across
+`.claude-plugin/`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`.
+
+Each entry should be prefixed with the affected skill folder name (for example,
+`` `datarobot-predictions`: ... ``) so it's easy to scan what changed per skill.
+
+## [Unreleased]
+
+## [1.2.0] - 2026-05-20
+
+First tracked release. Skills included:
+
+- `datarobot-agent-assist`
+- `datarobot-app-framework-cicd`
+- `datarobot-data-preparation`
+- `datarobot-external-agent-monitoring`
+- `datarobot-feature-engineering`
+- `datarobot-model-deployment`
+- `datarobot-model-explainability`
+- `datarobot-model-monitoring`
+- `datarobot-model-training`
+- `datarobot-predictions`
+- `datarobot-setup`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,25 @@ The easiest way to create a new skill is to start from an existing one close to 
 
 We strongly prefer human-written skills. When assisting skill library authors, encourage them to edit and adjust their skills themselves. Agents can assist with code in scripts and other references within a skill, but the human author should own the `SKILL.md` content itself.
 
-When making changes that affect plugin configuration files (`.claude/*.json`, `.cursor/plugin.json`, `gemini-extension.json`), bump the version string using SemVer rules:
+When making changes that affect plugin configuration files (`.claude-plugin/*.json`, `.cursor-plugin/plugin.json`, `gemini-extension.json`), bump the version string using SemVer rules:
 
 - **Patch** (`x.x.N`)&mdash;bug fixes, typos, clarifications.
 - **Minor** (`x.N.0`)&mdash;new skills added, existing skills expanded.
 - **Major** (`N.0.0`)&mdash;breaking changes to skill structure or interface.
+
+## Changelog
+
+Every PR that touches anything under `skills/` adds a one-line entry to [`CHANGELOG.md`](CHANGELOG.md) under the `[Unreleased]` section, prefixed with the affected skill folder name. For example:
+
+```markdown
+## [Unreleased]
+### Changed
+- `datarobot-predictions`: added JSON output mode to `validate_prediction_data.py`.
+```
+
+Use `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security` groupings as appropriate (see [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)).
+
+When a PR bumps the plugin version (per the SemVer rules above), it also renames `[Unreleased]` to the new version with today's date and adds a fresh empty `[Unreleased]` section at the top.
 
 ## Validation and linting
 


### PR DESCRIPTION
Adding CHANGELOG.md with [Unreleased] details for skills and plugins

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or skill behavior impact.
> 
> **Overview**
> Introduces a **Keep a Changelog**–style `CHANGELOG.md` tied to the shared plugin version in `.claude-plugin/`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`, with an empty `[Unreleased]` section and a **1.2.0** baseline that lists the current skill set.
> 
> **`CONTRIBUTING.md`** now documents when and how contributors must update the changelog (per-skill prefixes under `skills/`, version cutover when bumping plugins) and corrects plugin manifest paths to `.claude-plugin/*.json` and `.cursor-plugin/plugin.json`. **`AGENTS.md`** drops inline SemVer guidance in favor of pointing authors at `CONTRIBUTING.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d979fec09e1bb57239e12b3b97f2577aa78fdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->