### PR TITLE
Add datarobot-agent-skill-assessment skill for automated skill testing and improvement [MODEL-23986]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.4"
+      "version": "1.4.4"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.4"
+  "version": "1.4.4"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.4",
+  "version": "1.4.4",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
-## [1.3.4] - 2028-07-01
+## [1.4.4] - 2026-07-07
+
+- `datarobot-agent-skill-assessment`: Added skill to allow to assess and improve any skill using the `datarobot-agent-tester` open source DataRobot LLM as a judge. It does require a `DATAROBOT_API_TOKEN`. Use when you want to get a specific skill reviewed and improved in your own repo, fork or before creating a PR to contribute to this repo.
+
+## [1.3.4] - 2026-07-01
 
 - `datarobot-agent-assist`: Improved rehearsal flow to properly handle missing LLM model cases and improved user-facing messaging; refactored Dress Rehearsal instructions into separate `references/dress-rehearsal.md` file to reduce SKILL.md token count while preserving all behavior and control-flow reliability.
 - `datarobot-discover`: New skill for discovering DataRobot resources — fetches the live catalog from `datarobot.com` and, if set, from `$DATAROBOT_ENDPOINT` to surface skills, MCP servers, agents, and platform resources without search index dependency.

--- a/docs/.well-known/ai-catalog.json
+++ b/docs/.well-known/ai-catalog.json
@@ -160,6 +160,18 @@
         "scale or debug a DataRobot workload",
         "manage autoscaling and replicas for a DataRobot workload"
       ]
+    },
+    {
+      "identifier": "urn:air:github.com:datarobot-oss:datarobot-agent-skills:skill-assessment",
+      "displayName": "datarobot-agent-skill-assessment",
+      "type": "application/ai-skill",
+      "url": "https://github.com/datarobot-oss/datarobot-agent-skills/blob/main/skills/datarobot-agent-skill-assessment/SKILL.md",
+      "description": "Evaluate and improve a skill using datarobot-agent-tester in a local skill. It requires DATAROBOT_API_TOKEN.",
+      "representativeQueries": [
+        "Assess and improve a skill using datarobot skills",
+        "evalute a skill using datarobot skills",
+        "improve a skill using datarobot skills"
+      ]
     }
   ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -68,6 +68,11 @@
       "name": "datarobot-discover",
       "description": "Discover DataRobot resources — skills, MCP servers, agents, and platform tools — by fetching the live catalog from datarobot.com and the user's own DataRobot instance",
       "path": "skills/datarobot-discover/SKILL.md"
+    },
+    {
+      "name": "datarobot-agent-skill-assessment",
+      "description": "Evaluate, assess and improve a skill using datarobot. It requires DATAROBOT_API_TOKEN.",
+      "path": "skills/datarobot-agent-skill-assessment/SKILL.md"
     }
   ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.4",
+  "version": "1.4.4",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/skills/datarobot-agent-skill-assessment/SKILL.md
+++ b/skills/datarobot-agent-skill-assessment/SKILL.md
@@ -30,11 +30,29 @@ This skill requires a valid `DATAROBOT_API_TOKEN`.
 
 ---
 
+## Example Usage
+
+**Basic test:**
+```
+User: "Test the my-skill skill"
+→ skill_dir="my-skill", improve=false
+```
+
+**Test and improve:**
+```
+User: "Assess and improve skills/data-processor"
+→ skill_dir="skills/data-processor", improve=true, retest_after_improve=true
+```
+
+---
+
 ## Preconditions
 
 1. Repository contains the target skill directory.
 2. `DATAROBOT_API_TOKEN` is set in environment (or `.env` used by the tester runtime).
 3. `datarobot-agent-tester` is installed and `dr-agent` CLI is available (or can be installed with user permission via `uv`).
+4. Commands should be executed from the repository root directory (parent of `skills/`).
+   If current directory is not repository root, `cd` to it first.
 
 If any precondition fails, stop and return a clear error with remediation steps.
 
