### PR TITLE
Add security comment, dependabot auto-label and reminder triggers to review-router

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,13 +1,24 @@
 ---
 name: Review Router
 
+# SECURITY: This workflow intentionally uses pull_request_target (not
+# pull_request) because review-router never checks out or executes PR code.
+# Do NOT add actions/checkout or shell run: blocks here.
+#
+# If you need to build or test PR code, use a separate workflow with the
+# pull_request trigger instead.
+#
+# See: https://github.com/datarobot-oss/review-router/blob/main/docs/security/pull-request-target.md
+
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, opened]
   pull_request_review:
     types: [submitted]
   issue_comment:
     types: [created]
+  schedule:
+    - cron: "0 3,9,15,21 * * 1-5"
 
 jobs:
   route:


### PR DESCRIPTION
## Summary

Enable dependabot auto-label functionality and reminders in Slack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with inherited secrets on more events (including every opened PR); mitigated by documented no-checkout policy but misconfiguration could be high impact.
> 
> **Overview**
> Extends the **Review Router** workflow so routing runs on more events and documents safe use of `pull_request_target`.
> 
> **Triggers:** `pull_request_target` now fires on `opened` as well as `labeled` (so new PRs—including Dependabot opens—get routed without waiting for a label). A **weekday cron** (`0 3,9,15,21 * * 1-5`) was added for scheduled reminder-style runs. The job still delegates to `datarobot-oss/.github`’s reusable workflow with `secrets: inherit`.
> 
> **Security:** A prominent workflow comment warns not to add checkout or `run:` steps under `pull_request_target` and points to review-router security docs, since this path never executes PR code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180eb481ba0af81c5cdbb69cfec337143ed06df6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->