### PR TITLE
fix(external-agent-monitoring): require Agent.instrument_all() for PydanticAI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.5"
+      "version": "1.3.6"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.6"
+      "version": "1.3.7"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.5"
+  "version": "1.3.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.6"
+  "version": "1.3.7"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.3.6] - 2026-07-09
+
+- `datarobot-external-agent-monitoring`: Fix PydanticAI instrumentation — modern PydanticAI makes OpenTelemetry instrumentation opt-in, so configuring a provider alone emitted no spans; document the required `Agent.instrument_all()` call, correct the outdated "no modifications needed" guidance, cover the v1/v2 API differences (`instrument=True` vs `capabilities=[Instrumentation(...)]`), the `InstrumentationSettings(version=…)` data-format default and `include_content` privacy option, and add a verification step for the DataRobot Prompt/Completion columns.
+
 ## [1.3.5] - 2028-07-08
 
 - `datarobot-agent-assist`: Bumped application template version to 11.10.7.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.3.3",
+  "version": "1.3.6",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-external-agent-monitoring/SKILL.md
+++ b/skills/datarobot-external-agent-monitoring/SKILL.md
@@ -36,7 +36,7 @@ Use this skill when an existing DataRobot user has built an agent elsewhere and 
 | LangChain / LangGraph | `langchain` or `langgraph` in deps/imports | Auto-instrumentor + standard setup |
 | CrewAI | `crewai` in deps/imports | Auto-instrumentor + standard setup |
 | LlamaIndex | `llama-index` or `llama_index` in deps/imports | Auto-instrumentor + standard setup |
-| PydanticAI | `pydantic-ai` or `pydantic_ai` in deps/imports | Standard setup (respects global TracerProvider) |
+| PydanticAI | `pydantic-ai` or `pydantic_ai` in deps/imports | Standard setup + required `Agent.instrument_all()` (instrumentation is opt-in) |
 | Generic Python | None of the above detected | Manual span instrumentation |
 
 ## Workflow

--- a/skills/datarobot-external-agent-monitoring/frameworks/pydantic-ai.md
+++ b/skills/datarobot-external-agent-monitoring/frameworks/pydantic-ai.md
@@ -2,65 +2,138 @@
 
 ## Overview
 
-PydanticAI works with the standard `configure_otel()` pattern — it respects the global TracerProvider and does NOT override it. Use the generic `dr_otel_config.py` without modification.
+PydanticAI does NOT override the global `TracerProvider`, so the generic
+`dr_otel_config.py` works unchanged — but **OpenTelemetry instrumentation is opt-in**. Configuring a provider with
+`configure_otel()` is necessary but **not sufficient**: without an explicit
+`Agent.instrument_all()` call, PydanticAI emits **no spans**. There is no error —
+telemetry simply never appears in DataRobot.
 
-PydanticAI has built-in integration with Pydantic Logfire, which exports OTel-compatible telemetry. The preferred approach for DataRobot integration is to use direct OTel setup (no logfire dependency needed).
+PydanticAI also has built-in integration with Pydantic Logfire, which exports
+OTel-compatible telemetry. The preferred approach for DataRobot is direct OTel setup
+(no Logfire dependency needed) plus the required `instrument_all()` opt-in.
 
 ## OTel Strategy
 
-| Signal    | Strategy                                          |
-|-----------|---------------------------------------------------|
-| **Traces**  | Standard setup — PydanticAI respects global TracerProvider |
-| **Metrics** | Standard setup (optional custom metrics)          |
-| **Logs**    | Standard setup                                    |
+| Signal    | Strategy                                                            |
+|-----------|--------------------------------------------------------------------|
+| **Traces**  | Standard `configure_otel()` **+ required `Agent.instrument_all()`** (opt-in) |
+| **Metrics** | Standard setup (optional custom metrics)                           |
+| **Logs**    | Standard setup                                                     |
 
-## Preferred Setup: Direct OTel
+## Required Setup
 
 ### 1. Use the generic `dr_otel_config.py` as-is
 
