### PR TITLE
[-] Add review-router workflow for automated code review routing

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,0 +1,36 @@
+# SECURITY: Use "pull_request" only — NEVER "pull_request_target".
+# pull_request does not pass secrets to fork PRs (safe).
+# pull_request_target does pass secrets to fork PRs (unsafe — credentials leak risk).
+name: Review Router
+
+on:
+  pull_request:
+    types: [labeled]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  route:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'Ready for Review') ||
+        (github.event.action == 'submitted' && github.event.review.state == 'approved')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REVIEW_ROUTER_APP_ID }}
+          private-key: ${{ secrets.REVIEW_ROUTER_APP_PRIVATE_KEY }}
+
+      - name: Run Review Router
+        uses: datarobot-oss/review-router@v1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -16,11 +16,6 @@ permissions:
 
 jobs:
   route:
-    if: >
-      github.event.pull_request.head.repo.full_name == github.repository && (
-        (github.event.action == 'labeled' && github.event.label.name == 'Ready for Review') ||
-        (github.event.action == 'submitted' && github.event.review.state == 'approved')
-      )
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,6 +1,7 @@
 # SECURITY: Use "pull_request" only — NEVER "pull_request_target".
 # pull_request does not pass secrets to fork PRs (safe).
 # pull_request_target does pass secrets to fork PRs (unsafe — credentials leak risk).
+---
 name: Review Router
 
 on:

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -16,8 +16,7 @@ permissions:
 jobs:
   route:
     if: >
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
+      github.event.pull_request.head.repo.full_name == github.repository && (
         (github.event.action == 'labeled' && github.event.label.name == 'Ready for Review') ||
         (github.event.action == 'submitted' && github.event.review.state == 'approved')
       )

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -33,3 +33,4 @@ jobs:
         uses: datarobot-oss/review-router@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/skills/datarobot-app-framework-cicd/README.md
+++ b/skills/datarobot-app-framework-cicd/README.md
@@ -1,6 +1,6 @@
 # DataRobot Application Templates CI/CD Skill
 
-This skill provides comprehensive guidance for setting up production-grade CI/CD pipelines for DataRobot application templates.
+A skill that provides comprehensive guidance for setting up production-grade CI/CD pipelines for DataRobot application templates.
 
 ## Overview
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New workflow uses repository secrets and can write to pull requests; risk is mitigated by same-repo-only guards and avoiding pull_request_target for fork PRs.
> 
> **Overview**
> Adds a **Review Router** GitHub Actions workflow that runs automated code-review routing when a PR is labeled **Ready for Review** or when a review is **approved**, but only for PRs whose head branch is in the same repository (fork PRs are excluded).
> 
> The job mints a short-lived token via `actions/create-github-app-token` using `REVIEW_ROUTER_APP_ID` and `REVIEW_ROUTER_APP_PRIVATE_KEY`, then invokes `datarobot-oss/review-router@v1`. The workflow is wired to `pull_request` / `pull_request_review` (not `pull_request_target`), with an inline note that this avoids exposing secrets to fork PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e72d38aeb83baadef561c94f92b7d276f46f45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->