### PR TITLE
[CFX-6616] datarobot-agent-assist: Implement pre-code, pre-deployment & workspace resolution flows.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.5"
+      "version": "1.3.6"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.5"
+  "version": "1.3.6"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.3.6] - 2028-07-14
+
+- `datarobot-agent-assist`: Implement pre-coding-checklist, pre-deployment-checklist & workspace-resolution flows.
+
+
 ## [1.3.5] - 2028-07-08
 
 - `datarobot-agent-assist`: Bumped application template version to 11.10.7.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -37,7 +37,10 @@ What would you like to do?
   3. Deploy an AI agent     → Deploy an implemented agent to DataRobot
 ```
 
-Show this menu first. After the user selects an option (`1`, `2`, or `3`), run the **[Pre-requisite Check](#pre-requisite-check)** and then the **[Script Path Resolution](#script-path-resolution)** before doing anything else for that option.
+Show this menu first. After the user selects an option (`1`, `2`, or `3`), run the **[Pre-requisite Check](#pre-requisite-check)** and then the **[Script Path Resolution](#script-path-resolution)**.
+
+- Options **1** and **2** — read and follow [references/workspace-resolution.md](references/workspace-resolution.md), then proceed to the selected workflow.
+- Option **3** — skip Workspace Resolution; `<target_dir>` is resolved in the [Pre-deployment Checklist](references/pre-deployment-checklist.md) when unset.
 
 ---
 
@@ -48,6 +51,34 @@ Before invoking any helper script, resolve `<skill_scripts_dir>` once for the se
 - `<skill_scripts_dir>` is the `scripts/` subdirectory of the directory containing this `SKILL.md` file.
 - Confirm it exists with `ls <path_to_this_skill_dir>/scripts/`. If the directory is missing, tell the user the skill installation is incomplete and stop.
 - Use the resolved absolute path for every `<skill_scripts_dir>/...` reference in this skill.
+
+---
+
+## Session State
+
+Track these for the conversation:
+
+- `<target_dir>` — project root for design, coding, and deployment. Set during [Workspace Resolution](references/workspace-resolution.md) or the [Pre-deployment Checklist](references/pre-deployment-checklist.md). Reuse across phases in the same session. Only change when the user explicitly asks, during [pre-coding subdir recovery](references/pre-coding-checklist.md), or in a new session.
+- `<dependency_check_passed>` — `false` until a passing `dr dependency check` in `<target_dir>`.
+- `<dependency_check_target_dir>` — the `<target_dir>` value when the last check passed.
+
+### Dependency check session rule
+
+Before running `dr dependency check`:
+
+- If `<dependency_check_passed>` is true and `<target_dir>` equals `<dependency_check_target_dir>`, skip the check.
+- Otherwise, run `dr dependency check` in `<target_dir>`. On zero exit: set `<dependency_check_passed>` = true and `<dependency_check_target_dir>` = `<target_dir>`. On non-zero exit: hard stop — return full output; do not attempt to resolve automatically.
+
+Invalidate `<dependency_check_passed>` (set to false) when:
+
+- `<target_dir>` changes
+- `clone_template.py`, `select_framework.py`, or `setup_template.py` runs in `<target_dir>`
+
+---
+
+## Workspace Resolution
+
+Read and follow [references/workspace-resolution.md](references/workspace-resolution.md) after menu options **1** or **2**.
 
 ---
 
@@ -79,7 +110,7 @@ Run in order before proceeding:
 
 ### Model Selection
 
-- To check available models: Run the helper script:
+- To check available models, run the helper script from `<target_dir>`:
    ```
    python <skill_scripts_dir>/list_llm_models.py \
      --json
@@ -94,7 +125,7 @@ Run in order before proceeding:
 
 ### Spec Display
 
-- **Always write the current spec to `agent_spec.md`** (YAML format) whenever showing it to the user.
+- **Always write the current spec to `<target_dir>/agent_spec.md`** (YAML format) whenever showing it to the user.
 - Show the spec frequently and iteratively — even if incomplete or partial.
 - Do **not** summarize the spec in prose; display it as YAML in a code block.
 - After displaying, invite the user to refine system prompts, add/modify tools, change the model, or update examples.