@@ -47,6 +65,16 @@ If any precondition fails, stop and return a clear error with remediation steps.
 - If input is `my-skill`, normalize to `skills/my-skill`.
 - If input already starts with `skills/`, keep as-is.
 - Verify directory exists.
+
+If directory does not exist:
+- Return Status: `NEEDS WORK`
+- Error: `Skill directory not found: ${TARGET_SKILL_DIR}`
+- List available skills:
+  ```bash
+  ls -d skills/*/
+  ```
+- Suggest user check spelling or provide correct path
+- Stop execution
 
 Set:
 - `TARGET_SKILL_DIR=<normalized path>`
@@ -79,6 +107,18 @@ If success, continue to Step 5.
 If failure, continue to Step 4.
 
 ### 4) Install datarobot-agent-tester
+
+First verify `uv` is available:
+```bash
+uv --version >/dev/null
+```
+
+If not found:
+- Return Status: `NEEDS WORK`
+- Error: `uv package manager not found`
+- Remediation: Install from https://github.com/astral-sh/uv
+- Stop execution
+
 When `dr-agent --help` fails, the assistant must stop and ask the user to choose:
 
 `datarobot-agent-tester` is not currently available (`dr-agent` not found).
@@ -115,6 +155,17 @@ dr-agent --help >/dev/null
 ```
 If still failing, return `NEEDS WORK` with command output.
 
+### 4.5) Set reasonable timeouts
+
+Testing may take time for complex skills. Set timeouts:
+- Test command: 5 minutes
+- Improve command: 10 minutes
+
+If timeout exceeded:
+- Kill process
+- Return partial results with timeout note
+- Status: `NEEDS WORK`
+
 ### 5) Run skill test
 
 Run exactly:
@@ -125,21 +176,62 @@ dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 
 Capture stdout/stderr and exit code.
 
+If exit code is non-zero:
+- Set Status to `NEEDS WORK`
+- Include full stderr in output
+- Check if report was still generated (some testers write partial reports on failure)
+- Continue to Step 6 to attempt report retrieval
+
 ### 6) Locate generated report
 
-The tester writes a skill report file named with suffix `.skill-report.md`.
-Find report(s) associated with `TARGET_SKILL_DIR` and identify the newest one.
+The tester writes reports to the current working directory with pattern:
+`<skill-name>.skill-report.md` or timestamped variants.
 
-If report cannot be found:
-- Return command output and fail clearly.
+Search for reports:
+```bash
+find . -maxdepth 2 -name "*skill-report.md" -type f
+```
+
+Identify the newest file by modification time:
+```bash
+ls -t *skill-report.md | head -n1
+```
+
+If no report found, check:
+- Command output for error messages
+- Whether test actually ran successfully (exit code 0)
+
+Store path as `REPORT_FILE`.
+
+Parse the report to extract:
+- Overall test result (pass/fail)
+- Number of test cases run
+- List of failing test cases (if any)
+- Key recommendations or issues
+
+Store these for the Summary section.
 
 ### 7) Optional improve flow
 
-If `improve=true`, run:
+If `improve=true`:
 
+**Note**: The `improve` command will modify skill files in-place based on test findings.
+
+Before running, inform the user:
+"About to run improvement on ${TARGET_SKILL_DIR}. This will modify files. Continue? (yes/no)"
+
+If user declines, skip to output and note improvement was skipped.
+
+Before running improve:
+- Store path to initial report as `INITIAL_REPORT`
+- Note initial test results (pass/fail counts, scores if present)
+
+Run:
 ```bash
 dr-agent skills improve --skill "${TARGET_SKILL_DIR}"
 ```
+
+Capture exit code. If non-zero, include error in output but continue to retest if requested.
 
 If `retest_after_improve=true`, run:
 
@@ -147,7 +239,13 @@ If `retest_after_improve=true`, run:
 dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 ```
 