-No modifications needed. Call `configure_otel()` at startup.
+No modifications to the config module. Call `configure_otel()` at startup, before any
+PydanticAI import or agent creation.
 
-### 2. Wire into agent entrypoint
+### 2. Opt in to instrumentation and wire the entrypoint
+
+Call `Agent.instrument_all()` after `configure_otel()`. This is the step that makes
+PydanticAI emit spans; skipping it is the most common cause of "no telemetry."
 
 ```python
+import os
+
 from dr_otel_config import configure_otel
 
-configure_otel()
+configure_otel()  # sets the global TracerProvider (additive) BEFORE PydanticAI opt-in
 
-# PydanticAI automatically uses the global TracerProvider
 from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
 
-agent = Agent(
-    "openai:gpt-4o",
-    system_prompt="You are a helpful assistant.",
+# Opt in to PydanticAI's OTel instrumentation — without this, no spans are emitted.
+Agent.instrument_all()
+
+# Example: routing through the DataRobot LLM Gateway (any provider works).
+provider = OpenAIProvider(
+    base_url=f"{os.environ['DATAROBOT_ENDPOINT'].rstrip('/')}/genai/llmgw",
+    api_key=os.environ["DATAROBOT_API_TOKEN"],
 )
+model = OpenAIChatModel("azure/gpt-5-mini-2025-08-07", provider=provider)
+
+agent = Agent(model, system_prompt="You are a helpful assistant.")
 ```
 
-PydanticAI creates spans for:
-- Agent runs (with input/output)
-- LLM API calls (model, messages, response)
-- Tool/function calls
-- Retries and error handling
+`Agent.instrument_all()` uses the global `TracerProvider` that `configure_otel()` set,
+so every agent in the process exports to DataRobot without editing each `Agent(...)`
+constructor. PydanticAI creates spans for agent runs, LLM API calls, tool/function
+calls, and retries/error handling.
 
-### 3. Optional: Enable Logfire instrumentation
+## Version robustness
+
+PydanticAI's instrumentation API has changed across versions. Prefer the global call;
+fall back to per-agent only if you cannot call `instrument_all()` at startup.
+
+- **Recommended — global, version-robust:**
+  ```python
+  Agent.instrument_all()
+  ```
+
+- **Per-agent alternative — PydanticAI v2.x:**
+  ```python
+  from pydantic_ai import Agent
+  from pydantic_ai.capabilities import Instrumentation
+  from pydantic_ai.models.instrumented import InstrumentationSettings
+
+  agent = Agent(
+      model,
+      capabilities=[Instrumentation(settings=InstrumentationSettings())],
+  )
+  ```
+
+- **Per-agent alternative — older PydanticAI v1.x:**
+  ```python
+  agent = Agent(model, instrument=True)
+  ```
+
+- **`InstrumentationSettings(version=…)`** controls the telemetry data format
+  (`Literal[2, 3, 4, 5]`, default `5`, following OTel GenAI semantic conventions
+  1.37.0). Versions 2–4 are deprecated and emit `PydanticAIDeprecationWarning`. Only
+  pin a version if you must match a specific downstream schema (see Verify below).
+
+- **Privacy — exclude prompt/completion content:**
+  ```python
+  from pydantic_ai import Agent
+  from pydantic_ai.models.instrumented import InstrumentationSettings
+
+  Agent.instrument_all(InstrumentationSettings(include_content=False))
+  ```
+  By default PydanticAI captures prompt and completion text in spans. Set
+  `include_content=False` to suppress it (this also empties DataRobot's
+  Prompt/Completion columns).
+
+## Verify
+
+After wiring, confirm telemetry lands in DataRobot: run the agent once, then check the
+Use Case Tracing view (or the `dr xp` panel — see SKILL.md Step 5).
+
+- **Spans present, Prompt/Completion columns populated** → done.
+- **No spans at all** → `Agent.instrument_all()` was not called, or `configure_otel()`
+  ran after agent creation. Fix ordering.
+- **Spans present but Prompt/Completion columns empty** → attribute-name mismatch.
+  PydanticAI's default `version=5` emits `gen_ai.input.messages` /
+  `gen_ai.output.messages` (OTel GenAI semconv), while DataRobot's tracing table reads
+  `gen_ai.prompt` / `gen_ai.completion`. To fix, add the `gen_ai.prompt` / `gen_ai.completion` span attributes yourself — note that **no** `InstrumentationSettings(version=…)` value produces them (every selectable format, 2–5, emits `gen_ai.input.messages` / `gen_ai.output.messages`), so pinning a version does not help. Also confirm `include_content` is not `False`, and check whether your DataRobot instance already normalizes the newer semconv attributes.
+
+## Optional: Logfire instrumentation
 
 If the user already uses Logfire or wants richer PydanticAI-specific spans:
 
 ```python
 import logfire
 
-logfire.configure(
-    send_to_logfire=False,  # Don't send to Logfire cloud
-    # Logfire respects the global TracerProvider set by configure_otel()
-)
+logfire.configure(send_to_logfire=False)  # don't send to Logfire cloud; keep global provider
 logfire.instrument_pydantic_ai()
 ```
 
