### PR TITLE
update claude installation inststructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,27 @@ Click on the section that corresponds to your coding agent to see the installati
 
 <details><summary><strong>Claude Code</strong></summary>
 
-Register the repository as a plugin marketplace:
+Install all DataRobot skills from the official Claude plugins marketplace.
+
+From your terminal:
+
+```bash
+claude plugin install datarobot-agent-skills@claude-plugins-official
+```
+
+From within a Claude Code CLI session:
+
+```bash
+/plugin install datarobot-agent-skills@claude-plugins-official
+```
+
+**Alternative:** register the repository as a plugin marketplace from within a Claude Code CLI session:
 
 ```bash
 /plugin marketplace add datarobot-oss/datarobot-agent-skills
 ```
 
-To install a skill, run:
+To install a specific skill, run:
 
 ```bash
 /plugin install <skill-folder>@datarobot-skills


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update the Claude installation instruction

## Rationale
https://datarobot.atlassian.net/browse/CFX-6488

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1782289982.671749 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to installation instructions; no code, auth, or runtime behavior is affected.
> 
> **Overview**
> Updates the **Claude Code** section of `README.md` so the **recommended** path is installing the full `datarobot-agent-skills` bundle from the official **`claude-plugins-official`** marketplace (terminal `claude plugin install …` and in-session `/plugin install …`).
> 
> The previous **GitHub marketplace registration** flow (`/plugin marketplace add datarobot-oss/datarobot-agent-skills`) is kept as an **alternative**, and the wording for per-skill installs is clarified (“install a specific skill”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6b623b0fee847d1e1ae06ee64a3566918dc6f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->