-Then locate newest report again and compare with pre-improvement report.
+After retest:
+- Store path to new report as `IMPROVED_REPORT`
+- Compare:
+  - Number of passing vs failing test cases
+  - Specific issues resolved (diff the "Issues" sections)
+  - New issues introduced
+  - Overall score changes (if reports include numeric scores)
 
 ---
 
@@ -156,7 +254,13 @@ Then locate newest report again and compare with pre-improvement report.
 Return all of the following sections:
 
 1. **Status**
-   - `PASS` or `NEEDS WORK`
+   - `PASS`: Test completed successfully, report generated, no critical errors
+   - `NEEDS WORK`: Test failed, CLI unavailable, preconditions not met, or critical issues found in report
+   
+   Base status on:
+   - Whether all commands executed successfully
+   - Whether report was generated
+   - Severity of issues in report (if it includes severity ratings)
 
 2. **Install Mode**
    - `already-installed` | `uv-add` | `uv-tool-install` | `not-installed (user-declined)`

--- a/skills/datarobot-agent-skill-assessment/SKILL.md
+++ b/skills/datarobot-agent-skill-assessment/SKILL.md
@@ -159,8 +159,8 @@ When `dr-agent --help` fails, the assistant must stop and ask the user to choose
 Would you like me to install it using uv now?
 
 Choose one option:
-1) Project-only install (adds dependency to this repository):
-   `uv add datarobot-agent-tester`
+1) Project dependency group (adds to skill-assessment group in this repository):
+   `uv add --group skill-assessment datarobot-agent-tester`
 
 2) Global tool install (available system-wide):
    `uv tool install datarobot-agent-tester`
@@ -174,7 +174,7 @@ Rules:
 - Do not run any install command before the user explicitly chooses.
 - If user replies `"1"`, run:
   ```bash
-  uv add datarobot-agent-tester
+  uv add --group skill-assessment datarobot-agent-tester
   ```
 - If user replies `"2"`, run:
   ```bash
@@ -182,10 +182,10 @@ Rules:
   ```
 - If user replies `"no"`, stop and return `NEEDS WORK` with remediation steps.
 
-After install, re-check:
-```bash
-dr-agent --help >/dev/null
-```
+After install, re-check based on install method:
+- If installed with dependency group: `uv run --group skill-assessment dr-agent --help >/dev/null`
+- If installed as global tool: `dr-agent --help >/dev/null`
+
 If still failing, return `NEEDS WORK` with command output.
 
 ### 4.5) Set command timeouts
@@ -194,8 +194,13 @@ Use `timeout` command (GNU coreutils) to enforce limits:
 - Test command: 300 seconds (5 minutes)
 - Improve command: 600 seconds (10 minutes)
 
-Example:
+Example (adjust command based on installation method):
 ```bash
+# For dependency group installation:
+timeout 300 uv run --group skill-assessment dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+EXIT_CODE=$?
+
+# For global tool installation:
 timeout 300 dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 EXIT_CODE=$?
 ```
@@ -212,8 +217,14 @@ If `timeout` command not available (e.g., macOS without GNU coreutils):
 
 ### 5) Run skill test
 
-Run exactly:
+Run based on installation method:
 
+If installed with dependency group:
+```bash
+uv run --group skill-assessment dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+```
+
+If installed as global tool or already installed:
 ```bash
 dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 ```
@@ -288,15 +299,28 @@ Before running improve:
 - Store path to initial report as `INITIAL_REPORT`
 - Note initial test results (pass/fail counts, scores if present)
 
-Run:
+Run based on installation method:
+
+If installed with dependency group:
+```bash
+uv run --group skill-assessment dr-agent skills improve --skill "${TARGET_SKILL_DIR}"
+```
+
+If installed as global tool or already installed:
 ```bash
 dr-agent skills improve --skill "${TARGET_SKILL_DIR}"
 ```
 
 Capture exit code. If non-zero, include error in output but continue to retest if requested.
 
