### PR TITLE
Add closed trigger to review-router workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /skills/datarobot-predictions/ @datarobot/core-modeling
 
 # All App Framework skills are owned by the Applications team
-/skills/datarobot-app-framework-*/ @datarobot/applications
+/skills/datarobot-app-framework-*/ @datarobot-oss/applications
 
 # OpenCode plugin (theme, install scripts, metadata)
 /.opencode-plugin/ @datarobot-oss/datarobot-agent-skills

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Find the appropriate team in https://github.com/orgs/datarobot-oss/teams and grant it write permissions to the repository
 
 # Default owner for repo scaffolding, CI, docs, and anything outside skills/
-* @datarobot-oss/datarobot-agent-skills
+* @datarobot-oss/agent-skills-maintainers
 
 /.github/workflows/review-router.yml @andriykislitsyn
 
@@ -21,7 +21,7 @@
 /skills/datarobot-app-framework-*/ @datarobot-oss/applications
 
 # OpenCode plugin (theme, install scripts, metadata)
-/.opencode-plugin/ @datarobot-oss/datarobot-agent-skills
+/.opencode-plugin/ @datarobot-oss/agent-skills-maintainers
 
 # Individual Contributor skills
 /skills/datarobot-external-agent-monitoring/ @vitali93

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # Default owner for repo scaffolding, CI, docs, and anything outside skills/
 * @datarobot-oss/datarobot-agent-skills
 
+/.github/workflows/review-router.yml @andriykislitsyn
+
 # Agent assist team skills
 /skills/datarobot-agent-assist/ @datarobot/agentic-assistant
 

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -12,7 +12,7 @@ name: Review Router
 
 on:
   pull_request_target:
-    types: [labeled, opened]
+    types: [labeled, opened, closed]
   pull_request_review:
     types: [submitted]
   issue_comment:


### PR DESCRIPTION
## Summary

* Add `closed` PR trigger
* Correct CODEOWNERS

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single trigger-type addition on an existing pull_request_target workflow that still does not checkout PR code.
> 
> **Overview**
> Extends the **Review Router** GitHub Actions workflow so it also runs when a pull request is **closed**, not only on `labeled` and `opened`.
> 
> The `pull_request_target` trigger’s `types` list now includes `closed`, so the shared `datarobot-oss/.github` review-router job can react when PRs are closed (e.g. merge/close cleanup or final routing). No other workflow logic, jobs, or security comments change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d8f5aa15d17b81f1e99fb99a81aa30b2c860c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->