### PR TITLE
Enable review-router thread notifications

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -15,6 +15,8 @@ on:
     types: [labeled, opened, closed]
   pull_request_review:
     types: [submitted]
+  pull_request_review_comment:
+    types: [created]
   issue_comment:
     types: [created]
   schedule:
@@ -22,7 +24,5 @@ on:
 
 jobs:
   route:
-    if: >-
-      github.event_name != 'issue_comment' || contains(github.event.comment.body, '/review')
     uses: datarobot-oss/.github/.github/workflows/review-router.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Add pull_request_review_comment trigger for inline comment notifications. Remove issue_comment filter, `review-router` now handles dispatch internally.

## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1781382443.727319 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application code; slightly broader GitHub Actions trigger surface, still using the same reusable router and `pull_request_target` security model.
> 
> **Overview**
> **Review Router** now runs when someone creates an **inline PR review comment**, so thread-style notifications can be routed the same way as reviews and labels.
> 
> The `route` job no longer gates `issue_comment` events on a `/review` substring in the comment body; every `issue_comment` creation still invokes the reusable workflow, and **filtering/dispatch is delegated** to `datarobot-oss/.github`’s shared `review-router.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5d32b5ec98c1e72bc4cc40001865cec2c7cef1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->