-If `retest_after_improve=true`, run:
+If `retest_after_improve=true`, run based on installation method:
 
+If installed with dependency group:
+```bash
+uv run --group skill-assessment dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+```
+
+If installed as global tool or already installed:
 ```bash
 dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 ```
@@ -360,7 +384,7 @@ Return all of the following sections:
    When in doubt (e.g., test passed but report shows warnings), default to `PASS` and include warnings in Summary.
 
 2. **Install Mode**
-   - `already-installed` | `uv-add` | `uv-tool-install` | `not-installed (user-declined)`
+   - `already-installed` | `uv-add-group-skill-assessment` | `uv-tool-install` | `not-installed (user-declined)`
 
 3. **Commands Run**
    - Exact commands executed, in order
@@ -415,6 +439,7 @@ High-priority fixes:
 ## Troubleshooting
 
 **"Command not found: dr-agent" after installation**
+- If installed with dependency group: use `uv run --group skill-assessment dr-agent --help`
 - If installed with `uv tool install`, ensure `~/.local/bin` is in PATH
 - Try: `uv tool run dr-agent --help`
 

--- a/skills/datarobot-agent-skill-assessment/SKILL.md
+++ b/skills/datarobot-agent-skill-assessment/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: datarobot-agent-skill-assessment
+description: >-
+  Use when the user wants to assess and optionally improve a target skill directory using datarobot-agent-tester. 
+  When datarobot-agent-tester is not installed, it installs via uv the datarobot-agent-tester 
+  and calls an LLM ad judge to assess an skill via the installed dr-agent CLI. It requires DATAROBOT_API_TOKEN.
+---
+
+# Purpose
+
+Given a target skill directory, run DataRobot Agent Tester to:
+1. test the skill and produce a report
+2. optionally improve the skill based on that report
+3. optionally re-test and summarize before/after results
+
+This skill requires a valid `DATAROBOT_API_TOKEN`.
+
+---
+
+## Inputs
+
+- `skill_dir` (required): Path to the target skill directory under `skills/`.
+  - Examples:
+    - `my-skill`
+    - `skills/my-skill`
+- `improve` (optional, default: `false`): Whether to run improvement after testing.
+  - Allowed: `true` / `false`
+- `retest_after_improve` (optional, default: `true`): If `improve=true`, run test again and summarize deltas.
+  - Allowed: `true` / `false`
+
+---
+
+## Preconditions
+
+1. Repository contains the target skill directory.
+2. `DATAROBOT_API_TOKEN` is set in environment (or `.env` used by the tester runtime).
+3. `datarobot-agent-tester` is installed and `dr-agent` CLI is available (or can be installed with user permission via `uv`).
+
+If any precondition fails, stop and return a clear error with remediation steps.
+
+---
+
+## Execution Steps
+
+### 1) Normalize target path
+
+- If input is `my-skill`, normalize to `skills/my-skill`.
+- If input already starts with `skills/`, keep as-is.
+- Verify directory exists.
+
+Set:
+- `TARGET_SKILL_DIR=<normalized path>`
+
+### 2) Validate token
+
+Run:
+
+```bash
+printenv DATAROBOT_API_TOKEN >/dev/null
+```
+
+If token missing, return:
+
+- Error: `DATAROBOT_API_TOKEN is not set`
+- Fix:
+  - `export DATAROBOT_API_TOKEN=<your_token>`
+  - or configure `.env` per project conventions
+
+### 3) Check CLI availability
+
+Run:
+
+```bash
+dr-agent --help >/dev/null
+```
+
+If success, continue to Step 5.
+
+If failure, continue to Step 4.
+
+### 4) Install datarobot-agent-tester
+When `dr-agent --help` fails, the assistant must stop and ask the user to choose:
+
+`datarobot-agent-tester` is not currently available (`dr-agent` not found).
+
+Would you like me to install it using uv now?
+
+Choose one option:
+1) Project-only install (adds dependency to this repository):
+   `uv add datarobot-agent-tester`
+
+2) Global tool install (available system-wide):
+   `uv tool install datarobot-agent-tester`
+
+Reply with:
+- `"1"` for project-only
+- `"2"` for global
+- `"no"` to skip installation
+
+Rules:
+- Do not run any install command before the user explicitly chooses.
+- If user replies `"1"`, run:
+  ```bash
+  uv add datarobot-agent-tester
+  ```
+- If user replies `"2"`, run:
+  ```bash
+  uv tool install datarobot-agent-tester
+  ```
+- If user replies `"no"`, stop and return `NEEDS WORK` with remediation steps.
+
+After install, re-check:
+```bash
+dr-agent --help >/dev/null
+```
+If still failing, return `NEEDS WORK` with command output.
+
+### 5) Run skill test
+
+Run exactly:
+
+```bash
+dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+```
+
+Capture stdout/stderr and exit code.
+
+### 6) Locate generated report
+
+The tester writes a skill report file named with suffix `.skill-report.md`.
+Find report(s) associated with `TARGET_SKILL_DIR` and identify the newest one.
+
+If report cannot be found:
+- Return command output and fail clearly.
+
+### 7) Optional improve flow
+
+If `improve=true`, run:
+
+```bash
+dr-agent skills improve --skill "${TARGET_SKILL_DIR}"
+```
+
+If `retest_after_improve=true`, run:
+
+```bash
+dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+```
+
+Then locate newest report again and compare with pre-improvement report.
+
+---
+
+## Output Contract
+
+Return all of the following sections:
+
+1. **Status**
+   - `PASS` or `NEEDS WORK`
+
+2. **Install Mode**
+   - `already-installed` | `uv-add` | `uv-tool-install` | `not-installed (user-declined)`
+
+3. **Commands Run**
+   - Exact commands executed, in order
+
+4. **Artifacts**
+   - Report file path(s)
+   - Improvement command result (if run)
+
+5. **Summary**
+   - overall assessment
+   - major issues
+   - high-priority fixes
+
+6. **Before/After Comparison** (only when improve+retest used)
+   - What changed
+   - What improved
+   - Remaining gaps
+
+---
+
+## Guardrails
+
+- Only act on the provided target skill directory.
+- Do not modify unrelated files.
+- Do not fabricate report contents.
+- Keep outputs concise and actionable.
+- Never install without explicit user confirmation.

