### PR TITLE
Setup skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides instructions for an agent to use DataRobot skills. An agent will automatically load these instructions when working with DataRobot-related tasks.
 
+## DataRobot Authentication
+
+If any DataRobot skill fails due to missing or invalid credentials, invoke `datarobot-setup` before retrying the original task. Do not print manual instructions — run the skill.
+
 ## Should I Add a Skill Here?
 
 There are many places you can add skills for use. This repository is for customer facing skills that help other build more effectively in DataRobot. Here is the goal, intended use, and criteria for determining if your skill is correct for this library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Each entry should be prefixed with the affected skill folder name (for example,
 ## [Unreleased]
 
 - `datarobot-setup`: Broaden trigger to cover credential failures; add env var and auth validity checks to pre-flight.
-- `CONTRIBUTING.md`: Add `license-eye` and `yamlfmt` as prerequisites.
 
 - `datarobot-model-explainability`: Correct SHAP export guidance for `datarobot.insights.ShapMatrix` (in-memory `matrix`/`columns` or classmethod `get_as_dataframe`/`get_as_csv`); fix `compute_shap_matrix.py` `--output` export; fix anomaly assessment date-range example to use `get_explanations()` instead of `get_latest_explanations()`; fix Model diagnostics examples (`get_confusion_chart`, `get_feature_effect`); document insights diagnostics (`RocCurve`, `LiftChart`, `ConfusionMatrix`); correct documented SHAP caveats for blenders, the >1000-feature limit, `ShapImpact` source support, logit-link probability conversion, XEMP contribution wording, XEMP routing guidance, and XEMP `max_explanations` limit; raise the documented minimum SDK version to `datarobot>=3.6.0` when referencing `ShapDistributions`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+- `datarobot-setup`: Broaden trigger to cover credential failures; add env var and auth validity checks to pre-flight.
+- `CONTRIBUTING.md`: Add `license-eye` and `yamlfmt` as prerequisites.
+
 - `datarobot-model-explainability`: Correct SHAP export guidance for `datarobot.insights.ShapMatrix` (in-memory `matrix`/`columns` or classmethod `get_as_dataframe`/`get_as_csv`); fix `compute_shap_matrix.py` `--output` export; fix anomaly assessment date-range example to use `get_explanations()` instead of `get_latest_explanations()`; fix Model diagnostics examples (`get_confusion_chart`, `get_feature_effect`); document insights diagnostics (`RocCurve`, `LiftChart`, `ConfusionMatrix`); correct documented SHAP caveats for blenders, the >1000-feature limit, `ShapImpact` source support, logit-link probability conversion, XEMP contribution wording, XEMP routing guidance, and XEMP `max_explanations` limit; raise the documented minimum SDK version to `datarobot>=3.6.0` when referencing `ShapDistributions`.
 
 ## [1.3.1] - 2026-06-02

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ Install these tools before running validation tasks:
 
 - [Task](https://taskfile.dev/)&mdash;task runner (`brew install go-task`).
 - [uv](https://docs.astral.sh/uv/)&mdash;Python package and environment manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+- [license-eye](https://github.com/apache/skywalking-eyes)&mdash;license header checker (`go install github.com/apache/skywalking-eyes/cmd/license-eye@latest`, then ensure `~/go/bin` is on your PATH).
 
 ### Common tasks
 

--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datarobot-setup
-description: Sets up DataRobot for local development including Python SDK, dr-cli, Agent Assist, and all required dependencies. Use when the user has not yet worked with DataRobot on this machine and wants to deploy agents to DataRobot, build an agent from scratch, or connect to DataRobot's APIs from a new project.
+description: Sets up DataRobot for local development including Python SDK, dr-cli, Agent Assist, and all required dependencies. Use when the user has not yet worked with DataRobot on this machine, OR when any DataRobot task fails due to missing or invalid credentials. Covers first-time setup, re-authentication, and credential recovery.
 ---
 
 # DataRobot Local Development Setup
@@ -29,8 +29,15 @@ dr plugin list 2>/dev/null | grep -i assist
 python3 -c "import datarobot; print(datarobot.__version__)" 2>/dev/null
 python3 -c "import datarobot_predict; print('datarobot-predict installed')" 2>/dev/null
 
-# dr-cli auth state
-test -f ~/.config/datarobot/drconfig.yaml && echo "dr-cli already configured"
+# Credential state
+echo "DATAROBOT_API_TOKEN: ${DATAROBOT_API_TOKEN:+set (via env)}"
+echo "DATAROBOT_ENDPOINT:  ${DATAROBOT_ENDPOINT:-not set}"
+test -f ~/.config/datarobot/drconfig.yaml && echo "drconfig: found" || echo "drconfig: missing"
+
+# If drconfig exists, verify credentials are actually valid
+if test -f ~/.config/datarobot/drconfig.yaml; then
+  dr auth status 2>/dev/null && echo "auth: valid" || echo "auth: INVALID (re-authentication required)"
+fi
 ```
 
 Compare each detected version to the minimums in the table in Step 3. Tell the user:

--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -36,7 +36,7 @@ test -f ~/.config/datarobot/drconfig.yaml && echo "drconfig: found" || echo "drc
 
 # If drconfig exists, verify credentials are actually valid
 if test -f ~/.config/datarobot/drconfig.yaml; then
-  dr auth status 2>/dev/null && echo "auth: valid" || echo "auth: INVALID (re-authentication required)"
+  dr auth check 2>/dev/null && echo "auth: valid" || echo "auth: INVALID (re-authentication required)"
 fi
 ```
 


### PR DESCRIPTION
Improve datarobot-setup credential handling and contributor onboarding

## Summary
AGENTS.md: Add auth recovery rule - any DataRobot skill that hits missing or invalid credentials now invokes datarobot-setup automatically instead of printing manual instructions

datarobot-setup: Broaden trigger description to cover re-authentication scenarios, not just first-time setup; replace the drconfig existence check with a canonical env var check + dr auth status validation

CONTRIBUTING.md: Document license-eye as a required prerequisite with the correct go install command (not available via Homebrew)

## Summary


## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1781277892.129999 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 22fba5230239e066d155cb6fbaa2c8d90c23d72d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->