### PR TITLE
Switch to reusable workflow from datarobot-oss/.github

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   route:
     if: >-
-      github.event_name != 'issue_comment'
-      || contains(github.event.comment.body, '/review')
+      github.event_name != 'issue_comment' || contains(github.event.comment.body, '/review')
     uses: datarobot-oss/.github/.github/workflows/review-router.yml@main
     secrets: inherit

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -9,27 +9,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   route:
     if: >-
-      github.event_name != 'issue_comment' || contains(github.event.comment.body, '/review')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.REVIEW_ROUTER_APP_ID }}
-          private-key: ${{ secrets.REVIEW_ROUTER_APP_PRIVATE_KEY }}
-
-      - name: Run Review Router
-        uses: datarobot-oss/review-router@v1
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          config-repo: datarobot/.review-router-config
-          config-token: ${{ secrets.REVIEW_ROUTER_CONFIG_TOKEN }}
-          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
+      github.event_name != 'issue_comment'
+      || contains(github.event.comment.body, '/review')
+    uses: datarobot-oss/.github/.github/workflows/review-router.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Switch to reusable workflow from datarobot-oss/.github

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions wiring changes; behavior should match the shared workflow, with dependency on `@main` of the central workflow for future updates.
> 
> **Overview**
> **Replaces the inlined Review Router job** with a **reusable workflow** from `datarobot-oss/.github` (`review-router.yml@main`), using `secrets: inherit` so existing repo secrets stay available to the shared implementation.
> 
> The **event triggers are unchanged** (`pull_request_target` labeled, `pull_request_review` submitted, `issue_comment` created), and the **`/review` comment gate** on `issue_comment` events is preserved. **Removed from this repo**: workflow-level `permissions`, the GitHub App token step, and the direct `datarobot-oss/review-router@v1` action invocation with explicit config/slack tokens—those concerns move into the central reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1dd4a7391688ea476c7e4a241e09db1a78c4d2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->