--- a/skills/datarobot-agent-skill-assessment/SKILL.md
+++ b/skills/datarobot-agent-skill-assessment/SKILL.md
@@ -53,6 +53,14 @@ User: "Assess and improve skills/data-processor"
 3. `datarobot-agent-tester` is installed and `dr-agent` CLI is available (or can be installed with user permission via `uv`).
 4. Commands should be executed from the repository root directory (parent of `skills/`).
    If current directory is not repository root, `cd` to it first.
+5. Target skill directory must contain at minimum:
+   - A markdown file (`.md`) with skill instructions
+   - OR a `skill.yaml` / `skill.json` configuration file
+   
+   If directory exists but contains no recognizable skill files:
+   - Status: `NEEDS WORK`
+   - Error: `Directory exists but does not appear to contain a valid skill`
+   - List directory contents for debugging
 
 If any precondition fails, stop and return a clear error with remediation steps.
 
@@ -60,7 +68,32 @@ If any precondition fails, stop and return a clear error with remediation steps.
 
 ## Execution Steps
 
-### 1) Normalize target path
+### 1) Verify and set working directory
+
+Check if current directory is repository root:
+```bash
+if [ -d "skills" ]; then
+  echo "Already in repository root"
+else
+  # Attempt to find repository root
+  if [ -d "../skills" ]; then
+    cd ..
+  elif [ -d "../../skills" ]; then
+    cd ../..
+  else
+    # Return error
+    echo "Cannot locate repository root (no skills/ directory found)"
+    exit 1
+  fi
+fi
+```
+
+If `skills/` directory not found after navigation:
+- Status: `NEEDS WORK`
+- Error: `Cannot locate repository root. Please run from a directory containing skills/`
+- Stop execution
+
+### 1.1) Normalize target path
 
 - If input is `my-skill`, normalize to `skills/my-skill`.
 - If input already starts with `skills/`, keep as-is.
