### PR TITLE
Test external config from datarobot/.review-router-config

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -16,8 +16,7 @@ permissions:
 jobs:
   route:
     if: >-
-      github.event_name != 'issue_comment'
-      || contains(github.event.comment.body, '/review')
+      github.event_name != 'issue_comment' || contains(github.event.comment.body, '/review')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -2,6 +2,8 @@
 name: Review Router
 
 on:
+  pull_request:
+    types: [labeled]
   pull_request_target:
     types: [labeled]
   pull_request_review:

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,14 +1,13 @@
-# SECURITY: Use "pull_request" only — NEVER "pull_request_target".
-# pull_request does not pass secrets to fork PRs (safe).
-# pull_request_target does pass secrets to fork PRs (unsafe — credentials leak risk).
 ---
 name: Review Router
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   pull_request_review:
     types: [submitted]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -16,6 +15,9 @@ permissions:
 
 jobs:
   route:
+    if: >-
+      github.event_name != 'issue_comment'
+      || contains(github.event.comment.body, '/review')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
@@ -29,4 +31,6 @@ jobs:
         uses: datarobot-oss/review-router@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          config-repo: datarobot/.review-router-config
+          config-token: ${{ secrets.REVIEW_ROUTER_CONFIG_TOKEN }}
           slack-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -2,8 +2,6 @@
 name: Review Router
 
 on:
-  pull_request:
-    types: [labeled]
   pull_request_target:
     types: [labeled]
   pull_request_review:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> `pull_request_target` plus secrets (config token, Slack, app key) increases exposure on fork PRs and comment-triggered runs compared to the previous `pull_request`-only setup.
> 
> **Overview**
> **Review Router** now loads routing rules from **`datarobot/.review-router-config`** via new `config-repo` and `config-token` inputs on `datarobot-oss/review-router@v1`.
> 
> Workflow triggers expand beyond label/review events: **`issue_comment` (created)** runs the job when the comment body contains **`/review`**, with a job-level `if` so other comments are ignored.
> 
> For **`labeled`** events, the workflow switches from **`pull_request`** to **`pull_request_target`**, and the inline comments that warned against `pull_request_target` (fork + secrets risk) are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d3ce8e08d3c1cfe25b5d28837f98c35ae75bd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->