### PR TITLE
Corrected issues with setup commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 - `datarobot-model-explainability`: Correct SHAP export guidance for `datarobot.insights.ShapMatrix` (in-memory `matrix`/`columns` or classmethod `get_as_dataframe`/`get_as_csv`); fix `compute_shap_matrix.py` `--output` export; fix anomaly assessment date-range example to use `get_explanations()` instead of `get_latest_explanations()`; fix Model diagnostics examples (`get_confusion_chart`, `get_feature_effect`); document insights diagnostics (`RocCurve`, `LiftChart`, `ConfusionMatrix`); correct documented SHAP caveats for blenders, the >1000-feature limit, `ShapImpact` source support, logit-link probability conversion, XEMP contribution wording, XEMP routing guidance, and XEMP `max_explanations` limit; raise the documented minimum SDK version to `datarobot>=3.6.0` when referencing `ShapDistributions`.
 
+## [1.3.1] - 2026-06-02
+
+- `datarobot-setup`: Corrected issues with setup commands.
+
 ## [1.3.0] - 2026-05-27
 
 - `datarobot-model-explainability`: Updated SHAP guidance to use the current `datarobot.insights` APIs, added data slice and anomaly assessment coverage, added SHAP and XEMP reference docs, and added a `compute_shap_matrix.py` helper script.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, and data preparation",
   "author": "DataRobot",
   "skills": [

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -468,4 +468,3 @@ dr auth login
 ```
 
 This will guide the user through the authentication process interactively.
-=======

--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -193,8 +193,9 @@ dr plugin install assist
 
 2. **Python SDK**:
    ```bash
-   source .venv/bin/activate && timeout 60 python -c "import datarobot as dr; dr.Client(); [print(p.project_name) for p in dr.Project.list(limit=3)]" < /dev/null
+   source .venv/bin/activate && python -c "import datarobot; datarobot.Client(connect_timeout=10); [print(p.project_name) for p in datarobot.Project.list(limit=3)]"
    ```
+   if this fails due to the source command not working, try it without activating the venv
 
 ## Step 9: Print Summary
 

--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -188,16 +188,12 @@ dr plugin install assist
 1. **CLI and plugins**:
    ```bash
    dr --version
-   dr plugin list
-   dr assist --help
+   dr plugin list 2>/dev/null | grep -i assist
    ```
 
-2. **Python SDK** (inside the activated venv):
-   ```python
-   import datarobot as dr
-   dr.Client()
-   for p in dr.Project.list()[:3]:
-       print(p.project_name)
+2. **Python SDK**:
+   ```bash
+   source .venv/bin/activate && timeout 60 python -c "import datarobot as dr; dr.Client(); [print(p.project_name) for p in dr.Project.list(limit=3)]" < /dev/null
    ```
 
 ## Step 9: Print Summary


### PR DESCRIPTION
## Summary

Claude code was not properly executing the Python in multiple users' environments as it was hanging forever. 
`dr assist --help` is not a command. So switched the verification to use the same command as the check

## Rationale
Improving harness success for setup skill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and plugin version metadata only; no runtime code or API behavior changes.
> 
> **Overview**
> Bumps the shared plugin package version to **1.3.1** across Claude, Cursor, and Gemini manifests and records the release in `CHANGELOG.md`.
> 
> **`datarobot-setup`** verification is tightened so agents don’t hang or fail on bad checks: Step 8 drops `dr assist --help` (not a real command) and reuses the same `dr plugin list … | grep -i assist` check as the pre-flight step; the Python SDK check becomes a single shell one-liner with an explicit `connect_timeout` and `Project.list(limit=3)` inside the project `.venv`.
> 
> **`datarobot-agent-assist`** removes a stray merge-artifact line (`=======`) from the authenticate section so the doc renders cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866265d1f0102e830f7c9b6dfb9f89d996355f5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->