@@ -155,16 +188,27 @@ dr-agent --help >/dev/null
 ```
 If still failing, return `NEEDS WORK` with command output.
 
-### 4.5) Set reasonable timeouts
+### 4.5) Set command timeouts
 
-Testing may take time for complex skills. Set timeouts:
-- Test command: 5 minutes
-- Improve command: 10 minutes
+Use `timeout` command (GNU coreutils) to enforce limits:
+- Test command: 300 seconds (5 minutes)
+- Improve command: 600 seconds (10 minutes)
 
-If timeout exceeded:
-- Kill process
-- Return partial results with timeout note
+Example:
+```bash
+timeout 300 dr-agent skills test --skill "${TARGET_SKILL_DIR}"
+EXIT_CODE=$?
+```
+
+If exit code is 124 (timeout):
 - Status: `NEEDS WORK`
+- Error: `Command exceeded timeout limit`
+- Include partial output if available
+- Stop execution
+
+If `timeout` command not available (e.g., macOS without GNU coreutils):
+- Log warning: "Timeout enforcement unavailable, commands may run indefinitely"
+- Continue without timeout
 
 ### 5) Run skill test
 
@@ -184,17 +228,19 @@ If exit code is non-zero:
 
 ### 6) Locate generated report
 
-The tester writes reports to the current working directory with pattern:
-`<skill-name>.skill-report.md` or timestamped variants.
-
-Search for reports:
+Extract skill name from `TARGET_SKILL_DIR`:
 ```bash
-find . -maxdepth 2 -name "*skill-report.md" -type f
+SKILL_NAME=$(basename "${TARGET_SKILL_DIR}")
 ```
 
-Identify the newest file by modification time:
+Search for reports matching this skill:
 ```bash
-ls -t *skill-report.md | head -n1
+find . -maxdepth 2 -name "${SKILL_NAME}*.skill-report.md" -o -name "*${SKILL_NAME}*skill-report.md" | head -n1
+```
+
+If multiple matches found, select newest by modification time:
+```bash
+ls -t ${SKILL_NAME}*.skill-report.md 2>/dev/null | head -n1
 ```
 
 If no report found, check:
@@ -203,13 +249,19 @@ If no report found, check:
 
 Store path as `REPORT_FILE`.
 
-Parse the report to extract:
-- Overall test result (pass/fail)
-- Number of test cases run
-- List of failing test cases (if any)
-- Key recommendations or issues
+Parse the report using these strategies:
+- Look for markdown headers like `## Summary`, `## Test Results`, `## Issues`
+- Extract pass/fail counts from lines matching patterns like:
+  - `Passed: X/Y tests`
+  - `✓ X passed, ✗ Y failed`
+- Identify failing tests from bullet lists or tables under "Failed Tests" or "Issues" sections
+- If report format is unclear, include the first 50 lines of the report in output for user review
 
-Store these for the Summary section.
+Store extracted data as:
+- `TOTAL_TESTS=<number>`
+- `PASSED_TESTS=<number>`
+- `FAILED_TESTS=<number>`
+- `FAILING_TEST_NAMES=<list>`
 
 ### 7) Optional improve flow
 
@@ -217,10 +269,20 @@ If `improve=true`:
 
 **Note**: The `improve` command will modify skill files in-place based on test findings.
 
-Before running, inform the user:
-"About to run improvement on ${TARGET_SKILL_DIR}. This will modify files. Continue? (yes/no)"
+Before running improve:
+- Inform user: "About to run improvement on ${TARGET_SKILL_DIR}. This will modify files in-place. Continue?"
+- Wait for explicit response
 
