### PR TITLE
killer-onboarding datarobot-setup step5 improvements

### DIFF
--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -159,7 +159,11 @@ If the user prefers `pip` directly, the same pattern applies — they must creat
 
 ## Step 5: Get Access & Authenticate
 
-This step gets the user authenticated with as little friction as possible. `dr auth login` already captures the API key automatically via the browser: it opens `<host>/account/developer-tools?cliRedirect=true`, and that page hands the key back to the CLI's local listener on `localhost:51164`. **Never ask the user to copy and paste an API key by hand.**
+Get the user authenticated with as little friction as possible. `dr auth login`
+already captures the API key automatically through the browser — it opens
+`<host>/account/developer-tools?cliRedirect=true`, and that page returns the key
+to the CLI's local listener on `localhost:51164`. **Never ask the user to copy
+and paste an API key by hand.**
 
 First, detect whether this machine is already authenticated:
 
@@ -168,31 +172,46 @@ python skills/datarobot-setup/scripts/signup_and_authenticate.py check --json
 ```
 
 - Exit `0` (`"authenticated": true`) -> already set up. Skip the rest of this step and continue to Step 6.
-- Exit `2` -> not authenticated. Continue below.
-
-Then ask the user which situation they're in:
+- Exit `2` -> not authenticated. Ask the user:
 
 > **Do you already have a DataRobot account?** (yes / no — I'll start a free trial)
 
 ### Path A — Brand-new user (no account): guided trial signup
 
-The trial is free (30 days, no credit card). Keep the user in the terminal: open a pre-filled signup page, let them complete the one unavoidable browser step, then capture the key automatically.
+The trial is free (30 days, no credit card). Drop the user straight onto the
+lean signup page — no marketing form to hunt for.
 
-1. **Open signup** (email pre-filled from `git config user.email`):
+1. **Open signup:**
 
    ```bash
-   python skills/datarobot-setup/scripts/signup_and_authenticate.py signup
+   python skills/datarobot-setup/scripts/signup_and_authenticate.py signup --mode deeplink
    ```
 
-   Tell the user the fastest path is **"Sign up with GitHub or Google"** — it skips email verification entirely. Otherwise they enter an email, click the verification link, and set a password.
+   Tell the user the fastest path is **"Sign up with GitHub or Google"** — it
+   skips email verification and setting a password. The browser journey is:
 
-2. **Wait for the user.** Do not proceed until they confirm they've reached the DataRobot welcome/onboarding screen. This also gives the trial org time to finish provisioning.
+   - **GitHub/Google:** authorize -> *Tell us about yourself* -> welcome screen.
+   - **Email:** enter email -> click the verification link we email -> set a
+     password -> *Tell us about yourself* -> welcome screen.
 
-3. **Capture the key** — now that the browser has an authenticated session, `dr auth login` collapses to a single "Authorize" click:
+   The **"Tell us about yourself"** page (name, company, title, country) is a
+   required step that finishes provisioning the trial. Have the user fill it in
+   normally — do **not** attempt to skip or auto-fill it.
+
+2. **Wait for the user.** Do not proceed until they confirm they've reached the
+   DataRobot welcome/onboarding screen.
+
+3. **Capture the key** — the browser now has an authenticated session, so
+   `dr auth login` collapses to one "Authorize" click and stores the key:
 
    ```bash
    python skills/datarobot-setup/scripts/signup_and_authenticate.py login
    ```
+
+   > Note: `--mode deeplink` is validated end-to-end for **email** signup. The
+   > **GitHub/Google** path through the deep-link is not yet confirmed; if it
+   > errors at the callback, re-run signup with `--mode app` (its login screen
+   > offers the same Google/GitHub buttons and signs up cleanly).
 
 ### Path B — Existing account: authenticate directly
 
@@ -200,14 +219,15 @@ The trial is free (30 days, no credit card). Keep the user in the terminal: open
 python skills/datarobot-setup/scripts/signup_and_authenticate.py login
 ```
 
-This runs `dr auth login`, opens the browser, and stores the key in `~/.config/datarobot/drconfig.yaml`. If the user is on EU, JP, or self-managed DataRobot, pass their URL, for example `--host https://app.eu.datarobot.com`.
+For EU/JP/self-managed, pass the URL, e.g. `--host https://app.eu.datarobot.com`.
 
 ### Optional: export env vars for the Python SDK
 
