### PR TITLE
[CFX] datarobot-agent-assist: Bumped application template version to 11.10.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.4"
+      "version": "1.3.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.4"
+  "version": "1.3.5"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.3.5] - 2028-07-08
+
+- `datarobot-agent-assist`: Bumped application template version to 11.10.7.
+
 ## [1.3.4] - 2028-07-01
 
 - `datarobot-agent-assist`: Improved rehearsal flow to properly handle missing LLM model cases and improved user-facing messaging; refactored Dress Rehearsal instructions into separate `references/dress-rehearsal.md` file to reduce SKILL.md token count while preserving all behavior and control-flow reliability.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/skills/datarobot-agent-assist/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/scripts/clone_template.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 REPO_URL = "https://github.com/datarobot-community/datarobot-agent-application.git"
 BRANCH: str | None = None
-TAG: str | None = "11.9.2"
+TAG: str | None = "11.10.7"
 
 
 def cleanup_git_dir(target_dir: Path) -> None:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

`datarobot-agent-assist`: Bumped application template version to `11.10.7`

## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1783516957.753239 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and a default clone tag only; no auth, deployment, or runtime logic changes.
> 
> **Overview**
> Releases **1.3.5** across the shared plugin manifests (Claude, Cursor, Gemini) and documents it in **CHANGELOG.md**.
> 
> For **`datarobot-agent-assist`**, `clone_template.py` now checks out the agent application template at git tag **`11.10.7`** instead of **`11.9.2`**, so new scaffolds pull the newer template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba6d9da70eadf89aef6ee9f1dbb739ed269f35c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->