-If user declines, skip to output and note improvement was skipped.
+If user responds with "no", "n", "skip", or declines:
+- Skip improvement step
+- Jump to Output Contract
+- In Summary section, note: "Improvement skipped by user request"
+
+If user responds with "yes", "y", or confirms:
+- Proceed with improve command
+
+If response is unclear:
+- Ask again: "Please respond 'yes' to continue or 'no' to skip improvement"
 
 Before running improve:
 - Store path to initial report as `INITIAL_REPORT`
@@ -241,11 +303,34 @@ dr-agent skills test --skill "${TARGET_SKILL_DIR}"
 
 After retest:
 - Store path to new report as `IMPROVED_REPORT`
-- Compare:
-  - Number of passing vs failing test cases
-  - Specific issues resolved (diff the "Issues" sections)
-  - New issues introduced
-  - Overall score changes (if reports include numeric scores)
+
+Generate Before/After comparison:
+
+1. **Test counts comparison:**
+   ```
+   Before: X passed, Y failed (Z total)
+   After:  A passed, B failed (C total)
+   Delta:  +/- N passing
+   ```
+
+2. **Issue-level diff:**
+   - Extract issue lists from both reports (look for bullet points under "Issues" or "Failures")
+   - Identify resolved issues (present in INITIAL_REPORT but not IMPROVED_REPORT)
+   - Identify new issues (present in IMPROVED_REPORT but not INITIAL_REPORT)
+   - Identify persistent issues (present in both)
+
+3. **File changes:**
+   ```bash
+   git diff --stat "${TARGET_SKILL_DIR}" 2>/dev/null || echo "Git not available for diff"
+   ```
+
+If retest shows degradation (more failures after improve):
+- Highlight this prominently in Summary: "⚠️ Improvement resulted in MORE failing tests"
+- List newly introduced failures
+- Suggest: "Consider reverting changes and reviewing improve command output for errors"
+- Status should be `NEEDS WORK`
+
+Include all three sections in "Before/After Comparison" output.
 
 ---
 
@@ -257,10 +342,22 @@ Return all of the following sections:
    - `PASS`: Test completed successfully, report generated, no critical errors
    - `NEEDS WORK`: Test failed, CLI unavailable, preconditions not met, or critical issues found in report
    