-`dr auth login` writes `drconfig.yaml`, which is used by the CLI. The Python SDK also reads these env vars. Offer to add them to the user's shell rc file (`~/.zshrc`, `~/.bashrc`):
+The same two variables the SDK reads. Offer to add them to the user's shell rc
+(`~/.zshrc`, `~/.bashrc`):
 
 ```bash
-export DATAROBOT_ENDPOINT="<endpoint-url>"
+export DATAROBOT_ENDPOINT="<endpoint-url>"     # e.g. https://app.datarobot.com/api/v2
 export DATAROBOT_API_TOKEN="<api-token>"
 ```
 

--- a/skills/datarobot-setup/SKILL.md
+++ b/skills/datarobot-setup/SKILL.md
@@ -9,7 +9,7 @@ You are helping set up DataRobot for local development. Before installing anythi
 
 ## Step 1: Pre-Flight Check (Detect Existing Installation)
 
-Build a checklist of what is already installed before doing any installation work. Run each check and record the result. Skip any install step in Steps 3-7 whose check below already passes.
+Build a checklist of what is already installed before doing any installation work. Run each check and record the result. Skip any install step in Steps 3-6 whose check below already passes.
 
 ```bash
 # Required tools — record version for each, or "missing"
@@ -43,7 +43,7 @@ fi
 Compare each detected version to the minimums in the table in Step 3. Tell the user:
 - What is already installed and at acceptable versions (skip)
 - What is missing or below minimum version (install)
-- Whether dr-cli is already authenticated (skip Step 6 if so, but confirm with user)
+- Whether dr-cli is already authenticated (skip the login portion of Step 5 if so, but confirm with user)
 
 Only proceed past this step after presenting the diff to the user so they can confirm.
 
@@ -157,32 +157,61 @@ uv pip install datarobot datarobot-predict
 
 If the user prefers `pip` directly, the same pattern applies — they must create and activate a venv first, then run `pip install datarobot datarobot-predict` inside it. Never instruct the user to run `pip install --break-system-packages` against the system Python.
 
-## Step 5: Get API Key
+## Step 5: Get Access & Authenticate
 
-If the user does not already have a DataRobot Personal API key:
+This step gets the user authenticated with as little friction as possible. `dr auth login` already captures the API key automatically via the browser: it opens `<host>/account/developer-tools?cliRedirect=true`, and that page hands the key back to the CLI's local listener on `localhost:51164`. **Never ask the user to copy and paste an API key by hand.**
 
-1. Open: https://app.datarobot.com/account/developer-tools
-2. Use the **Personal API keys** tab (NOT Application or Agent keys).
-3. Wait for the user to provide the key.
-
-## Step 6: Authenticate with dr-cli
-
-If Step 1 showed `~/.config/datarobot/drconfig.yaml` already exists, ask the user if they want to re-authenticate or keep the existing credentials. Otherwise run:
+First, detect whether this machine is already authenticated:
 
 ```bash
