### PR TITLE
Update CODEOWNERS to remove review-router.yml owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,6 @@
 # Default owner for repo scaffolding, CI, docs, and anything outside skills/
 * @datarobot-oss/agent-skills-maintainers
 
-/.github/workflows/review-router.yml @andriykislitsyn
-
 # Agent assist team skills
 /skills/datarobot-agent-assist/ @datarobot/agentic-assistant
 


### PR DESCRIPTION
## Summary

Removed CODEOWNER for review-router.yml and updated default owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub review routing ownership; no runtime or application code is affected.
> 
> **Overview**
> Updates **CODEOWNERS** so `/.github/workflows/review-router.yml` no longer has a dedicated owner (`@andriykislitsyn`). That workflow file is now covered by the repo-wide default `* @datarobot-oss/agent-skills-maintainers` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1699bb7a0607b801005613c682512b38d1000910. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->