### PR TITLE
Update the model explainability skill to use the new insights API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,12 @@
 # Default owner for repo scaffolding, CI, docs, and anything outside skills/
 * @datarobot-oss/datarobot-agent-skills
 
+# Changelog is owned by the predictive-ai team
+/CHANGELOG.md @datarobot/predictive-ai
+
+# CODEOWNERS / repo meta — explicit so it doesn't fall to the default `*` rule
+/.github/ @datarobot-oss/datarobot-agent-skills
+
 # Agent assist team skills
 /skills/datarobot-agent-assist/ @datarobot/agentic-assistant
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+- `datarobot-model-explainability`: migrate SHAP explanations and model diagnostics
+  (ROC curve, confusion matrix, lift chart) from the legacy per-resource APIs to the
+  unified `datarobot.insights` API.
+
 ## [1.2.0] - 2026-05-20
 
 First tracked release. Skills included:

--- a/skills/datarobot-model-explainability/SKILL.md
+++ b/skills/datarobot-model-explainability/SKILL.md
@@ -9,13 +9,21 @@ This skill provides comprehensive guidance for understanding model decisions, an
 
 ## Quick Start
 
-**Most common use case**: Get prediction explanations for a specific prediction
+**Most common use case**: Get SHAP explanations for a leaderboard / training model
 