-dr auth login
+python skills/datarobot-setup/scripts/signup_and_authenticate.py check --json
 ```
 
-This persists credentials in `~/.config/datarobot/drconfig.yaml`.
+- Exit `0` (`"authenticated": true`) -> already set up. Skip the rest of this step and continue to Step 6.
+- Exit `2` -> not authenticated. Continue below.
 
-Optionally, offer to add these to the user's shell rc file (~/.zshrc, ~/.bashrc) for SDK use:
+Then ask the user which situation they're in:
+
+> **Do you already have a DataRobot account?** (yes / no — I'll start a free trial)
+
+### Path A — Brand-new user (no account): guided trial signup
+
+The trial is free (30 days, no credit card). Keep the user in the terminal: open a pre-filled signup page, let them complete the one unavoidable browser step, then capture the key automatically.
+
+1. **Open signup** (email pre-filled from `git config user.email`):
+
+   ```bash
+   python skills/datarobot-setup/scripts/signup_and_authenticate.py signup
+   ```
+
+   Tell the user the fastest path is **"Sign up with GitHub or Google"** — it skips email verification entirely. Otherwise they enter an email, click the verification link, and set a password.
+
+2. **Wait for the user.** Do not proceed until they confirm they've reached the DataRobot welcome/onboarding screen. This also gives the trial org time to finish provisioning.
+
+3. **Capture the key** — now that the browser has an authenticated session, `dr auth login` collapses to a single "Authorize" click:
+
+   ```bash
+   python skills/datarobot-setup/scripts/signup_and_authenticate.py login
+   ```
+
+### Path B — Existing account: authenticate directly
+
+```bash
+python skills/datarobot-setup/scripts/signup_and_authenticate.py login
+```
+
+This runs `dr auth login`, opens the browser, and stores the key in `~/.config/datarobot/drconfig.yaml`. If the user is on EU, JP, or self-managed DataRobot, pass their URL, for example `--host https://app.eu.datarobot.com`.
+
+### Optional: export env vars for the Python SDK
+
+`dr auth login` writes `drconfig.yaml`, which is used by the CLI. The Python SDK also reads these env vars. Offer to add them to the user's shell rc file (`~/.zshrc`, `~/.bashrc`):
 
 ```bash
 export DATAROBOT_ENDPOINT="<endpoint-url>"
 export DATAROBOT_API_TOKEN="<api-token>"
 ```
 
-## Step 7: Install Agent Assist Plugin
+## Step 6: Install Agent Assist Plugin
 
 Skip if Step 1 showed the `assist` plugin already installed. Otherwise:
 
@@ -190,7 +219,7 @@ Skip if Step 1 showed the `assist` plugin already installed. Otherwise:
 dr plugin install assist
 ```
 
-## Step 8: Verify Installation
+## Step 7: Verify Installation
 
 1. **CLI and plugins**:
    ```bash