-This adds more detailed Pydantic validation spans on top of the standard OTel traces.
+This layers detailed Pydantic validation spans on top of the standard OTel traces. Use
+either direct OTel (`instrument_all()`) or Logfire, not both, to avoid duplicate traces.
 
 ## Extra Dependencies
 
-None beyond the generic OTel packages for the preferred approach.
+None beyond the generic OTel packages.
 
 Optional (if using Logfire):
 ```
@@ -83,21 +156,21 @@ async def run_with_metrics(agent, prompt):
     start = time.time()
     try:
         result = await agent.run(prompt)
-        elapsed_ms = (time.time() - start) * 1000
         request_counter.add(1, {"status": "success"})
-        request_duration.record(elapsed_ms)
         return result
-    except Exception as e:
-        elapsed_ms = (time.time() - start) * 1000
+    except Exception:
         request_counter.add(1, {"status": "error"})
-        request_duration.record(elapsed_ms)
         raise
+    finally:
+        request_duration.record((time.time() - start) * 1000)
 ```
 
 ## Known Pitfalls
 
 | Issue | Cause | Fix |
 |-------|-------|-----|
-| No spans from PydanticAI | `configure_otel()` called after agent creation | Ensure `configure_otel()` is called before any PydanticAI imports or agent instantiation |
-| Logfire overrides TracerProvider | `logfire.configure()` called with default settings | Use `send_to_logfire=False` to prevent Logfire from replacing the provider |
-| Duplicate traces | Both direct OTel and Logfire active | Choose one approach — prefer direct OTel unless Logfire is already in use |
+| No spans from PydanticAI | `Agent.instrument_all()` never called (instrumentation is opt-in) | Call `Agent.instrument_all()` after `configure_otel()`, before running agents |
+| No spans from PydanticAI | `configure_otel()` called after agent creation | Ensure `configure_otel()` runs before any PydanticAI import or agent instantiation |
+| Spans appear but Prompt/Completion columns empty | v5 semconv attributes (`gen_ai.input.messages`) differ from DataRobot's `gen_ai.prompt`/`gen_ai.completion`; or `include_content=False` | Add the `gen_ai.prompt`/`gen_ai.completion` span attributes yourself (no `version` value emits them); ensure `include_content` is not `False` (see Verify) |
+| Logfire overrides TracerProvider | `logfire.configure()` called with default settings | Use `send_to_logfire=False` to keep the global provider |
+| Duplicate traces | Both direct OTel and Logfire active | Choose one approach — prefer direct OTel |