-   Base status on:
-   - Whether all commands executed successfully
-   - Whether report was generated
-   - Severity of issues in report (if it includes severity ratings)
+   **Status determination logic:**
+
+   Set `NEEDS WORK` if ANY of:
+   - Target skill directory not found
+   - DATAROBOT_API_TOKEN not set
+   - CLI installation failed or was declined
+   - Test command exited with non-zero code AND no report generated
+   - Report contains issues marked "critical" or "high severity" (if severity ratings present)
+   - Command timeout occurred
+
+   Set `PASS` if ALL of:
+   - All commands executed successfully (exit code 0)
+   - Report was generated
+   - No critical/high-severity issues (or report doesn't include severity ratings)
+
+   When in doubt (e.g., test passed but report shows warnings), default to `PASS` and include warnings in Summary.
 
 2. **Install Mode**
    - `already-installed` | `uv-add` | `uv-tool-install` | `not-installed (user-declined)`
@@ -281,6 +378,58 @@ Return all of the following sections:
    - What changed
    - What improved
    - Remaining gaps
+
+---
+
+## Example Output
+
+**Scenario: Test-only run with issues found**
+
+```
+**Status**: NEEDS WORK
+
+**Install Mode**: already-installed
+
+**Commands Run**:
+1. `dr-agent skills test --skill "skills/my-skill"`
+
+**Artifacts**:
+- Report: `./my-skill.skill-report.md`
+
+**Summary**:
+Test completed but found 3 failing test cases:
+- `test_input_validation`: Missing required field validation
+- `test_error_handling`: Unhandled exception for null inputs
+- `test_output_format`: Output missing 'timestamp' field
+
+High-priority fixes:
+1. Add input validation for required fields (line 45)
+2. Wrap processing logic in try-catch (line 78)
+3. Include timestamp in output schema (line 120)
+
+**Before/After Comparison**: N/A (improve not run)
+```
+
+---
+
+## Troubleshooting
+
+**"Command not found: dr-agent" after installation**
+- If installed with `uv tool install`, ensure `~/.local/bin` is in PATH
+- Try: `uv tool run dr-agent --help`
+
+**"Report not found" after successful test**
+- Check current directory: `pwd`
+- List all .md files: `find . -name "*.md"`
+- Report may have unexpected name; include find output in error message
+
+**Timeout on large skills**
+- Increase timeout values in Step 4.5
+- Or run test command manually without timeout to see full execution time
+
+**Token authentication fails**
+- Verify token format (should be alphanumeric string)
+- Test token: `curl -H "Authorization: Bearer $DATAROBOT_API_TOKEN" <api-endpoint>`
 
 ---
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Introduces a new skill `datarobot-agent-skill-assessment` that enables automated testing and improvement of DataRobot agent skills using the datarobot-agent-tester tool.

## What's New
- **New Skill**: `datarobot-agent-skill-assessment` provides a comprehensive workflow for skill quality assurance
- **Automated Testing**: Uses DataRobot Agent Tester (`dr-agent` CLI) to evaluate skill quality and functionality
- **Skill Improvement**: Optional automated improvement based on test results with before/after comparison
- **Smart Installation**: Handles datarobot-agent-tester installation via uv (both project group and global tool options)
- **Comprehensive Reporting**: Generates detailed assessment reports with pass/fail metrics and actionable feedback

## Key Features
- **Target Skill Assessment**: Test any skill in the `skills/` directory
- **Installation Management**: Automatically handles datarobot-agent-tester setup when not available
- **Improvement Workflow**: Optional skill enhancement with re-testing and delta analysis
- **Robust Error Handling**: Clear error messages and remediation steps for common issues
- **Timeout Protection**: Prevents hanging commands with configurable timeout limits
- **Status Reporting**: Clear PASS/NEEDS WORK status with detailed summaries

## Usage Examples
```bash
# Basic skill testing
User: "Test the my-skill skill"
# Test and improve with comparison
User: "Assess and improve skills/data-processor"
```

## Technical Details
Requires `DATAROBOT_API_TOKEN` for LLM-as-judge assessment
Supports both uv dependency group and global tool installation patterns
Includes comprehensive precondition validation and error handling
Provides detailed before/after comparisons when improvement is performed

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1783379420.360099 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The optional improve path instructs agents to modify skill files in-place and may add dependencies via `uv`; misuse or skipped confirmations could change repo content, though scope is limited to the named skill directory.
> 
> **Overview**
> Adds **`datarobot-agent-skill-assessment`** as a new agent skill (`skills/datarobot-agent-skill-assessment/SKILL.md`) that drives **DataRobot Agent Tester** (`dr-agent`) to test a target skill under `skills/`, optionally run **in-place improvement**, and optionally **re-test** with a before/after summary.
> 
> The skill defines inputs (`skill_dir`, `improve`, `retest_after_improve`), preconditions (`DATAROBOT_API_TOKEN`, repo root, valid skill layout), and a step-by-step runbook: normalize paths, validate token/CLI, **prompt before** installing `datarobot-agent-tester` via `uv` (project `skill-assessment` group or global tool), run `dr-agent skills test` / `improve` with optional timeouts, locate and parse `*.skill-report.md`, and return a structured **PASS** / **NEEDS WORK** output contract (install mode, commands, artifacts, summary, comparison). Guardrails require explicit consent for installs and for the improve step, which can modify skill files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d7b90151181b0c6feec1e275e23890083270951. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->