-1. **Identify model/project**: Get `project_id` + `model_id` (from a deployment’s champion model, or from training)
-2. **Compute explanations**: Use `dr.PredictionExplanations.create(project_id, model_id, dataset_id, ...)`
-3. **Read explanation rows**: Use `dr.PredictionExplanations.get(project_id, prediction_explanations_id)` and iterate `get_rows()`
+1. **Identify the model**: Get `model_id` (from a deployment's champion model, or from training)
+2. **Compute the insight**: Use the unified Insights API — `ShapMatrix.create(entity_id=model_id, source="validation")`
+3. **Read the values**: Use `ShapMatrix.get_as_dataframe(model_id)`, or read `.matrix` / `.columns` / `.base_value`
 
 **Example**: "Explain why the model predicted 0.85 for this customer record"
+
+> **API note**: This skill uses the unified `datarobot.insights` API (SDK 3.x+), which is the
+> preferred way to compute and retrieve model insights. Every insight class shares the same
+> `create` / `compute` / `get` / `list` methods keyed on an `entity_id` (the model ID). The older
+> per-resource methods (`model.get_roc_curve`, `model.get_confusion_matrix`,
+> `model.get_lift_chart`, `dr.PredictionExplanations`) are legacy and should not be used for new
+> work. For **deployment-time, per-row** prediction explanations returned alongside scoring, use
+> the `datarobot-predictions` skill instead.
 
 ## When to use this skill
 
@@ -94,21 +102,33 @@ pip install datarobot
 
 ### Key SDK Operations
 
-Use these DataRobot SDK methods for model explainability:
+Model insights live in the unified `datarobot.insights` module. Import the class you need and
+call `create` (compute + wait + return) or `get` (retrieve a previously computed insight). All
+classes are keyed on `entity_id` (the model ID) and accept `source` (`"validation"`,
+`"crossValidation"`, `"holdout"`, `"training"`) plus optional `data_slice_id`.
 
-**Prediction Explanations (SDK v3.10.0)**:
-- `dr.PredictionExplanations.create(project_id, model_id, dataset_id, ...)` - Compute prediction explanations on a dataset
-- `dr.PredictionExplanations.get(project_id, prediction_explanations_id)` - Fetch explanations and read rows
-- `prediction_explanations.get_rows()` - Iterate explanation rows
+```python
+from datarobot.insights import (
+    ShapMatrix, ShapImpact, RocCurve, ConfusionMatrix, LiftChart,
+)
+```
 
-**Model Diagnostics**:
-- `model.get_roc_curve(source='validation')` - Get ROC curve with AUC
-- `model.get_confusion_matrix()` - Get confusion matrix
-- `model.get_lift_chart()` - Get lift chart data
-- `model.get_feature_impact()` - Get feature importance
+**Prediction explanations (SHAP)**:
+- `ShapMatrix.create(entity_id=model_id, source="validation")` - Compute per-row SHAP values
+- `ShapMatrix.get_as_dataframe(model_id)` - SHAP matrix as a pandas DataFrame
+- `.matrix`, `.columns`, `.base_value` - Raw SHAP values, feature names, and baseline
 
-**Feature Analysis**:
-- `model.get_partial_dependence(feature_name)` - Get partial dependence data
+**Model diagnostics**:
+- `RocCurve.create(entity_id=model_id, source="validation")` - `.auc`, `.roc_points`
+- `ConfusionMatrix.create(entity_id=model_id, source="validation")` - `.confusion_matrix_data`, `.global_metrics`
+- `LiftChart.create(entity_id=model_id, source="validation")` - `.bins`
+
+**Feature importance**:
+- `ShapImpact.create(entity_id=model_id, source="training")` - `.shap_impacts` (SHAP-based global importance)
+- `model.get_or_request_feature_impact()` - Permutation-based feature impact (remains a `Model` method)
+
+**Feature analysis**:
+- `dr.FeatureEffects` / `model.get_or_request_feature_effects(source)` - Partial dependence / feature effects (remains a `Model` method; not part of the insights module)
 
 See the [Common Patterns](#common-patterns) section below for complete examples.
 
@@ -123,10 +143,11 @@ See the [Common Patterns](#common-patterns) section below for complete examples.
 
 ## Common patterns
 
-### Pattern 1: Get prediction explanations
+### Pattern 1: Get SHAP prediction explanations (Insights API)
 
 ```python
 import datarobot as dr
+from datarobot.insights import ShapMatrix
 import os
 
 # Initialize client
@@ -135,48 +156,49 @@ client = dr.Client(
     endpoint=os.getenv("DATAROBOT_ENDPOINT")
 )
 
-# Example: compute explanations for a dataset (batch)
-project_id = "project_id_here"
 model_id = "model_id_here"
-dataset_id = "dataset_id_here"  # dataset to explain
 
-pe = dr.PredictionExplanations.create(
-    project_id=project_id,
-    model_id=model_id,
-    dataset_id=dataset_id,
-    max_explanations=5,
-)
+# create() computes the insight and blocks until it's ready (use compute() for async).
+shap = ShapMatrix.create(entity_id=model_id, source="validation")
 
-pe2 = dr.PredictionExplanations.get(project_id, pe.id)
-for row in pe2.get_rows():
-    # row contains per-row explanation info
-    print(row)
+# Per-row SHAP values as a DataFrame (rows = scored records, columns = features)
+df = ShapMatrix.get_as_dataframe(model_id)
+print(df.head())
+
+# Or work with the raw values
+print("Baseline (base value):", shap.base_value)
+print("Features:", shap.columns)
+print("First row SHAP values:", shap.matrix[0])
 ```
 
-### Pattern 2: Generate model diagnostics
+> SHAP-based explanations require a model that supports SHAP. If `create` reports the insight is
+> unavailable, fall back to XEMP via the deployment scoring path (`datarobot-predictions` skill)
+> or the legacy `dr.PredictionExplanations` API.
+
+### Pattern 2: Generate model diagnostics (Insights API)
 
 ```python
 import datarobot as dr
+from datarobot.insights import RocCurve, ConfusionMatrix, LiftChart
 
-# Get model
-model = dr.Model.get("xyz123")
+model_id = "xyz123"
 
-# Get ROC curve
-roc_curve = model.get_roc_curve(source='validation')
-print(f"AUC Score: {roc_curve.auc:.3f}")
+# ROC curve + AUC
+roc = RocCurve.create(entity_id=model_id, source="validation")
+print(f"AUC Score: {roc.auc:.3f}")
+# roc.roc_points is a list of {falsePositiveRate, truePositiveRate, threshold, ...} dicts
+best = max(roc.roc_points, key=lambda p: p["truePositiveRate"] - p["falsePositiveRate"])
+print(f"Best threshold (Youden's J): {best['threshold']:.3f}")
 
-# Get confusion matrix (for classification models)
-try:
-    cm = model.get_confusion_matrix(source='validation')
-    print(f"Precision: {cm.precision:.3f}")
-    print(f"Recall: {cm.recall:.3f}")
-    print(f"F1 Score: {cm.f1_score:.3f}")
-except:
-    print("Confusion matrix not available for this model type")
+# Confusion matrix (classification models)
+cm = ConfusionMatrix.create(entity_id=model_id, source="validation")
+print("Classes:", cm.columns)
+print("Matrix:", cm.confusion_matrix_data)
+print("Global metrics:", cm.global_metrics)
 
-# Get lift chart
-lift_chart = model.get_lift_chart(source='validation')
-print(f"Lift at 10%: {lift_chart.lift[10]:.3f}")
+# Lift chart
+lift = LiftChart.create(entity_id=model_id, source="validation")
+print(f"Number of bins: {len(lift.bins)}")
 ```
 
 ## Understanding SHAP Values
@@ -244,7 +266,7 @@ client = dr.Client(
 ## Resources
 
 - [DataRobot Python SDK Documentation](https://datarobot-public-api-client.readthedocs-hosted.com/)
+- [DataRobot Insights API Reference](https://datarobot-public-api-client.readthedocs-hosted.com/en/latest/autodoc/api_reference.html#insights) (`datarobot.insights`)
 - [DataRobot Model Insights Documentation](https://docs.datarobot.com/en/docs/modeling/analyze-models/index.html)
-- [Prediction Explanations Guide](https://docs.datarobot.com/en/docs/api/dev-learning/python/modeling/insights/prediction_explanations.html)
 - [SHAP Documentation](https://shap.readthedocs.io/)
 

--- a/skills/datarobot-model-explainability/SKILL.md
+++ b/skills/datarobot-model-explainability/SKILL.md
@@ -124,8 +124,8 @@ from datarobot.insights import (
 - `LiftChart.create(entity_id=model_id, source="validation")` - `.bins`
 
 **Feature importance**:
-- `ShapImpact.create(entity_id=model_id, source="training")` - `.shap_impacts` (SHAP-based global importance)
-- `model.get_or_request_feature_impact()` - Permutation-based feature impact (remains a `Model` method)
+- `ShapImpact.create(entity_id=model_id, source="training")` - SHAP-based global importance. `.shap_impacts` is a list of dicts with **snake_case** keys: `feature_name`, `impact_normalized`, `impact_unnormalized`.
+- `model.get_or_request_feature_impact()` - Permutation-based feature impact (remains a `Model` method). Returns a list of dicts with **camelCase** keys: `featureName`, `impactNormalized`, `impactUnnormalized`, `redundantWith`. (The two APIs use different casing — don't assume one's keys work on the other.)
 
 **Feature analysis**:
 - `dr.FeatureEffects` / `model.get_or_request_feature_effects(source)` - Partial dependence / feature effects (remains a `Model` method; not part of the insights module)
@@ -199,6 +199,33 @@ print("Global metrics:", cm.global_metrics)
 # Lift chart
 lift = LiftChart.create(entity_id=model_id, source="validation")
 print(f"Number of bins: {len(lift.bins)}")
+```
+
+### Pattern 3: Global feature importance (SHAP-based)
+
+```python
+import datarobot as dr
+from datarobot.insights import ShapImpact
+
+model_id = "xyz123"
+
+# SHAP-based global importance — snake_case keys
+si = ShapImpact.create(entity_id=model_id, source="training")
+for row in sorted(si.shap_impacts, key=lambda r: -abs(r["impact_normalized"]))[:10]:
+    print(f"{row['feature_name']:30s}  {row['impact_normalized']:+.4f}")
+```
+
+### Pattern 4: Global feature importance (permutation-based, legacy `Model` method)
+
+```python
+import datarobot as dr
+
+# Permutation feature impact lives on the Model object, not in the insights module.
+# Note the camelCase keys — different from ShapImpact above.
+model = dr.Model.get(project_id="proj123", model_id="xyz123")
+fi = model.get_or_request_feature_impact()
+for row in fi[:10]:
+    print(f"{row['featureName']:30s}  {row['impactNormalized']:+.4f}")
 ```
 
 ## Understanding SHAP Values


### PR DESCRIPTION
## Summary

- Luke flagged in [Slack](https://datarobot.slack.com/archives/C09J9MLBF19/p1779854079835409) that `datarobot-model-explainability` was pointing agents at the legacy per-resource insight APIs.
- Migrates the skill to the unified `datarobot.insights` API (`ShapMatrix`, `ShapImpact`, `RocCurve`, `ConfusionMatrix`, `LiftChart`) — the preferred path on SDK 3.x+.
- Replaces legacy calls: `dr.PredictionExplanations`, `model.get_roc_curve`, `model.get_confusion_matrix`, `model.get_lift_chart`.
- Adds two patterns the migration left implicit: global SHAP-based feature importance (`ShapImpact`) and permutation-based feature impact (`Model.get_or_request_feature_impact`), with an explicit note that the two APIs use **different key casing** (snake_case vs camelCase) — a real footgun agents trip over.

## What changed

- **Quick Start** rewritten around `ShapMatrix.create(entity_id=model_id, source=...)` with a note calling out that `datarobot.insights` is preferred and naming the legacy methods to avoid.
- **Key SDK Operations** restructured around the insights classes with their real property names. Documents the snake_case / camelCase return-key difference between `ShapImpact.shap_impacts` and `Model.get_or_request_feature_impact()`.
- **Patterns 1 & 2** code examples regenerated against the new API.
- **Pattern 3 (new)**: global SHAP-based feature importance via `ShapImpact`.
- **Pattern 4 (new)**: permutation-based feature impact via the legacy `Model` method, with correct camelCase keys.
- **Resources** now links the Insights API reference.
- `CHANGELOG.md`: one-line entry under `[Unreleased]` (per CONTRIBUTING). No plugin version bump — correctness fix, accumulated for the next release cut per Keep a Changelog convention.
- `.github/CODEOWNERS`: added explicit rules for `/CHANGELOG.md` and `/.github/` so those files no longer fall through to only the default `*` rule.

## Test plan

- [x] Verified `datarobot.insights` class signatures and return-key conventions against `datarobot==3.13.0` (installed locally). Confirmed the snake_case / camelCase split between `ShapImpact` and permutation feature-impact.
- [x] `task lint` clean (only failure is the unrelated `test_gemini_extension_validate`, because the `gemini` CLI isn't installed locally).
- [x] End-to-end demo against a real deployed model — see **Demo** section below.
- [x] Skill scored via SkillOpt — see **SkillOpt evaluation** below.
- [ ] CI green on this PR.
- [ ] Spot-check by `@datarobot/core-modeling`.

## Demo

Recorded run against the deployed **Churn Binary Classification** model (`685c49405442874e2c9c20e8`, XGBoost binary classifier on `app.datarobot.com`). `urllib3` DEBUG logging is on so every HTTP call the SDK makes is visible. Real data; secrets scrubbed.

The point: prove that the revised skill drives agents to call `/api/v2/insights/<type>/models/<id>/` rather than the legacy per-resource endpoints.

![demo](https://gist.githubusercontent.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43/raw/demo.gif)

**HTTP calls captured** (5 of 5 insights endpoints hit):

```
GET /api/v2/insights/rocCurve/models/685c49405442874e2c9c20e8/        200
GET /api/v2/insights/confusionMatrix/models/685c49405442874e2c9c20e8/ 422  *
GET /api/v2/insights/liftChart/models/685c49405442874e2c9c20e8/       200
GET /api/v2/insights/shapImpact/models/685c49405442874e2c9c20e8/      200
GET /api/v2/insights/shapMatrix/models/685c49405442874e2c9c20e8/      200
```

`*` 422 is the insights endpoint itself reporting that this OTV project type doesn't support `confusionMatrix` — which also proves the URL is correct (the endpoint answered).

**Real data returned**: `RocCurve` AUC **0.8132**, 120 ROC points · `LiftChart` 60 bins · `ShapImpact` top driver `HEALTH_SUMMARY_FLAG` (+1.0000 normalized) · `ShapMatrix` 2500×7.

Artifacts on gist: [GIF](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43#file-demo-gif) · [MP4](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43/raw/demo.mp4) · [transcript](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43#file-dr-demo-insights-api-20260529t110108-txt).

## SkillOpt evaluation

Scored the revised SKILL.md with the GEPA-style SkillOpt loop ([`datarobot-agent-tester` PR #7](https://github.com/datarobot-oss/datarobot-agent-tester/pull/7)). 25 auto-generated eval rows, 5 iters, cosine edit-budget schedule.

![SkillOpt chart](https://gist.githubusercontent.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43/raw/skillopt-chart.png)

| | val | test |
|---|---:|---:|
| **baseline** | 0.909 | 0.889 |
| **final** | 0.909 | 0.945 |

Optimizer ran 5 iterations and accepted **0 / 5** candidate edits — none beat the baseline on the held-out validation gate. The skill is at the optimizer's local optimum for this eval set. The test-score uptick (0.889 → 0.945) is LLM scoring noise on the unchanged skill — the chart's flat baseline line is the real signal.

(Two pre-PR side effects fed into this score: a bug in the SkillOpt mock-import sandbox was hiding ~30% of legit rollouts behind a phantom `ModuleNotFoundError` — fix submitted upstream — and the manual addition of Patterns 3 & 4 above moved the migration-only baseline from 0.861 → 0.889. Both noted only so the score is reproducible; neither belongs in the skill itself.)

Full artifacts: [HTML report](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43/raw/skillopt-report.html) · [summary.md](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43#file-skillopt-summary-md) · [summary.json](https://gist.github.com/j1z0/946bb10377efb9d66dc85e75f8b8ed43#file-skillopt-summary-json).