@@ -122,7 +153,7 @@ Wait for their reply:
 - **If yes** — follow **[Dress Rehearsal](#dress-rehearsal)** end to end. Do not substitute improvised role-play or manual mock tool traces.
 - **If no** (or any decline such as "no", "skip", "not now") — go to **[Post-design next steps](#post-design-next-steps)**. **Do not** jump to coding, framework selection, or template setup.
 
-Script path: `python <skill_scripts_dir>/rehearsal.py ...`
+Script path: `python <skill_scripts_dir>/rehearsal.py ...` (run from `<target_dir>`; use `--spec <target_dir>/agent_spec.md` if needed)
 
 ### Post-design next steps
 
@@ -138,8 +169,8 @@ Wait for their choice. **Do not** assume a default or proceed without a reply.
 | Choice | Action |
 |--------|--------|
 | 1 or "rehearsal" / "simulate" | Follow **[Dress Rehearsal](#dress-rehearsal)** |
-| 2 or "code" / "implement" | Follow **[2. Coding an AI Agent](#2-coding-an-ai-agent)** — framework selection happens only inside the pre-coding checklist, not here |
-| 3 or "review" / "edit spec" | Display `agent_spec.md` as YAML, invite changes, update the file, then show this menu again |
+| 2 or "code" / "implement" | Follow **[2. Coding an AI Agent](#2-coding-an-ai-agent)** — read and follow [references/pre-coding-checklist.md](references/pre-coding-checklist.md) |
+| 3 or "review" / "edit spec" | Display `<target_dir>/agent_spec.md` as YAML, invite changes, update the file, then show this menu again |
 
 If the user's reply is unclear, re-display the menu and wait. Never skip straight to framework selection after a rehearsal decline.
 
@@ -163,76 +194,23 @@ Before running rehearsal, read and follow `references/dress-rehearsal.md` end to
 
 ### Before Coding Begins
 
-Verify `agent_spec.md` contains at minimum:
+Verify `<target_dir>/agent_spec.md` contains at minimum:
 
 - `model` — a valid LLM Gateway model ID
 - `system_prompt` — non-empty
 - `tools` — at least one tool defined (or explicit confirmation from the user that no tools are needed)
 - `frontend.type` — set
 
-If `agent_spec.md` does not exist, inform the user and offer to run the Design phase (option 1) first. If any required field above is missing, surface the gap and update the spec before continuing. Do not start coding against an incomplete spec.
+If `agent_spec.md` does not exist in `<target_dir>`, inform the user and offer to run the Design phase (option 1) first. If any required field above is missing, surface the gap and update the spec before continuing. Do not start coding against an incomplete spec.
 
 ### Pre-coding Checklist
 
-1. **Read `agent_spec.md`** — it must exist (see gate above).
-2. **Classify the working directory state** (default target: current working directory) using all checks below, in order:
-  a. Is it a git repository?
-  b. If git repo: does `git remote get-url origin` match `https://github.com/datarobot-community/datarobot-agent-application.git`?
-  c. Is `AGENTS.md` present?
-  d. If not a git repo: is the directory empty, or does it contain only `agent_spec.md`?
-3. **Decide action by state**:
-  - **Clean Workspace**: Empty directory, not a git repo → proceed with clone + setup.
-  - **Spec-Only Workspace**: Non-empty directory, not a git repo, contains only `agent_spec.md` → proceed with clone + setup.
-  - **Non-Template Workspace**: Non-empty directory, not a git repo, contains files other than `agent_spec.md` → **STOP** and ask user to use a new empty directory.
-  - **Existing Template Workspace**: Git repo is the correct template repo and `AGENTS.md` is present → skip clone; detect whether framework and setup were already completed, then only run missing steps.
-  - **Wrong Repository Workspace**: Git repo is not the correct template repo → **STOP** and ask user to use a new empty directory.
-4. **If Existing Template Workspace**, detect initialization markers before running any setup actions:
-  a. Framework configured marker: `.datarobot/answers/agent-agent.yml` exists and contains `agent_template_framework`.
-  b. Prior setup marker: `.env` exists.
-  c. If both markers are present and `dr dependency check` passes, treat template as already initialized: skip framework selection and `setup_template.py`, then continue to TODO creation.
-5. **If clone is required** (Clean Workspace or Spec-Only Workspace), prepare the template with these steps in order. ALWAYS follow the steps in order and do not skip any, even if they seem redundant. This is critical for ensuring the template is properly set up and avoiding wasted effort coding on a broken foundation.
-  a. **Move `agent_spec.md` aside if present** — if the file exists in the working directory, move it to a temp location (e.g. `/tmp/agent_spec.md.bak`) before cloning so it isn't overwritten. Restore it after cloning completes.
-  b. **Clone the template**: Run the helper script:
-   ```
-   python <skill_scripts_dir>/clone_template.py
-   ```
-6. **If framework is not already configured, select the agentic framework**:
-
-   **STOP. Do NOT proceed until the user has replied with their framework choice.**
-
-   Ask the user (exact message):
-   > Which agentic framework would you like to use?
-   > 1. LangGraph
-   > 2. CrewAI
-   > 3. LlamaIndex
-   > 4. NeMo Agent Toolkit (NAT)
-   > 5. Base
-
-   Wait for the user's reply. Do not assume or default to any framework. If their next message is not a framework choice (silence, unrelated text), re-display the options and wait again — do not proceed with any other coding step. Once the user replies, map their choice to the corresponding value (`langgraph`, `crewai`, `llamaindex`, `nat`, `base`) and run:
-   ```
-   python <skill_scripts_dir>/select_framework.py \
-     --target-dir . \
-     --framework <value>
-   ```
-
-7. **Validate the template**: Run `dr dependency check`. Treat any non-zero exit as a hard error — do not attempt to resolve it automatically. Return the full output to the user and stop.
-8. **If setup is not already complete, run setup**: Use the helper script. Use the `model` field from `agent_spec.md` as `--llm-model`; if absent, use the model selected during the design phase.
-   ```
-   python <skill_scripts_dir>/setup_template.py \
-     --llm-model <model-name> \
-     --target-dir .
-   ```
-
-**CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
-
-9. **Re-read `AGENTS.md`** now that the template is ready.
-10. Recreate the TODO list based on `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool.
-
+Read and follow [references/pre-coding-checklist.md](references/pre-coding-checklist.md) end to end before writing or editing implementation code.
 
 ### Coding Rules
 
 - Implement by adapting the template code — do not write from scratch
-- Modify files only inside the current directory and its subdirectories
+- Modify files only inside `<target_dir>` and its subdirectories
 - Do not view `.env` files (`.env.template` files are OK)
 - Do not add code comments unless asked
 - Do not mock tool implementations unless they would be complex to implement
@@ -246,19 +224,19 @@ If `agent_spec.md` does not exist, inform the user and offer to run the Design p
 
 ### After Coding
 
-1. Read `AGENTS.md` to find the local test command.
+1. Read `<target_dir>/AGENTS.md` to find the local test command.
 2. Display the command in a code block.
-3. Tell the user: "Run this command in a **new terminal** in the current directory to test the agent locally."
+3. Tell the user: "Run this command in a **new terminal** in `<target_dir>` to test the agent locally."
 4. Do **not** run the command yourself.
-5. Present next steps: revise the implementation, or deploy to DataRobot.
+5. Present next steps: revise the implementation, or deploy to DataRobot (follow [references/pre-deployment-checklist.md](references/pre-deployment-checklist.md)).
 
 ---
 
 ## 3. Deploying an AI Agent
 
-- Read `AGENTS.md` for deployment instructions
-- Follow the instructions **strictly**
-- Do not deviate without user confirmation
+Read and follow [references/pre-deployment-checklist.md](references/pre-deployment-checklist.md) end to end.
+
+If the user requests deploy in the same session without having coded, explain that implementation is required and offer **[2. Coding an AI Agent](#2-coding-an-ai-agent)**.
 
 ---
 
@@ -282,16 +260,13 @@ Requires env vars: `DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`
 
 Clones the DataRobot agent application template repository.
 
-Clones the template to the current directory (repository URL and branch are hardcoded):
-```bash
-python <scripts_dir>/clone_template.py
-```
-
-Clone to a specific directory:
+Clones the template to a target directory (repository URL and tag are defined in the script):
 ```bash
 python <scripts_dir>/clone_template.py \
-  --target-dir ./my-project
+  --target-dir <target_dir>
 ```
+
+The canonical template URL is the `REPO_URL` constant in this script — reference it for remote comparison; do not hardcode the URL elsewhere.
 
 ### setup_template.py
 
@@ -300,7 +275,7 @@ Sets up a template repository for initializing a new agent project.
 ```bash
 python <scripts_dir>/setup_template.py \
   --llm-model <model-name> \
-  --target-dir .
+  --target-dir <target_dir>
 ```
 
 ### select_framework.py
@@ -311,7 +286,7 @@ Saves the chosen agentic framework to `.datarobot/answers/agent-agent.yml`
 ```bash
 python <scripts_dir>/select_framework.py \
   --framework langgraph \
-  --target-dir .
+  --target-dir <target_dir>
 ```
 
 Valid `--framework` values: `langgraph`, `crewai`, `llamaindex`, `nat`, `base`
@@ -322,13 +297,14 @@ Valid `--framework` values: `langgraph`, `crewai`, `llamaindex`, `nat`, `base`
 - If a tool returns an error, read the error message carefully before responding
 - For template-prep **warnings**: try to resolve yourself
 - For template-prep **errors**: return the message to the user and ask how to proceed
+- For `dr dependency check` failures: hard stop — return full output; do not attempt to resolve automatically (see [Dependency check session rule](#dependency-check-session-rule))
 - On unexpected errors, ask the user if they want to retry
 
 ---
 
 ## agent_spec.md Schema
 
-Write specs in YAML to `agent_spec.md` in the working directory. Fields are optional when the spec is still evolving.
+Write specs in YAML to `<target_dir>/agent_spec.md`. Fields are optional when the spec is still evolving.
 
 ```yaml
 model: "anthropic/claude-sonnet-4-5-20250929"   # DataRobot LLM Gateway model ID
@@ -386,7 +362,7 @@ Claude's built-in tools replace the plugin's custom Python tools:
 | `web_search` | WebSearch |
 | `get_web_page` | WebFetch |
 | `write_todos` / `read_todos` | TodoWrite |
-| `show_agent_spec` | Write to `agent_spec.md` + display as YAML |
+| `show_agent_spec` | Write to `<target_dir>/agent_spec.md` + display as YAML |
 | `prepare_to_code` | Bash (`git clone` + `dr start`) |
 | `list_available_models` | WebFetch (DataRobot API) |
 | `code_research` | Agent (Explore subagent) |
@@ -399,8 +375,9 @@ Claude's built-in tools replace the plugin's custom Python tools:
 - If it is unclear whether the request falls into one of the three categories, ask a clarifying question
 - If the user insists on a task outside these three categories, politely decline
 - If a user asks to code before designing, strongly encourage designing first
-- Before running any CLI command or helper script, provide a clear explanation in 2-5 sentences. The explanation must include  why this specific command is needed now, what it will check/change/create.
-- After the user declines dress rehearsal, always show **[Post-design next steps](#post-design-next-steps)** — never skip to framework selection
+- If a user requests deploy without coding in the same session, offer coding — do not deploy
+- Before running any CLI command or helper script, provide a clear explanation in 2-5 sentences. The explanation must include why this specific command is needed now, what it will check/change/create.
+- After the user declines dress rehearsal, always show **[Post-design next steps](#post-design-next-steps)** — never skip to framework selection or the pre-coding checklist
 - During **rehearsal turns**: display only the `output_file` contents — never add performance commentary or replace the script's bottom decoration / DONE hint
 - During **coding**: keep responses to 1–3 sentences; no introductions or conclusions
 - During **design**: be conversational and thorough

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -175,15 +175,28 @@ If `agent_spec.md` does not exist, inform the user and offer to run the Design p
 ### Pre-coding Checklist
 
 1. **Read `agent_spec.md`** — it must exist (see gate above).
-2. Check if `AGENTS.md` exists in the template directory (default: current working directory).
-3. If `AGENTS.md` does **not** exist, prepare the template with these steps in order. ALWAYS follow the steps in order and do not skip any, even if they seem redundant. This is critical for ensuring the template is properly set up and avoiding wasted effort coding on a broken foundation.
-   a. **Check the working directory** — if it contains files other than `agent_spec.md`, warn the user and ask them to clear it before proceeding.
-   b. **Move `agent_spec.md` aside if present** — if the file exists in the working directory, move it to a temp location (e.g. `/tmp/agent_spec.md.bak`) before cloning so it isn't overwritten. Restore it after cloning completes.
-   c. **Clone the template**: Run the helper script:
+2. **Classify the working directory state** (default target: current working directory) using all checks below, in order:
+  a. Is it a git repository?
+  b. If git repo: does `git remote get-url origin` match `https://github.com/datarobot-community/datarobot-agent-application.git`?
+  c. Is `AGENTS.md` present?
+  d. If not a git repo: is the directory empty, or does it contain only `agent_spec.md`?
+3. **Decide action by state**:
+  - **Clean Workspace**: Empty directory, not a git repo → proceed with clone + setup.
+  - **Spec-Only Workspace**: Non-empty directory, not a git repo, contains only `agent_spec.md` → proceed with clone + setup.
+  - **Non-Template Workspace**: Non-empty directory, not a git repo, contains files other than `agent_spec.md` → **STOP** and ask user to use a new empty directory.
+  - **Existing Template Workspace**: Git repo is the correct template repo and `AGENTS.md` is present → skip clone; detect whether framework and setup were already completed, then only run missing steps.
+  - **Wrong Repository Workspace**: Git repo is not the correct template repo → **STOP** and ask user to use a new empty directory.
+4. **If Existing Template Workspace**, detect initialization markers before running any setup actions:
+  a. Framework configured marker: `.datarobot/answers/agent-agent.yml` exists and contains `agent_template_framework`.
+  b. Prior setup marker: `.env` exists.
+  c. If both markers are present and `dr dependency check` passes, treat template as already initialized: skip framework selection and `setup_template.py`, then continue to TODO creation.
+5. **If clone is required** (Clean Workspace or Spec-Only Workspace), prepare the template with these steps in order. ALWAYS follow the steps in order and do not skip any, even if they seem redundant. This is critical for ensuring the template is properly set up and avoiding wasted effort coding on a broken foundation.
+  a. **Move `agent_spec.md` aside if present** — if the file exists in the working directory, move it to a temp location (e.g. `/tmp/agent_spec.md.bak`) before cloning so it isn't overwritten. Restore it after cloning completes.
+  b. **Clone the template**: Run the helper script:
    ```
    python <skill_scripts_dir>/clone_template.py
    ```
-   d. **Select the agentic framework**:
+6. **If framework is not already configured, select the agentic framework**:
 
    **STOP. Do NOT proceed until the user has replied with their framework choice.**
 
@@ -202,18 +215,18 @@ If `agent_spec.md` does not exist, inform the user and offer to run the Design p
      --framework <value>
    ```
 
-   e. **Validate the template**: Run `dr dependency check`. Treat any non-zero exit as a hard error — do not attempt to resolve it automatically. Return the full output to the user and stop.
-   f. **Setup the template**: Run the helper script. Use the `model` field from `agent_spec.md` as `--llm-model`; if absent, use the model selected during the design phase.
+7. **Validate the template**: Run `dr dependency check`. Treat any non-zero exit as a hard error — do not attempt to resolve it automatically. Return the full output to the user and stop.
+8. **If setup is not already complete, run setup**: Use the helper script. Use the `model` field from `agent_spec.md` as `--llm-model`; if absent, use the model selected during the design phase.
    ```
    python <skill_scripts_dir>/setup_template.py \
      --llm-model <model-name> \
      --target-dir .
    ```
 
-   **CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
+**CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
 
-   g. **Re-read `AGENTS.md`** now that the template is ready.
-4. Recreate the TODO list based on `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool.
+9. **Re-read `AGENTS.md`** now that the template is ready.
+10. Recreate the TODO list based on `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool.
 
 
 ### Coding Rules
@@ -386,6 +399,7 @@ Claude's built-in tools replace the plugin's custom Python tools:
 - If it is unclear whether the request falls into one of the three categories, ask a clarifying question
 - If the user insists on a task outside these three categories, politely decline
 - If a user asks to code before designing, strongly encourage designing first
+- Before running any CLI command or helper script, provide a clear explanation in 2-5 sentences. The explanation must include  why this specific command is needed now, what it will check/change/create.
 - After the user declines dress rehearsal, always show **[Post-design next steps](#post-design-next-steps)** — never skip to framework selection
 - During **rehearsal turns**: display only the `output_file` contents — never add performance commentary or replace the script's bottom decoration / DONE hint
 - During **coding**: keep responses to 1–3 sentences; no introductions or conclusions

--- a/skills/datarobot-agent-assist/references/pre-coding-checklist.md
+++ b/skills/datarobot-agent-assist/references/pre-coding-checklist.md
@@ -1,0 +1,116 @@
+## Pre-coding Checklist
+
+Run this checklist when the user enters **[2. Coding an AI Agent](../SKILL.md#2-coding-an-ai-agent)** — including when offered from a failed pre-deployment check.
+
+**Same-session design → code:** `<target_dir>` is already set — skip **Bootstrap** steps 1–2 and start at **Template setup**.
+
+---
+
+### Bootstrap
+
+1. **Confirm `<target_dir>`** — the project root for this session (set in [Workspace Resolution](workspace-resolution.md)). All paths and scripts use this directory.
+
+2. **Confirm spec** — read `<target_dir>/agent_spec.md`. It must exist and meet the [Before Coding Begins](../SKILL.md#before-coding-begins) gate. If missing or incomplete, stop and resolve before continuing.
+
+---
+
+### Template setup
+
+3. **Read `REPO_URL`** from `REPO_URL` in `<skill_scripts_dir>/clone_template.py`. This is the only canonical template repository URL — use it for remote comparison and cloning.
+
+4. **Classify `<target_dir>`** (evaluate in order; first match wins):
+
+   | Classification | Conditions |
+   |----------------|------------|
+   | **Existing template** | Git repository, `origin` matches `REPO_URL`, `AGENTS.md` present |
+   | **Spec-only** | Not existing template, and directory contains only `agent_spec.md` and/or `.env` (no other files or directories) |
+   | **Everything else** | Any other state — including wrong git remote, git repo without `AGENTS.md`, or extra files/directories (e.g. `src/`, `.datarobot/`, `.gitignore`) |
+
+5. **Existing template** — notify the user the template is already present in `<target_dir>`. Then:
+
+   a. If `.datarobot/answers/agent-agent.yml` contains `agent_template_framework` → skip framework selection (step 8).
+
+   b. If `.env` exists (setup was run previously) → skip `setup_template.py` (step 9).
+
+   c. Continue to step 10 (dependency check).
+
+6. **Spec-only** — clone and set up the template in `<target_dir>`:
+
+   a. **Move `agent_spec.md` aside** if present — move to a temp location (e.g. `/tmp/agent_spec.md.bak`) before cloning so it is not overwritten. Restore it after cloning completes.
+
+   b. **Clone the template:**
+
+   ```
+   python <skill_scripts_dir>/clone_template.py \
+     --target-dir <target_dir>
+   ```
+
+   c. Continue to framework selection (step 8).
+
+7. **Everything else** — conflicting workspace. Do not clone into `<target_dir>` as-is.
+
+   a. Explain what was found in `<target_dir>`.
+
+   b. Offer to create the agent in a subdirectory (default name: `BYO-datarobot-agent`). Tell the user that `agent_spec.md` will be **moved** into that subdirectory (not copied) so there is a single project location. Ask the user to confirm or provide a different subdirectory name.
+
+   c. If the subdirectory already exists: warn that using it will **clear everything** in that subdirectory. Ask for confirmation. If the user declines, ask for a different name or return to the [welcome menu](../SKILL.md#on-activation).
+
+   d. If the user agrees:
+
+      - **Move** (do not copy) `<target_dir>/agent_spec.md` into the subdirectory if it exists in the parent. The parent must not keep a duplicate — a stale cwd spec breaks future sessions.
+      - Clear the subdirectory contents if it already exists.
+      - Set `<target_dir>` to the subdirectory (automatic update — do not ask the user to reset `<target_dir>`).
+      - Run clone (step 6b), framework selection (step 8), setup (step 9), and dependency check (step 10) in the new `<target_dir>`.
+
+   e. If the user declines: show the [welcome menu](../SKILL.md#on-activation). Do not modify `<target_dir>`.
+
+8. **Framework selection** (skip if step 5a applied):
+
+   **STOP. Do NOT proceed until the user has replied with their framework choice.**
+
+   Ask the user (exact message):
+
+   > Which agentic framework would you like to use?
+   > 1. LangGraph
+   > 2. CrewAI
+   > 3. LlamaIndex
+   > 4. NeMo Agent Toolkit (NAT)
+   > 5. Base
+
+   Wait for the user's reply. Do not assume or default to any framework. If their next message is not a framework choice (silence, unrelated text), re-display the options and wait again — do not proceed with any other coding step. Once the user replies, map their choice to the corresponding value (`langgraph`, `crewai`, `llamaindex`, `nat`, `base`) and run:
+
+   ```
+   python <skill_scripts_dir>/select_framework.py \
+     --target-dir <target_dir> \
+     --framework <value>
+   ```
+
+   Invalidate `<dependency_check_passed>` after this step.
+
+9. **Setup** (skip if step 5b applied):
+
+   ```
+   python <skill_scripts_dir>/setup_template.py \
+     --llm-model <model-name> \
+     --target-dir <target_dir>
+   ```
+
+   Use the `model` field from `agent_spec.md` as `--llm-model`; if absent, use the model selected during the design phase.
+
+   Invalidate `<dependency_check_passed>` after this step.
+
+10. **Validate dependencies** — run after setup completes:
+
+    ```
+    dr dependency check
+    ```
+
+    Run in `<target_dir>`. Follow the [Dependency check session rule](../SKILL.md#dependency-check-session-rule).
+
+    **CRITICAL**: On non-zero exit, return the full output to the user and stop. Do not attempt to resolve automatically.
+
+11. **Re-read `<target_dir>/AGENTS.md`** now that the template is ready.
+
+12. **Recreate the TODO list** based on `agent_spec.md` — break down the implementation into discrete steps and add them to the TodoWrite tool.
+
+**CRITICAL**: If any helper script fails, do **not** proceed with coding. Return the error message to the user and ask how they want to proceed.

--- a/skills/datarobot-agent-assist/references/pre-coding-checklist.md
+++ b/skills/datarobot-agent-assist/references/pre-coding-checklist.md
@@ -51,7 +51,7 @@ Run this checklist when the user enters **[2. Coding an AI Agent](../SKILL.md#2-
 
    a. Explain what was found in `<target_dir>`.
 
-   b. Offer to create the agent in a subdirectory (default name: `BYO-datarobot-agent`). Tell the user that `agent_spec.md` will be **moved** into that subdirectory (not copied) so there is a single project location. Ask the user to confirm or provide a different subdirectory name.
+   b. Offer to create the agent in a subdirectory (default name: `new-datarobot-agent`). Tell the user that `agent_spec.md` will be **moved** into that subdirectory (not copied) so there is a single project location. Ask the user to confirm or provide a different subdirectory name.
 
    c. If the subdirectory already exists: warn that using it will **clear everything** in that subdirectory. Ask for confirmation. If the user declines, ask for a different name or return to the [welcome menu](../SKILL.md#on-activation).
 

--- a/skills/datarobot-agent-assist/references/pre-deployment-checklist.md
+++ b/skills/datarobot-agent-assist/references/pre-deployment-checklist.md
@@ -1,0 +1,44 @@
+## Pre-deployment Checklist
+
+Run this checklist when the user enters **[3. Deploying an AI Agent](../SKILL.md#3-deploying-an-ai-agent)** — including after coding when the user chooses to deploy.
+
+**Prerequisite:** The agent must be coded before deployment in the same session. If the user requests deploy without having coded, explain that implementation is required and offer **[2. Coding an AI Agent](../SKILL.md#2-coding-an-ai-agent)**.
+
+**Different project:** If the user wants to deploy a different project than the one in this session, tell them to start a new session. Do not switch `<target_dir>` unless the user explicitly asks to change the project directory.
+
+---
+
+### Steps
+
+1. **Resolve `<target_dir>`:**
+
+   - If already set this session (from design or coding) → reuse it. Briefly confirm: *"Deploying from `<target_dir>`."*
+   - If unset (typically a deploy-only session) → ask:
+
+     > Which project directory contains your implemented agent (the directory with `AGENTS.md`)?
+
+     Set `<target_dir>` to the user's answer. Do not scan subdirectories automatically.
+
+2. **Read `REPO_URL`** from `REPO_URL` in `<skill_scripts_dir>/clone_template.py`.
+
+3. **Verify implementation** in `<target_dir>`:
+
+   | Check | On failure |
+   |-------|------------|
+   | `AGENTS.md` exists | Agent is not implemented. Offer **[2. Coding an AI Agent](../SKILL.md#2-coding-an-ai-agent)** on this `<target_dir>` and run the [Pre-coding Checklist](pre-coding-checklist.md). |
+   | Git repository with `origin` matching `REPO_URL` | Template is not initialized. Offer coding on this `<target_dir>` (same as above). |
+   | User declines coding | Show the [welcome menu](../SKILL.md#on-activation). Stop. |
+
+   Do **not** check for `agent_spec.md` — it is not required for deployment.
+
+4. **Validate dependencies:**
+
+   ```
+   dr dependency check
+   ```
+
+   Run in `<target_dir>`. Follow the [Dependency check session rule](../SKILL.md#dependency-check-session-rule).
+
+   On non-zero exit: return the full output to the user and stop. Do not attempt to resolve automatically.
+
+5. **Deploy** — read `<target_dir>/AGENTS.md` and follow deployment instructions **strictly**. Do not deviate without user confirmation.

--- a/skills/datarobot-agent-assist/references/workspace-resolution.md
+++ b/skills/datarobot-agent-assist/references/workspace-resolution.md
@@ -1,0 +1,79 @@
+## Workspace Resolution
+
+Run after menu options **1** (Design) or **2** (Code). Sets `<target_dir>` for the session.
+
+**Default subdirectory name:** `BYO-datarobot-agent`
+
+**After resolution:** all design/code work uses `<target_dir>` — specs at `<target_dir>/agent_spec.md`, helper scripts with `--target-dir <target_dir>`, and `list_llm_models.py` / `rehearsal.py` run from `<target_dir>`.
+
+---
+
+### Decision summary
+
+| Menu | `./agent_spec.md` in cwd? | Action |
+|------|---------------------------|--------|
+| **Design** | Yes | Set `<target_dir>` = cwd. Ask: continue this spec, or new agent in a subdirectory? |
+| **Design** | No | Ask: subdirectory (recommended) or current directory → set `<target_dir>` |
+| **Code** | Yes | See [Code — spec found in cwd](#code--spec-found-in-cwd) (may redirect to subdirectory) |
+| **Code** | No | Ask for project directory path → set `<target_dir>`. No subdir scanning. |
+
+Option **3** (Deploy) skips this document — see [pre-deployment-checklist.md](pre-deployment-checklist.md).
+
+---
+
+### Design — spec found in cwd
+
+1. Set `<target_dir>` to cwd.
+2. Notify: *"Continuing work on `./agent_spec.md` in `<target_dir>`."*
+3. Ask:
+
+   > Continue editing this spec, or start a new agent in a subdirectory?
+
+   - **Continue editing** → Design in `<target_dir>`.
+   - **New agent** → create/use subdirectory (default `BYO-datarobot-agent`), set `<target_dir>`, Design there.
+
+### Design — no spec in cwd
+
+Ask:
+
+> Where would you like to design your agent?
+> 1. **Subdirectory** (recommended) — e.g. `./BYO-datarobot-agent`
+> 2. **Current directory**
+
+**Subdirectory chosen:**
+
+- Exists with `agent_spec.md` → notify, set `<target_dir>`, continue editing.
+- Exists without `agent_spec.md` → set `<target_dir>`, continue Design.
+- Does not exist → create it, set `<target_dir>`, continue Design.
+
+**Current directory chosen:**
+
+- Set `<target_dir>` = cwd.
+- If files other than `agent_spec.md` / `.env` are present, warn:
+
+  > Other files are present. Design can continue here, but coding will require a clean workspace — likely a subdirectory. Files in this directory may be ignored for implementation.
+
+- Continue Design in `<target_dir>`.
+
+### Code — spec found in cwd
+
+1. **Detect active project location** — the spec file alone does not always mean cwd is the project root:
+
+   - If cwd is an **existing template** (git repo, `AGENTS.md` present) → set `<target_dir>` = cwd.
+   - Else if cwd contains only `agent_spec.md` and/or `.env` → set `<target_dir>` = cwd.
+   - Else if cwd has other files (conflicting workspace) **and** `./BYO-datarobot-agent/AGENTS.md` exists → set `<target_dir>` = `./BYO-datarobot-agent`. Notify:
+
+     > Found an implemented agent in `./BYO-datarobot-agent`. Continuing there. If `./agent_spec.md` also exists in the current directory, it may be outdated — use `<target_dir>/agent_spec.md`.
+
+   - Else → set `<target_dir>` = cwd (pre-coding will handle conflicting workspace).
+
+2. Notify: *"Continuing work on `agent_spec.md` in `<target_dir>`."*
+3. Proceed to coding.
+
+### Code — no spec in cwd
+
+Ask:
+
+> Which project directory contains your `agent_spec.md`?
+
+Set `<target_dir>` to the user's answer. Do not scan subdirectories automatically.

--- a/skills/datarobot-agent-assist/references/workspace-resolution.md
+++ b/skills/datarobot-agent-assist/references/workspace-resolution.md
@@ -2,7 +2,7 @@
 
 Run after menu options **1** (Design) or **2** (Code). Sets `<target_dir>` for the session.
 
-**Default subdirectory name:** `BYO-datarobot-agent`
+**Default subdirectory name:** `new-datarobot-agent`
 
 **After resolution:** all design/code work uses `<target_dir>` — specs at `<target_dir>/agent_spec.md`, helper scripts with `--target-dir <target_dir>`, and `list_llm_models.py` / `rehearsal.py` run from `<target_dir>`.
 
@@ -30,14 +30,14 @@ Option **3** (Deploy) skips this document — see [pre-deployment-checklist.md](
    > Continue editing this spec, or start a new agent in a subdirectory?
 
    - **Continue editing** → Design in `<target_dir>`.
-   - **New agent** → create/use subdirectory (default `BYO-datarobot-agent`), set `<target_dir>`, Design there.
+   - **New agent** → create/use subdirectory (default `new-datarobot-agent`), set `<target_dir>`, Design there.
 
 ### Design — no spec in cwd
 
 Ask:
 
 > Where would you like to design your agent?
-> 1. **Subdirectory** (recommended) — e.g. `./BYO-datarobot-agent`
+> 1. **Subdirectory** (recommended) — e.g. `./new-datarobot-agent`
 > 2. **Current directory**
 
 **Subdirectory chosen:**
@@ -61,9 +61,9 @@ Ask:
 
    - If cwd is an **existing template** (git repo, `AGENTS.md` present) → set `<target_dir>` = cwd.
    - Else if cwd contains only `agent_spec.md` and/or `.env` → set `<target_dir>` = cwd.
-   - Else if cwd has other files (conflicting workspace) **and** `./BYO-datarobot-agent/AGENTS.md` exists → set `<target_dir>` = `./BYO-datarobot-agent`. Notify:
+   - Else if cwd has other files (conflicting workspace) **and** `./new-datarobot-agent/AGENTS.md` exists → set `<target_dir>` = `./new-datarobot-agent`. Notify:
 
-     > Found an implemented agent in `./BYO-datarobot-agent`. Continuing there. If `./agent_spec.md` also exists in the current directory, it may be outdated — use `<target_dir>/agent_spec.md`.
+     > Found an implemented agent in `./new-datarobot-agent`. Continuing there. If `./agent_spec.md` also exists in the current directory, it may be outdated — use `<target_dir>/agent_spec.md`.
 
    - Else → set `<target_dir>` = cwd (pre-coding will handle conflicting workspace).
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Implement the following flows in the datarobot-agent-assist:
- pre-coding-checklist
- pre-deployment-checklist
- workspace-resolution

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill instructions; no runtime code or deployment behavior is modified.
> 
> **Overview**
> Refactors the **Coding** phase **Pre-coding Checklist** so agents classify the working directory before cloning or setup, instead of only checking for `AGENTS.md`.
> 
> The checklist now runs ordered checks (git repo, correct `origin` URL, `AGENTS.md`, empty vs spec-only vs other files) and maps them to five workspace types—**Clean**, **Spec-Only**, **Non-Template** (stop), **Existing Template** (skip clone), and **Wrong Repository** (stop). For an existing template repo, it uses markers (`.datarobot/answers/agent-agent.yml` with `agent_template_framework`, `.env`, passing `dr dependency check`) to skip framework selection and `setup_template.py` when already initialized.
> 
> Clone, framework prompt, `dr dependency check`, and setup are renumbered and gated so they run only when required. A new **Behavioral Rule** requires a 2–5 sentence rationale before any CLI command or helper script (why now, what it changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2290de6a1ed48e7e555d3d93983d739298c36ff6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->