### PR TITLE
feat(agent-assist): improve skill trigger precision for cross-harness activation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.1"
+      "version": "1.3.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, and data preparation",
   "author": "DataRobot",
   "skills": [
@@ -51,7 +51,7 @@
     },
     {
       "name": "datarobot-agent-assist",
-      "description": "Build AI agents and deploy them to DataRobot. Supports building LangGraph, CrewAI, LlamaIndex, NAT and Base agents. Created agents can be bundled with MCP server, backend APIs & React frontend",
+      "description": "Use when the user wants to design, build, code, simulate, or deploy an AI agent (not a predictive model) to DataRobot; mentions agent_spec.md, dr-assist, dress rehearsal, or the DataRobot agent template; wants to scaffold a LangGraph, CrewAI, LlamaIndex, NAT, or Base agent targeting DataRobot; or wants to add an MCP server, backend API, or React frontend to a DataRobot agent application.",
       "path": "skills/datarobot-agent-assist/SKILL.md"
     },
     {

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: datarobot-agent-assist
 description: >-
-  Unified DataRobot agent workflow — design (agent_spec.md), optional dress-rehearsal simulation
-  via built-in rehearsal engine, template-based coding, and deployment. Combines agent design guidance
-  with interactive pre-code simulation (DataRobot LLM Gateway, feedback report). Use when the user
-  wants to design, build, code, or deploy an AI agent for DataRobot, run a spec simulation before
-  coding, mentions "agent spec", "datarobot-agent-assist", "dr-assist", "dress rehearsal", or is creating agents on DataRobot's
-  platform.
+  Use when the user wants to design, build, code, simulate, or deploy an AI agent (not a predictive
+  model) to DataRobot; mentions agent_spec.md, dr-assist, datarobot-agent-assist, dress rehearsal,
+  or the DataRobot agent template; wants to scaffold a LangGraph, CrewAI, LlamaIndex, NAT, or Base
+  agent targeting DataRobot; wants to add an MCP server, backend API, or React frontend to a
+  DataRobot agent application; or uses the DataRobot CLI (dr) to build or deploy an agentic custom
+  application. Covers the full workflow: agent design, agent_spec.md authoring, dress-rehearsal
+  simulation via the DataRobot LLM Gateway, template-based coding, and deployment.
 ---
 
 # DataRobot Agent Assist


### PR DESCRIPTION
## Summary

- Moves "Use when" to the front of the `SKILL.md` description so harnesses (Claude Code, Cursor, Gemini CLI) weight the trigger signal correctly rather than finding it buried after 40 words of context
- Adds missing high-value trigger terms: MCP server, React frontend, DataRobot agent template, `dr` CLI, agentic custom application
- Adds "(not a predictive model)" disambiguation to reduce false-positive routing from model-deployment prompts
- Aligns `gemini-extension.json` to carry the same "Use when" guidance it was missing entirely
- Bumps all four plugin manifest versions 1.3.1 → 1.3.2 in lockstep

## Why this PR

The `datarobot-agent-assist` skill is now surfaced in Cursor, Claude Code, and Gemini CLI marketplaces. Across all three, the harness routes prompts to skills based on the description in `SKILL.md` frontmatter (and `gemini-extension.json` for Gemini). The current description buries the activation signal after a long preamble, and the Gemini entry has no "Use when" guidance at all. This causes two failure modes:

1. **False negatives**: a developer says "build me a competitive research agent on DataRobot" but the skill doesn't activate because trigger terms like "MCP server", "React frontend", "agent template" aren't in the description
2. **False positives**: a developer says "deploy to DataRobot" and agent-assist activates over `datarobot-model-deployment` because both contain "deploy" and "DataRobot"

This PR rewrites the description to front-load activation, expand trigger surface area, and disambiguate from neighboring DataRobot skills.

## What's intentionally not in this PR

`"Do NOT use when"` exclusion language is held for a follow-up PR pending discussion of whether negation in descriptions helps or hurts semantic routing in practice.

## Test plan

- [ ] `task lint` passes
- [ ] `test_skill_frontmatter_description_has_use_when` passes
- [ ] `test_all_plugin_versions_match` passes (all four manifests at 1.3.2)
- [ ] Manual smoke test in Claude Code and Cursor with a few should-trigger prompts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to skill descriptions and version strings; no application logic or security-sensitive code paths.
> 
> **Overview**
> Improves **when** the `datarobot-agent-assist` skill activates across Claude, Cursor, and Gemini by rewriting skill descriptions, not runtime agent code.
> 
> The **`datarobot-agent-assist`** `SKILL.md` frontmatter now **leads with “Use when…”** and adds clearer triggers (e.g. **not a predictive model**, MCP server, React frontend, agent template, `dr` CLI, agentic custom app) so harnesses match agent-building prompts and avoid colliding with model-deployment skills. **`gemini-extension.json`** gets the same activation text for that skill, which previously lacked it.
> 
> All four plugin manifests bump **1.3.1 → 1.3.2** in lockstep (`.claude-plugin`, `.cursor-plugin`, `gemini-extension.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248e0ad7de128a1a1ae70d1a842ae1bd5c289dd8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->