--- a/skills/datarobot-external-agent-monitoring/frameworks/pydantic-ai.md
+++ b/skills/datarobot-external-agent-monitoring/frameworks/pydantic-ai.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-PydanticAI does NOT override the global `TracerProvider`, so the generic
-`dr_otel_config.py` works unchanged — but **OpenTelemetry instrumentation is opt-in**. Configuring a provider with
-`configure_otel()` is necessary but **not sufficient**: without an explicit
-`Agent.instrument_all()` call, PydanticAI emits **no spans**. There is no error —
-telemetry simply never appears in DataRobot.
+PydanticAI's OpenTelemetry instrumentation is **opt-in**: call `Agent.instrument_all()`
+at startup to emit spans. `configure_otel()` sets up the provider, and PydanticAI reuses
+the global `TracerProvider` it installs, so the generic `dr_otel_config.py` works
+unchanged. Skip the `Agent.instrument_all()` call and PydanticAI emits **no spans** —
+silently, with no error, so telemetry never appears in DataRobot.
 
 PydanticAI also has built-in integration with Pydantic Logfire, which exports
 OTel-compatible telemetry. The preferred approach for DataRobot is direct OTel setup
@@ -24,8 +24,7 @@ OTel-compatible telemetry. The preferred approach for DataRobot is direct OTel s
 
 ### 1. Use the generic `dr_otel_config.py` as-is
 
-No modifications to the config module. Call `configure_otel()` at startup, before any
-PydanticAI import or agent creation.
+Call `configure_otel()` at startup, before any PydanticAI import or agent creation.
 
 ### 2. Opt in to instrumentation and wire the entrypoint
 


### PR DESCRIPTION
## Summary
PydanticAI's OpenTelemetry instrumentation is opt-in: configuring a TracerProvider is necessary but not sufficient — without `Agent.instrument_all()`, PydanticAI emits zero spans. 
The skill's `frameworks/pydantic-ai.md` previously said "no modifications needed", so instrumented PydanticAI agents silently produced no telemetry in DataRobot.

This change:
  - Adds the required `Agent.instrument_all()` step (after `configure_otel()`, before agent creation) and corrects the outdated "no modifications needed" / "automatically uses the global TracerProvider" guidance.
  - Documents v1/v2 API drift (`instrument=True` vs `capabilities=[Instrumentation(...)]`), the `InstrumentationSettings(version=…)` data-format default (5), and the `include_content` privacy option.
  - Adds a Verify step + Known Pitfalls rows for the DataRobot Prompt/Completion columns (v5 semconv `gen_ai.input.messages` vs DataRobot's `gen_ai.prompt`/`gen_ai.completion`).
  - Updates the SKILL.md detection-table cell.
  - Bumps the shared plugin version 1.3.5 → 1.3.6 (all manifests + package.json) and adds a CHANGELOG entry.

Verified end-to-end: instrumenting a brownfield PydanticAI agent via the skill emits traces/logs/metrics to DataRobot (viewed via `dr xp`); all APIs confirmed against the official PydanticAI v2.0.0 docs.

  ## Rationale
Without this, users following the skill to instrument a PydanticAI agent hit a silent no-telemetry failure with no error to debug — the most confusing failure mode for this framework. The fix is documentation-only (the `dr_otel_config` provider setup was already correct).
  

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1783983182.600439 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version manifest updates only; no application code or OTel wiring changes.
> 
> **Overview**
> Fixes **silent no-telemetry** for PydanticAI agents following the external-agent-monitoring skill: modern PydanticAI treats OpenTelemetry as **opt-in**, so `configure_otel()` alone was never enough.
> 
> The **`datarobot-external-agent-monitoring`** skill now documents calling **`Agent.instrument_all()`** after `configure_otel()` and before agent creation, updates the supported-frameworks table in `SKILL.md`, and rewrites **`frameworks/pydantic-ai.md`** (startup ordering, v1/v2 per-agent alternatives, `InstrumentationSettings`, `include_content`, a **Verify** checklist, and pitfalls for empty DataRobot Prompt/Completion columns vs GenAI semconv attributes). The optional metrics example now records duration in a `finally` block.
> 
> Releases **plugin version 1.3.6** across Claude/Cursor/Gemini manifests and **`package.json`** (aligned from 1.3.3), with a matching **CHANGELOG** entry. No runtime or `dr_otel_config` code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606fd371f1019d967bacef3ed9767fd94a81a9e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->