@@ -204,7 +233,7 @@ dr plugin install assist
    ```
    if this fails due to the source command not working, try it without activating the venv
 
-## Step 9: Print Summary
+## Step 8: Print Summary
 
 Summarize:
 - Tools installed this session vs. tools already present

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frictionless trial signup + CLI authentication for datarobot-setup Step 5.
+
+This helper collapses the brand-new-user onboarding path into a few CLI-driven
+steps so the developer never has to hunt for the trial form, copy an API key,
+or leave the terminal for longer than a single browser round-trip.
+
+Why it is split into subcommands (not one blocking script):
+    The datarobot-setup skill is driven by a coding agent that gates on the
+    *user's* chat replies, not on a script's stdin. So the agent calls these
+    subcommands in sequence and does the "wait for the human" part itself.
+
+    check        -> Is the machine already authenticated? (detection / skip)
+    signup       -> Open the browser to trial signup (email pre-filled). Returns
+                    immediately; the agent then waits for the user to finish.
+    login        -> Run `dr auth login`; the already-authenticated browser
+                    session makes this a one-click authorize, and the API key is
+                    captured into drconfig.yaml automatically (no copy-paste).
+    all          -> Interactive convenience: check -> signup -> (Enter gate) ->
+                    login. Only prompts when run in a real TTY.
+
+How the key actually lands (verified against datarobot-oss/cli
+internal/auth/auth.go): `dr auth login` opens
+`{host}/account/developer-tools?cliRedirect=true`, spins up a local server on
+localhost:51164, and the developer-tools page 302-redirects the browser to
+`http://localhost:51164/?key=<APIKEY>`. It rides the browser's existing app
+session, so signing up first (this script's `signup` step) makes the `login`
+step hands-free.
+
+Usage:
+    python signup_and_authenticate.py check   [--host URL] [--json]
+    python signup_and_authenticate.py signup  [--host URL] [--email you@co.com] [--mode app|deeplink]
+    python signup_and_authenticate.py login   [--host URL]
+    python signup_and_authenticate.py all     [--host URL] [--email you@co.com] [--mode app|deeplink]
+
+Exit codes:
+    0  success (authenticated, or step completed)
+    2  `check`: not authenticated yet (normal for a new user)
+    1  hard error (e.g. `dr` not installed, login failed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.parse
+import webbrowser
+
+DEFAULT_HOST = "https://app.datarobot.com"
+
+# --- Auth0 signup deep-link (US cloud) -------------------------------------
+# Captured from a live trial signup HAR. Lands the user directly on the signup
+# form with the email pre-filled. These values are specific to the US-cloud
+# public app; EU/JP or self-managed installs use a different Auth0 tenant and
+# client, so deep-link mode is only attempted when --host is the US cloud.
+#
+# CAVEAT (validate on a live run before making this the default): the app's
+# /account/oidc/callback may validate an OIDC `state` that only exists when the
+# *app* initiates the flow. A self-initiated authorize URL can therefore fail at
+# the callback with an invalid-state error. If that happens, use --mode app
+# (the robust default) which lets the app initiate and set state itself.
+US_AUTH_DOMAIN = "https://login.datarobot.com"
+US_CLIENT_ID = "xRJctzk4frlytI32DsAYHs0dhd7FQBli"
+
+
+def run(cmd: list[str], timeout: int | None = None, capture: bool = True):
+    """Run a command; return (returncode, stdout, stderr). Never raises on rc."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=capture,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, (proc.stdout or ""), (proc.stderr or "")
+    except FileNotFoundError:
+        return 127, "", f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timed out after {timeout}s: {' '.join(cmd)}"
+
+
+def dr_installed() -> bool:
+    return shutil.which("dr") is not None
+
+
+def is_authenticated(host: str) -> bool:
+    """True if `dr auth check` passes. Short timeout; never prompts."""
+    if not dr_installed():
+        return False
+    rc, _, _ = run(["dr", "auth", "check"], timeout=35)
+    return rc == 0
+
+
+def git_email() -> str:
+    rc, out, _ = run(["git", "config", "--get", "user.email"], timeout=10)
+    return out.strip() if rc == 0 else ""
+
+
+def is_us_cloud(host: str) -> bool:
+    return host.rstrip("/") in (DEFAULT_HOST, "https://app.datarobot.com")
+
+
+def build_signup_url(host: str, email: str, mode: str) -> tuple[str, str]:
+    """Return (url, mode_used). Falls back to app-initiated when deep-link
+    cannot be built safely for the given host."""
+    host = host.rstrip("/")
+
+    if mode == "deeplink":
+        if not is_us_cloud(host):
+            # No known Auth0 tenant/client for non-US hosts; stay robust.
+            return f"{host}/account/oidc/redirect", "app"
+        params = {
+            "client": US_CLIENT_ID,
+            "protocol": "oauth2",
+            "response_type": "code",
+            "redirect_uri": f"{host}/account/oidc/callback",
+            "scope": "openid email profile",
+            "initial_display": "signup",
+        }
+        if email:
+            params["login_hint"] = email
+        query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+        return f"{US_AUTH_DOMAIN}/authorize?{query}", "deeplink"
+
+    # mode == "app" (robust default): the app initiates OIDC and sets state.
+    # The Auth0 page still offers a "Sign up" toggle + Google/GitHub buttons.
+    return f"{host}/account/oidc/redirect", "app"
+
+
+def _is_wsl() -> bool:
+    if not hasattr(os, "uname"):
+        return False
+    return "microsoft" in os.uname().release.lower()
+
+
+def open_browser(url: str) -> bool:
+    """Best-effort cross-platform open. Always returns whether a browser was
+    launched; the caller prints the URL regardless so nothing is lost."""
+    # WSL: webbrowser usually can't reach the Windows browser. Try explorer.
+    if _is_wsl():
+        for opener in ("wslview", "explorer.exe"):
+            if shutil.which(opener):
+                rc, _, _ = run([opener, url], timeout=10)
+                if rc == 0:
+                    return True
+    try:
+        return webbrowser.open(url, new=2)
+    except Exception:
+        return False
+
+
+def print_signup_guidance(url: str, opened: bool, mode: str) -> None:
+    print()
+    print("🚀 Start your DataRobot free trial (30 days, no credit card):")
+    print()
+    print(f"    {url}")
+    print()
+    if not opened:
+        print("   (Your browser didn't open automatically — copy the link above.)")
+        print()
+    print("   ▶ Fastest path: sign up with GitHub or Google — this skips the")
+    print("     email-verification step entirely and gets you straight in.")
+    print("   ▶ Otherwise: enter your email, click the verification link we send,")
+    print("     then set a password.")
+    print()
+    print("   Finish until you land on the DataRobot welcome screen, then come")
+    print(
+        "   back here — the CLI will grab your API key automatically (no copy-paste)."
+    )
+    if mode == "deeplink":
+        print()
+        print("   NOTE: deep-link mode is experimental; if signup errors at the")
+        print("   callback, re-run with `--mode app`.")
+    print()
+
+
+def cmd_check(args) -> int:
+    installed = dr_installed()
+    authed = is_authenticated(args.host) if installed else False
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "dr_installed": installed,
+                    "authenticated": authed,
+                    "host": args.host,
+                }
+            )
+        )
+    else:
+        if not installed:
+            print("dr CLI not found on PATH (complete the install steps first).")
+        elif authed:
+            print("✅ Already authenticated with DataRobot.")
+        else:
+            print("Not authenticated yet.")
+    return 0 if authed else 2
+
+
+def cmd_signup(args) -> int:
+    email = args.email or git_email()
+    url, mode_used = build_signup_url(args.host, email, args.mode)
+    opened = open_browser(url)
+    print_signup_guidance(url, opened, mode_used)
+    return 0
+
+
+def cmd_login(args) -> int:
+    if not dr_installed():
+        print(
+            "❌ dr CLI not found on PATH. Install it before authenticating.",
+            file=sys.stderr,
+        )
+        return 1
+    print("🔐 Connecting the CLI to your DataRobot account...")
+    # Inherit stdio so the CLI's browser prompt / fallback URL is visible.
+    # No timeout: this blocks on the browser callback (localhost:51164).
+    rc, _, _ = run(["dr", "auth", "login", args.host], capture=False)
+    if rc != 0:
+        print(
+            "❌ `dr auth login` did not complete. You can re-run this step.",
+            file=sys.stderr,
+        )
+        return 1
+    if is_authenticated(args.host):
+        print("✅ Authenticated. API key stored in ~/.config/datarobot/drconfig.yaml")
+        return 0
+    print("⚠️  Login ran but verification failed. Try `dr auth check`.", file=sys.stderr)
+    return 1
+
+
+def cmd_all(args) -> int:
+    if is_authenticated(args.host):
+        print("✅ Already authenticated with DataRobot — nothing to do.")
+        return 0
+    cmd_signup(args)
+    if sys.stdin.isatty():
+        try:
+            input("Press Enter once you've reached the DataRobot welcome screen... ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        return cmd_login(args)
+    # Non-interactive (agent-driven): stop here; the agent runs `login` next
+    # after the user confirms signup is done.
+    print("Next: after finishing signup, run this script with `login`.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="DataRobot trial signup + CLI auth helper."
+    )
+    parser.add_argument("action", choices=["check", "signup", "login", "all"])
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("DATAROBOT_ENDPOINT_HOST", DEFAULT_HOST),
+        help=f"DataRobot app URL (default: {DEFAULT_HOST}).",
+    )
+    parser.add_argument(
+        "--email",
+        default="",
+        help="Email to pre-fill on signup (default: git config user.email).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["app", "deeplink"],
+        default="app",
+        help="signup URL style: 'app' (robust, default) or 'deeplink' (pre-fills email; validate live).",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Machine-readable output (check only)."
+    )
+    args = parser.parse_args()
+
+    # Normalize a bare host into a URL.
+    if not args.host.startswith(("http://", "https://")):
+        args.host = "https://" + args.host
+
+    return {
+        "check": cmd_check,
+        "signup": cmd_signup,
+        "login": cmd_login,
+        "all": cmd_all,
+    }[args.action](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -56,16 +56,22 @@ import webbrowser
 DEFAULT_HOST = "https://app.datarobot.com"
 
 # --- Auth0 signup deep-link (US cloud) -------------------------------------
-# Captured from a live trial signup HAR. Lands the user directly on the signup
-# form with the email pre-filled. These values are specific to the US-cloud
-# public app; EU/JP or self-managed installs use a different Auth0 tenant and
-# client, so deep-link mode is only attempted when --host is the US cloud.
+# Values captured from a live trial signup HAR. These are specific to the
+# US-cloud public app; EU/JP or self-managed installs use a different Auth0
+# tenant and client, so deep-link mode is only attempted when --host is US cloud.
 #
-# CAVEAT (validate on a live run before making this the default): the app's
-# /account/oidc/callback may validate an OIDC `state` that only exists when the
-# *app* initiates the flow. A self-initiated authorize URL can therefore fail at
-# the callback with an invalid-state error. If that happens, use --mode app
-# (the robust default) which lets the app initiate and set state itself.
+# STATUS (from live testing 2026-07): deep-link mode is NOT known to work
+# end-to-end and is kept only for experimentation. Two walls were observed:
+#   1. `/account/oidc/redirect` strictly allow-lists its query params and
+#      rejects display hints ("initial_display is not allowed key", etc.), so
+#      the app cannot be asked to render the signup screen.
+#   2. A self-initiated /authorize reaches Auth0, but the app's
+#      /account/oidc/callback validates an OIDC `state`/`nonce` that only exists
+#      when the *app* initiates the flow — so completing signup is expected to
+#      fail at the callback.
+# Reaching the lean CLI-native signup form almost certainly needs a small
+# platform change (e.g. allow-list a `screen_hint=signup` param on
+# /account/oidc/redirect). Until then, --mode app is the default.
 US_AUTH_DOMAIN = "https://login.datarobot.com"
 US_CLIENT_ID = "xRJctzk4frlytI32DsAYHs0dhd7FQBli"
 
@@ -118,11 +124,17 @@ def build_signup_url(host: str, email: str, mode: str) -> tuple[str, str]:
             # No known Auth0 tenant/client for non-US hosts; stay robust.
             return f"{host}/account/oidc/redirect", "app"
         params = {
-            "client": US_CLIENT_ID,
-            "protocol": "oauth2",
+            # Auth0 /authorize requires `client_id` (NOT `client`, which is the
+            # classic hosted-login page param). Getting this wrong yields
+            # "invalid_request: Missing required parameter: client_id".
+            "client_id": US_CLIENT_ID,
             "response_type": "code",
             "redirect_uri": f"{host}/account/oidc/callback",
             "scope": "openid email profile",
+            # Ask Auth0 to render signup. `screen_hint` is the New Universal
+            # Login key; `initial_display` is the classic Lock key. Send both;
+            # Auth0 ignores unknown /authorize params (unlike the app's redirect).
+            "screen_hint": "signup",
             "initial_display": "signup",
         }
         if email:
@@ -208,6 +220,10 @@ def cmd_check(args) -> int:
 def cmd_signup(args) -> int:
     email = args.email or git_email()
     url, mode_used = build_signup_url(args.host, email, args.mode)
+    if getattr(args, "print_url", False):
+        # Just emit the URL (for fast iteration / piping); don't open a browser.
+        print(url)
+        return 0
     opened = open_browser(url)
     print_signup_guidance(url, opened, mode_used)
     return 0
@@ -278,6 +294,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--json", action="store_true", help="Machine-readable output (check only)."
+    )
+    parser.add_argument(
+        "--print-url",
+        action="store_true",
+        help="signup only: print the URL instead of opening a browser.",
     )
     args = parser.parse_args()
 

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -63,8 +63,8 @@ DEFAULT_HOST = "https://app.datarobot.com"
 # STATUS (from live testing 2026-07):
 #   ✓ A self-initiated /authorize with client_id + screen_hint/initial_display
 #     DOES render the lean DataRobot signup page (confirmed live).
-#   ? Email pre-fill: the page ignores OIDC `login_hint`; we also pass a plain
-#     `email` param (see build_signup_url) — pending live confirmation.
+#   ✓ Email pre-fill: the page reads `autofill_email` from extraParams (NOT
+#     `login_hint`/`email`); `enforce_email` pre-fills and locks the field.
 #   ? End-to-end state: NOT yet confirmed that completing signup round-trips
 #     through /account/oidc/callback (which may validate a `state`/`nonce` that
 #     only exists when the *app* initiates). Reaching the form != the callback
@@ -138,13 +138,12 @@ def build_signup_url(host: str, email: str, mode: str) -> tuple[str, str]:
             "initial_display": "signup",
         }
         if email:
-            # `login_hint` is the OIDC standard, but the custom DataRobot signup
-            # page doesn't appear to read it. Also send a plain `email` param —
-            # Auth0 forwards unknown /authorize params through to the page (same
-            # path screen_hint/initial_display took). One of these should land in
-            # the email box; both are harmless if ignored.
-            params["login_hint"] = email
-            params["email"] = email
+            # The custom DataRobot signup page reads the email box from the
+            # `autofill_email` extraParam (confirmed in its JS bundle:
+            # `g=a.autofill_email … y={email:g||h}`). It ignores the OIDC
+            # `login_hint` and a plain `email` param. Use `enforce_email` instead
+            # if you want the field pre-filled AND locked (read-only).
+            params["autofill_email"] = email
         query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
         return f"{US_AUTH_DOMAIN}/authorize?{query}", "deeplink"
 

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -60,18 +60,18 @@ DEFAULT_HOST = "https://app.datarobot.com"
 # US-cloud public app; EU/JP or self-managed installs use a different Auth0
 # tenant and client, so deep-link mode is only attempted when --host is US cloud.
 #
-# STATUS (from live testing 2026-07): deep-link mode is NOT known to work
-# end-to-end and is kept only for experimentation. Two walls were observed:
-#   1. `/account/oidc/redirect` strictly allow-lists its query params and
-#      rejects display hints ("initial_display is not allowed key", etc.), so
-#      the app cannot be asked to render the signup screen.
-#   2. A self-initiated /authorize reaches Auth0, but the app's
-#      /account/oidc/callback validates an OIDC `state`/`nonce` that only exists
-#      when the *app* initiates the flow — so completing signup is expected to
-#      fail at the callback.
-# Reaching the lean CLI-native signup form almost certainly needs a small
-# platform change (e.g. allow-list a `screen_hint=signup` param on
-# /account/oidc/redirect). Until then, --mode app is the default.
+# STATUS (from live testing 2026-07):
+#   ✓ A self-initiated /authorize with client_id + screen_hint/initial_display
+#     DOES render the lean DataRobot signup page (confirmed live).
+#   ? Email pre-fill: the page ignores OIDC `login_hint`; we also pass a plain
+#     `email` param (see build_signup_url) — pending live confirmation.
+#   ? End-to-end state: NOT yet confirmed that completing signup round-trips
+#     through /account/oidc/callback (which may validate a `state`/`nonce` that
+#     only exists when the *app* initiates). Reaching the form != the callback
+#     accepting our state — run one full signup->onboarding->`dr auth login`.
+#   ✗ `/account/oidc/redirect` strictly allow-lists params and rejects display
+#     hints, so the app itself cannot be asked to show signup.
+# `--mode app` stays the default until the end-to-end run passes.
 US_AUTH_DOMAIN = "https://login.datarobot.com"
 US_CLIENT_ID = "xRJctzk4frlytI32DsAYHs0dhd7FQBli"
 
@@ -138,7 +138,13 @@ def build_signup_url(host: str, email: str, mode: str) -> tuple[str, str]:
             "initial_display": "signup",
         }
         if email:
+            # `login_hint` is the OIDC standard, but the custom DataRobot signup
+            # page doesn't appear to read it. Also send a plain `email` param —
+            # Auth0 forwards unknown /authorize params through to the page (same
+            # path screen_hint/initial_display took). One of these should land in
+            # the email box; both are harmless if ignored.
             params["login_hint"] = email
+            params["email"] = email
         query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
         return f"{US_AUTH_DOMAIN}/authorize?{query}", "deeplink"
 

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -63,15 +63,20 @@ DEFAULT_HOST = "https://app.datarobot.com"
 # STATUS (from live testing 2026-07):
 #   ✓ A self-initiated /authorize with client_id + screen_hint/initial_display
 #     DOES render the lean DataRobot signup page (confirmed live).
-#   ✓ Email pre-fill: the page reads `autofill_email` from extraParams (NOT
-#     `login_hint`/`email`); `enforce_email` pre-fills and locks the field.
-#   ? End-to-end state: NOT yet confirmed that completing signup round-trips
-#     through /account/oidc/callback (which may validate a `state`/`nonce` that
-#     only exists when the *app* initiates). Reaching the form != the callback
-#     accepting our state — run one full signup->onboarding->`dr auth login`.
+#   ✓ EMAIL signup completes end-to-end. On email submit the app creates an
+#     account-invite and emails a link back to
+#     app.datarobot.com/account/oidc/redirect?alsInviteId=… — which is
+#     APP-initiated (app-generated state/nonce). So the original self-initiated
+#     `state` is moot for this path; no callback state wall.
+#   ? SOCIAL signup (Google/GitHub) via deep-link returns straight to our
+#     self-initiated /account/oidc/callback (no invite re-init), so callback
+#     `state` acceptance is UNVERIFIED. If it fails, use --mode app for social.
+#   ✗ Cold-screen email pre-fill is NOT possible via URL param. The email box is
+#     only pre-filled from a server-side invite record (ALS: /api/account-invite
+#     /<id>), which exists only after email submit. `autofill_email`/`login_hint`
+#     /`email` do nothing on the initial trial-signup screen.
 #   ✗ `/account/oidc/redirect` strictly allow-lists params and rejects display
 #     hints, so the app itself cannot be asked to show signup.
-# `--mode app` stays the default until the end-to-end run passes.
 US_AUTH_DOMAIN = "https://login.datarobot.com"
 US_CLIENT_ID = "xRJctzk4frlytI32DsAYHs0dhd7FQBli"
 
@@ -138,11 +143,13 @@ def build_signup_url(host: str, email: str, mode: str) -> tuple[str, str]:
             "initial_display": "signup",
         }
         if email:
-            # The custom DataRobot signup page reads the email box from the
-            # `autofill_email` extraParam (confirmed in its JS bundle:
-            # `g=a.autofill_email … y={email:g||h}`). It ignores the OIDC
-            # `login_hint` and a plain `email` param. Use `enforce_email` instead
-            # if you want the field pre-filled AND locked (read-only).
+            # Best-effort email hint. NOTE: live testing showed the *cold*
+            # trial-signup screen does NOT pre-fill from any URL param — the page
+            # only auto-fills email from a server-side invite record (ALS), which
+            # exists only after the user submits their email. `autofill_email` is
+            # read solely by the invite/link-target components, so this is a
+            # harmless no-op on the initial screen. Kept in case an invite context
+            # applies; drop it if you prefer a cleaner URL.
             params["autofill_email"] = email
         query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
         return f"{US_AUTH_DOMAIN}/authorize?{query}", "deeplink"

--- a/skills/datarobot-setup/scripts/signup_and_authenticate.py
+++ b/skills/datarobot-setup/scripts/signup_and_authenticate.py
@@ -77,6 +77,9 @@ DEFAULT_HOST = "https://app.datarobot.com"
 #     /`email` do nothing on the initial trial-signup screen.
 #   ✗ `/account/oidc/redirect` strictly allow-lists params and rejects display
 #     hints, so the app itself cannot be asked to show signup.
+#   • Every new-user path (email AND social) passes through a required
+#     "Tell us about yourself" (/tell-us) lead-capture form before onboarding.
+#     It is an intentional gate — do NOT bypass or auto-fill it.
 US_AUTH_DOMAIN = "https://login.datarobot.com"
 US_CLIENT_ID = "xRJctzk4frlytI32DsAYHs0dhd7FQBli"
 


### PR DESCRIPTION
data wears prada hackathon WIP.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1784731030.800219 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding docs and a local helper only; auth still delegates to existing `dr auth login` with no changes to production services.
> 
> **Overview**
> **Replaces manual API-key onboarding** in the `datarobot-setup` skill with a browser-first flow: agents must not ask users to copy/paste keys; credentials come from `dr auth login` via the developer-tools CLI redirect.
> 
> **Step 5** is merged from the old “get API key” + “authenticate” steps into **Get Access & Authenticate**, with paths for **new trial users** (open signup → wait for welcome screen → `login`) vs **existing accounts** (`login` only). A pre-flight **`check --json`** skips the step when already authenticated. Later steps are renumbered (Agent Assist / verify / summary are now 6–8).
> 
> Adds **`signup_and_authenticate.py`** with `check`, `signup`, `login`, and `all` subcommands: opens trial/OIDC signup (optional US-cloud deeplink with email from `git config`), WSL-friendly browser launch, wraps `dr auth login`, and uses exit code `2` when not yet authed for agent-driven flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06bd894afa8c26bd78af9f2363719fdb2b7db513. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->