### PR TITLE
Improve workload api skills based on learnings deploying full stack app behind proxy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.8"
+      "version": "1.3.9"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.8"
+  "version": "1.3.9"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.3.9] - 2026-07-22
+
+- `datarobot-workload-api`: Add `references/web-uis-behind-the-edge.md` for serving a browser-facing web app (UI + backend) through the workload endpoint — the edge gateway strips the path prefix (inbound shim + base-path derived from the injected `WORKLOAD_ID`; proton-id path needs an explicit override), is itself the auth gate and hijacks the `Authorization` header (so disable the app's own auth and trust the edge), shared-origin `_xsrf`/CSRF collisions, and WebSocket pass-through. Correct artifact-replacement guidance: same-artifact replacement is allowed for drafts (RAPTOR-18806), `PATCH /settings/` rolling-redeploys onto a rebuilt image, and `imageUri` is build-managed (never hand-PATCH it or PATCH the spec mid-build). Trim `SKILL.md` ~18% to stay within the context-window budget.
+
 ## [1.3.8] - 2026-07-17
 
 - `datarobot-agent-assist`: Warn when the ports needed for local agent testing (5173, 8080, 8842) are not exposed inside a DataRobot Codespace, and stop with guidance when Agent Assist runs from an unsupported working directory. New `check_codespace.py` helper wired into the Pre-requisite Check; no-op outside a Codespace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [1.3.9] - 2026-07-22
 
-- `datarobot-workload-api`: Add `references/web-uis-behind-the-edge.md` for serving a browser-facing web app (UI + backend) through the workload endpoint — the edge gateway strips the path prefix (inbound shim + base-path derived from the injected `WORKLOAD_ID`; proton-id path needs an explicit override), is itself the auth gate and hijacks the `Authorization` header (so disable the app's own auth and trust the edge), shared-origin `_xsrf`/CSRF collisions, and WebSocket pass-through. Correct artifact-replacement guidance: same-artifact replacement is allowed for drafts (RAPTOR-18806), `PATCH /settings/` rolling-redeploys onto a rebuilt image, and `imageUri` is build-managed (never hand-PATCH it or PATCH the spec mid-build). Trim `SKILL.md` ~18% to stay within the context-window budget.
+- `datarobot-workload-api`: Add `references/web-uis-behind-the-edge.md` for serving a browser-facing web app (UI + backend) through the workload endpoint — the edge gateway strips the path prefix (inbound shim + base-path derived from the injected `WORKLOAD_ID`; proton-id path needs an explicit override), is itself the auth gate and hijacks the `Authorization` header (so disable the app's own auth and trust the edge), shared-origin `_xsrf`/CSRF collisions, and WebSocket pass-through. Correct artifact-replacement guidance: same-artifact replacement is allowed for drafts, `PATCH /settings/` rolling-redeploys onto a rebuilt image, and `imageUri` is build-managed (never hand-PATCH it or PATCH the spec mid-build). Trim `SKILL.md` ~18% to stay within the context-window budget.
 
 ## [1.3.8] - 2026-07-17
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-workload-api/SKILL.md
+++ b/skills/datarobot-workload-api/SKILL.md
@@ -295,11 +295,7 @@ To change a running workload's image / env vars / probes / port, find its curren
 
 **Lock an artifact:** `dr artifact lock <id>` (v0.2.74+) — equivalent to `PATCH /artifacts/{id}/ {"status": "locked"}`. No `POST /artifacts/{id}/lock/`. For a draft already running on a workload, use `promote` (no restart).
 
-**Replacement preconditions the API enforces (check before calling):**
-- **Status match.** `400 {"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running one's: draft↔draft, locked↔locked.
-- **Same-artifact rule (changing — mind your cluster's version).** Replacing an artifact with *itself* returns `422 {"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` for **locked** artifacts always, and for **drafts** too until RAPTOR-18806 (#1074) ships — after which same-artifact replacement is **allowed for drafts** (the intended C2W iteration path). When unsure, `PATCH /settings/` rolls onto the latest build regardless of status/version.
-
-There is **no `dr workload replacement` CLI subcommand** — replacement is REST-only (`POST /workloads/{id}/replacement/`).
+**Replacement preconditions:** the candidate's status must match the running artifact's (draft↔draft / locked↔locked, else `400`); replacing an artifact with *itself* `422`s for locked always and for drafts until RAPTOR-18806 (#1074) ships (then drafts may self-replace). No `dr workload replacement` CLI — REST-only. Exact error strings, the version transition, and the full same-draft redeploy matrix are in `references/lifecycle-flows.md`.
 
 **Promote (no restart):** `POST /workloads/{wid}/promote/` (empty body, returns 200) locks the draft the workload is currently running, in place. No pod restart. Only valid if the workload already runs that artifact — for a *different* one, use replacement.
 
@@ -314,10 +310,7 @@ The Workload API does **not yet accept image-pull credentials at workload creati
 
 Poll either path with `python scripts/wait_for_build.py <artifact_id> <build_id>`. Only drafts can build.
 
-**`imageUri` is build-managed — don't fight it:**
-- On build `COMPLETED` the platform **auto-populates the artifact's `imageUri`**. Do **not** set it by hand: `PATCH`-ing `imageUri` yourself returns `422 {"detail": "Image URI '...' is not permitted on this cluster."}` (only build-produced images are allowed).
-- Do **not PATCH the artifact spec while a build is in progress.** A spec PATCH is a read-modify-write of the whole spec, so it writes back the *pre-build* `imageUri` and clobbers the pending auto-populate — the workload then redeploys on the **old** image. Sequence it: make spec edits (env/probes) *before* `build create`, or *after* `COMPLETED` — and in the after case re-`GET` the artifact first so your PATCH carries the fresh `imageUri`.
-- After `COMPLETED`, `GET` the artifact and confirm `imageUri` advanced to the new build before redeploying.
+**`imageUri` is build-managed:** the build auto-populates it on `COMPLETED` — never `PATCH` it by hand (`422` "not permitted on this cluster"), and never PATCH the artifact spec *while a build is in progress* (a whole-spec write sends back the pre-build `imageUri` and clobbers the pending update → redeploys the old image). Sequence spec edits before `build create` or after `COMPLETED` (re-`GET` first), and confirm `imageUri` advanced before redeploying. Detail in `references/lifecycle-flows.md`.
 
 > **C2W is preview / feature-flagged** — needs `ENABLE_WORKLOAD_API_CONTAINERS=true` on the org and `DATAROBOT_CLI_FEATURE_WORKLOAD=true` client-side. Steps may change before GA.
 

--- a/skills/datarobot-workload-api/SKILL.md
+++ b/skills/datarobot-workload-api/SKILL.md
@@ -47,6 +47,7 @@ The SKILL.md is the operational core. Detail an agent needs occasionally lives i
 - `references/schema-reference.md` — OpenAPI schemas worth looking up, credential type → key mappings, public-spec path-key quirks
 - `references/lifecycle-flows.md` — artifact draft → lock → production flow rules and behavioral gotchas
 - `references/code-to-workload.md` — deploy from source code (no Dockerfile authoring): `dr` CLI commands, `codeRef`, Execution Environments, generated vs provided Dockerfile modes, iterate-rebuild loop
+- `references/web-uis-behind-the-edge.md` — serving a browser-facing web app (UI + backend) through the endpoint: the edge gateway strips the path prefix, gates auth, and hijacks `Authorization`; disable the app's own auth and trust the edge; sub-path hosting; CSRF; WebSockets
 
 ## OpenAPI spec is source of truth
 
@@ -109,6 +110,27 @@ Raw fallback when CLI unavailable: `httpx.post(f"{base}/workloads/", headers=hea
 - `port` MUST be `>= 1024`. The container must actually listen on it (set via image env vars or entrypoint).
 - Image must include a **linux/amd64** manifest. Apple Silicon defaults to ARM64 and crash-loops with `exec format error`. Build with `docker buildx build --platform linux/amd64,linux/arm64 -t <ref> --push .`.
 - Status lifecycle: `submitted` → `provisioning` → `launching` → `running` (happy path); `updating` during rolling redeploys; `errored` recoverable; `failed`/`terminated` unrecoverable. Full table in `references/status-vocabulary.md`.
+
+## Serving a browser-facing web UI through the endpoint
+
+If the container serves a **web app (UI + its own backend/API/WebSocket)** that
+users open in a browser via `dr workload endpoint <id>` — not just a headless
+service — the DataRobot edge gateway changes what the app must do. It serves the
+app under a path prefix (`…/api/v2/endpoints/workloads/<id>/`) and:
+
+- **strips that prefix inbound** (the container sees `/…`), while NOT rewriting
+  the app's outbound URLs/redirects — so the app must be sub-path aware;
+- **is itself the auth gate** (a DataRobot login is required to reach it), and
+  **hijacks the `Authorization` header** (treats it as a DataRobot API key →
+  `401 {"message":"Invalid API key"}`, request never reaches the container);
+- **passes WebSockets through** (`wss://` upgrades work).
+
+The winning pattern: set the app's base-path to the prefix (+ re-add it inbound),
+**disable the app's own auth and let the edge authenticate**, disable the app's
+CSRF check (shared-origin cookie collisions), and probe an unauthenticated path.
+Full guidance, per-symptom diagnostics, and a checklist are in
+`references/web-uis-behind-the-edge.md`. (Headless machine-to-machine services
+don't need any of this.)
 
 ## "Update the workload" disambiguation
 
@@ -266,11 +288,19 @@ An **artifact** is the immutable-after-lock definition of what a workload runs (
 
 ## Picking the right path
 
-To change a running workload's image / env vars / probes / port, find its current artifact (`workload["artifactId"]`) and check `artifact["status"]`. If `draft`: PATCH in place → `POST /workloads/{id}/replacement/`. If `locked`: clone → PATCH the clone → lock it → `POST /workloads/{id}/replacement/`.
+To change a running workload's image / env vars / probes / port, find its current artifact (`workload["artifactId"]`) and check `artifact["status"]`. **Key rule most agents get wrong: `POST /replacement/` requires a *different* artifact than the one running — you cannot replace an artifact with itself** (see the two ways below).
+
+- **Draft, brief downtime acceptable (simplest):** PATCH the draft in place (and/or rebuild its image), then redeploy with **`dr workload stop` → `dr workload start`**. Start re-reads the artifact's current spec + its latest `COMPLETED` build. Do **NOT** try `POST /replacement/` here — the candidate artifact ID equals the current one and it 422s (see below).
+- **Draft, zero-downtime required:** the running artifact ID must change. Clone (`POST /artifacts/{id}/clone/`) or create a *new* draft, apply the changes there, build it, then `POST /replacement/` onto that new artifact ID.
+- **Locked:** clone → PATCH the clone → lock it → `POST /replacement/` onto the clone. (The clone is a different artifact, so replacement is valid.)
 
 **Lock an artifact:** `dr artifact lock <id>` (v0.2.74+) — equivalent to `PATCH /artifacts/{id}/ {"status": "locked"}`. No `POST /artifacts/{id}/lock/`. For a draft already running on a workload, use `promote` (no restart).
 
-**Replacement status-match rule:** `400 {"detail": "Artifact status mismatch: ..."}` unless the new artifact's status matches the running one's. draft↔draft, locked↔locked. Check before calling.
+**Two replacement preconditions the API enforces (check both before calling):**
+- **Different artifact.** `422 {"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` if `artifactId` equals the running one. Applying an in-place change to the *same* draft is a `stop`/`start`, not a replacement.
+- **Status match.** `400 {"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running one's: draft↔draft, locked↔locked.
+
+There is **no `dr workload replacement` CLI subcommand** — replacement is REST-only (`POST /workloads/{id}/replacement/`).
 
 **Promote (no restart):** `POST /workloads/{wid}/promote/` (empty body, returns 200) locks the draft the workload is currently running, in place. No pod restart. Only valid if the workload already runs that artifact — for a *different* one, use replacement.
 
@@ -284,6 +314,11 @@ The Workload API does **not yet accept image-pull credentials at workload creati
 2. **Code-to-Workload (C2W)** — when you can't publish (no local Docker, no public registry, admin can't add pull credentials). `dr` CLI v0.2.74+ uploads source (`dr artifact code init` + `sync`), `dr artifact build create` triggers a platform build that pushes to DataRobot's **internal** registry and populates `imageUri`. From there, identical to bring-your-own-image. Full flow in `references/code-to-workload.md`.
 
 Poll either path with `python scripts/wait_for_build.py <artifact_id> <build_id>`. Only drafts can build.
+
+**`imageUri` is build-managed — don't fight it:**
+- On build `COMPLETED` the platform **auto-populates the artifact's `imageUri`**. Do **not** set it by hand: `PATCH`-ing `imageUri` yourself returns `422 {"detail": "Image URI '...' is not permitted on this cluster."}` (only build-produced images are allowed).
+- Do **not PATCH the artifact spec while a build is in progress.** A spec PATCH is a read-modify-write of the whole spec, so it writes back the *pre-build* `imageUri` and clobbers the pending auto-populate — the workload then redeploys on the **old** image. Sequence it: make spec edits (env/probes) *before* `build create`, or *after* `COMPLETED` — and in the after case re-`GET` the artifact first so your PATCH carries the fresh `imageUri`.
+- After `COMPLETED`, `GET` the artifact and confirm `imageUri` advanced to the new build before redeploying.
 
 > **C2W is preview / feature-flagged** — needs `ENABLE_WORKLOAD_API_CONTAINERS=true` on the org and `DATAROBOT_CLI_FEATURE_WORKLOAD=true` client-side. Steps may change before GA.
 
@@ -303,6 +338,8 @@ httpx.post(f"{base}/workloads/{wid}/replacement/", headers=headers, json={
 ```
 
 Then `python scripts/wait_for_replacement.py <workload_id>` to monitor.
+
+**Preconditions (both enforced, see "Picking the right path"):** `new_artifact_id` must be a *different* artifact than the one running (same ID → `422` "candidate artifact ID matches current artifact") and must match its status (draft↔draft / locked↔locked, else `400`). To apply a change to the *same* draft the workload runs, `stop`/`start` instead — replacement can't target the current artifact.
 
 `GET /workloads/{id}/replacement/` returns **404** when no active replacement (body: `{"detail": "There is no active replacement for this workload."}`) — that's "no replacement in progress", not an error. Cancel an in-progress one with `DELETE`. **Not idempotent**: calling `POST` while one is in progress queues a second swap — always check via the script first.
 

--- a/skills/datarobot-workload-api/SKILL.md
+++ b/skills/datarobot-workload-api/SKILL.md
@@ -288,17 +288,16 @@ An **artifact** is the immutable-after-lock definition of what a workload runs (
 
 ## Picking the right path
 
-To change a running workload's image / env vars / probes / port, find its current artifact (`workload["artifactId"]`) and check `artifact["status"]`. **Key rule most agents get wrong: `POST /replacement/` requires a *different* artifact than the one running — you cannot replace an artifact with itself** (see the two ways below).
+To change a running workload's image / env vars / probes / port, find its current artifact (`workload["artifactId"]`) and check `artifact["status"]`. A running workload does **not** auto-adopt a rebuild — it keeps its current image until you redeploy.
 
-- **Draft, brief downtime acceptable (simplest):** PATCH the draft in place (and/or rebuild its image), then redeploy with **`dr workload stop` → `dr workload start`**. Start re-reads the artifact's current spec + its latest `COMPLETED` build. Do **NOT** try `POST /replacement/` here — the candidate artifact ID equals the current one and it 422s (see below).
-- **Draft, zero-downtime required:** the running artifact ID must change. Clone (`POST /artifacts/{id}/clone/`) or create a *new* draft, apply the changes there, build it, then `POST /replacement/` onto that new artifact ID.
-- **Locked:** clone → PATCH the clone → lock it → `POST /replacement/` onto the clone. (The clone is a different artifact, so replacement is valid.)
+- **Draft — apply an in-place change or a rebuild to the *same* draft (the C2W loop).** PATCH/rebuild the draft, then roll the workload onto it with **`PATCH /workloads/{id}/settings/`**: re-send the runtime body (same shape `GET /workloads/{id}/settings/` returns — even re-sending the *current* values unchanged triggers the roll), and it redeploys re-reading the artifact's current spec + its latest `COMPLETED` build's `imageUri`. Returns `202`, rolling → zero-downtime at `replicaCount`/`minCount` ≥ 2 (brief gap on a single replica; fine for dev). **As of RAPTOR-18806 (workload-api #1074), `POST /replacement/` onto the *same* draft artifact also works** (and adds `warmupDurationMinutes`/`keepOldVersionMinutes` controls); until that ships it 422s for same-artifact — use the settings-PATCH.
+- **Locked, or switching to a *different* artifact.** `POST /replacement/` onto the other artifact ID. For locked-in-place edits: clone (`POST /artifacts/{id}/clone/`) → PATCH the clone → lock it → replace onto the clone. A locked artifact can **not** be replaced by itself.
 
 **Lock an artifact:** `dr artifact lock <id>` (v0.2.74+) — equivalent to `PATCH /artifacts/{id}/ {"status": "locked"}`. No `POST /artifacts/{id}/lock/`. For a draft already running on a workload, use `promote` (no restart).
 
-**Two replacement preconditions the API enforces (check both before calling):**
-- **Different artifact.** `422 {"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` if `artifactId` equals the running one. Applying an in-place change to the *same* draft is a `stop`/`start`, not a replacement.
+**Replacement preconditions the API enforces (check before calling):**
 - **Status match.** `400 {"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running one's: draft↔draft, locked↔locked.
+- **Same-artifact rule (changing — mind your cluster's version).** Replacing an artifact with *itself* returns `422 {"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` for **locked** artifacts always, and for **drafts** too until RAPTOR-18806 (#1074) ships — after which same-artifact replacement is **allowed for drafts** (the intended C2W iteration path). When unsure, `PATCH /settings/` rolls onto the latest build regardless of status/version.
 
 There is **no `dr workload replacement` CLI subcommand** — replacement is REST-only (`POST /workloads/{id}/replacement/`).
 
@@ -339,7 +338,7 @@ httpx.post(f"{base}/workloads/{wid}/replacement/", headers=headers, json={
 
 Then `python scripts/wait_for_replacement.py <workload_id>` to monitor.
 
-**Preconditions (both enforced, see "Picking the right path"):** `new_artifact_id` must be a *different* artifact than the one running (same ID → `422` "candidate artifact ID matches current artifact") and must match its status (draft↔draft / locked↔locked, else `400`). To apply a change to the *same* draft the workload runs, `stop`/`start` instead — replacement can't target the current artifact.
+**Preconditions (see "Picking the right path"):** status must match (draft↔draft / locked↔locked, else `400`). Same-artifact replacement 422s for **locked** artifacts (and for drafts until RAPTOR-18806/#1074 ships in your cluster); after #1074 a draft may replace itself — the C2W iteration path. To roll the *same* draft onto its latest build without replacement, `PATCH /workloads/{id}/settings/` (re-send the runtime body — even unchanged values trigger the rolling redeploy).
 
 `GET /workloads/{id}/replacement/` returns **404** when no active replacement (body: `{"detail": "There is no active replacement for this workload."}`) — that's "no replacement in progress", not an error. Cancel an in-progress one with `DELETE`. **Not idempotent**: calling `POST` while one is in progress queues a second swap — always check via the script first.
 

--- a/skills/datarobot-workload-api/SKILL.md
+++ b/skills/datarobot-workload-api/SKILL.md
@@ -40,27 +40,26 @@ Runnable Python in `scripts/` (this skill's folder). Each uses `httpx` and reads
 
 ## Deeper docs in references/
 
-The SKILL.md is the operational core. Detail an agent needs occasionally lives in `references/`:
+SKILL.md is the operational core; occasional detail lives in `references/`:
 
-- `references/status-vocabulary.md` — workload + proton status enums and lifecycle transitions
-- `references/common-error-patterns.md` — `CrashLoopBackOff` / `ImagePullBackOff` / `OOMKilled` / probe failures / `exec format error` / pending pods
-- `references/schema-reference.md` — OpenAPI schemas worth looking up, credential type → key mappings, public-spec path-key quirks
-- `references/lifecycle-flows.md` — artifact draft → lock → production flow rules and behavioral gotchas
-- `references/code-to-workload.md` — deploy from source code (no Dockerfile authoring): `dr` CLI commands, `codeRef`, Execution Environments, generated vs provided Dockerfile modes, iterate-rebuild loop
-- `references/web-uis-behind-the-edge.md` — serving a browser-facing web app (UI + backend) through the endpoint: the edge gateway strips the path prefix, gates auth, and hijacks `Authorization`; disable the app's own auth and trust the edge; sub-path hosting; CSRF; WebSockets
+- `status-vocabulary.md` — workload + proton status enums and transitions
+- `common-error-patterns.md` — CrashLoopBackOff / ImagePullBackOff / OOMKilled / probe / exec-format / pending
+- `schema-reference.md` — schemas to look up, credential-type→key maps, public-spec path quirks
+- `lifecycle-flows.md` — artifact draft→lock→prod rules, replacement preconditions, redeploy matrix, `imageUri` gotchas
+- `code-to-workload.md` — deploy from source: `dr` CLI, `codeRef`, Execution Environments, iterate-rebuild loop
+- `web-uis-behind-the-edge.md` — browser-facing web app through the endpoint: prefix stripping, auth gate, `Authorization` hijack, shim, CSRF, WebSockets
 
 ## OpenAPI spec is source of truth
 
-Published at `https://docs.datarobot.com/en/docs/api/reference/public-api/openapi.yaml`. **The spec is ~5 MB — never dump it whole into context.** Save once, then extract targeted slices with `yq`:
+At `${DATAROBOT_ENDPOINT}/openapi.yaml`. **~5 MB — never dump it whole.** Save once, then slice with `yq` (or `print()` only the specific key in Python):
 
 ```bash
 curl -sS "${DATAROBOT_ENDPOINT}/openapi.yaml" -o /tmp/wapi-spec.yaml
 yq '.components.schemas.CreateWorkloadRequest' /tmp/wapi-spec.yaml
-yq '.paths."/api/v2/workloads/{workload_id}/".patch' /tmp/wapi-spec.yaml
 yq '.components.schemas | keys | .[]' /tmp/wapi-spec.yaml | grep -i workload   # discover
 ```
 
-Python fallback: only `print()` the specific key, never the parsed dict. All workload paths in the public spec are keyed with `/api/v2/` prefix — see `references/schema-reference.md`.
+All workload paths are keyed with the `/api/v2/` prefix — see `references/schema-reference.md`.
 
 ---
 
@@ -113,24 +112,7 @@ Raw fallback when CLI unavailable: `httpx.post(f"{base}/workloads/", headers=hea
 
 ## Serving a browser-facing web UI through the endpoint
 
-If the container serves a **web app (UI + its own backend/API/WebSocket)** that
-users open in a browser via `dr workload endpoint <id>` — not just a headless
-service — the DataRobot edge gateway changes what the app must do. It serves the
-app under a path prefix (`…/api/v2/endpoints/workloads/<id>/`) and:
-
-- **strips that prefix inbound** (the container sees `/…`), while NOT rewriting
-  the app's outbound URLs/redirects — so the app must be sub-path aware;
-- **is itself the auth gate** (a DataRobot login is required to reach it), and
-  **hijacks the `Authorization` header** (treats it as a DataRobot API key →
-  `401 {"message":"Invalid API key"}`, request never reaches the container);
-- **passes WebSockets through** (`wss://` upgrades work).
-
-The winning pattern: set the app's base-path to the prefix (+ re-add it inbound),
-**disable the app's own auth and let the edge authenticate**, disable the app's
-CSRF check (shared-origin cookie collisions), and probe an unauthenticated path.
-Full guidance, per-symptom diagnostics, and a checklist are in
-`references/web-uis-behind-the-edge.md`. (Headless machine-to-machine services
-don't need any of this.)
+If the container serves a **web app (UI + its own backend/API/WebSocket)** opened in a browser via `dr workload endpoint <id>` (not a headless service), the DataRobot edge gateway serves it under a path prefix and: **strips the prefix inbound** (no outbound rewrite — the app must be sub-path aware); **is the auth gate** (DataRobot login required) and **hijacks the `Authorization` header** (→ `401 {"message":"Invalid API key"}`, never reaching the container); **passes WebSockets through**. Winning pattern: set the app's base-path to the prefix + re-add it inbound (derive it from the injected `WORKLOAD_ID`), **disable the app's own auth (trust the edge)**, disable CSRF, probe an unauthenticated path. Full guidance, shim code, and per-symptom diagnostics: `references/web-uis-behind-the-edge.md`.
 
 ## "Update the workload" disambiguation
 
@@ -198,15 +180,15 @@ Runs all 5 steps below, prints a structured report (status / logTail signals / f
 
 ## The 5-step flow
 
-The script encapsulates this; here's the model for ambiguous output or one-off calls.
+The script encapsulates this; use the model below for ambiguous output or one-off calls.
 
-1. **`GET /workloads/{id}/`** — `status`, `statusDetails.logTail` (~30 lines), `statusDetails.conditions`. Scan `logTail` for `error` / `exception` / `traceback` / `killed` / `permission denied` / `connection refused`. Guard `statusDetails` with `(w.get("statusDetails") or {})` — it can be `null` during `submitted` / `provisioning`.
-2. **`GET /workloads/{id}/events/`** — flag any event with `type: Warning` or `reason` containing `Failed` / `Error` / `Kill` / `OOM`. The last `Warning` before `errored` is usually the trigger.
-3. **`GET /workloads/{id}/protons/`** — response: `{"data": [{"id": "...", "role": "active"|"candidate"|"retiring", "createdAt": "..."}]}`. Pick `role: "active"`; during a rolling replacement debug the `candidate` if that's what's failing. If no active role, take the most recent `createdAt`.
-4. **`GET /workloads/{id}/protons/{pid}/statusDetails/`** — returns `204` while still initializing; that's not an error. Once populated, read in this order: `replicas[*].containers[*].status` + `restartCount` (the headline) → `replicas[*].conditions[*]` (any `value: false` is a smoking gun) → `overallStatus.summary` (DataRobot's human-readable interpretation).
+1. **`GET /workloads/{id}/`** — `status`, `statusDetails.logTail` (~30 lines; scan for `error`/`exception`/`traceback`/`killed`/`permission denied`/`connection refused`), `statusDetails.conditions`. Guard `statusDetails` — it's `null` during `submitted`/`provisioning`.
+2. **`GET /workloads/{id}/events/`** — flag `type: Warning` or `reason` with `Failed`/`Error`/`Kill`/`OOM`; the last Warning before `errored` is usually the trigger.
+3. **`GET /workloads/{id}/protons/`** — pick `role: "active"` (or the `candidate` during a rolling replacement; else newest `createdAt`).
+4. **`GET /workloads/{id}/protons/{pid}/statusDetails/`** — `204` while initializing (not an error). Read `replicas[*].containers[*].status`+`restartCount` → `replicas[*].conditions[*]` (any `value:false`) → `overallStatus.summary`.
 5. **Application logs** — section 3.
 
-Common patterns (`CrashLoopBackOff`, `ImagePullBackOff`, `OOMKilled`, probe failures, pending pods, `exec format error`) and their fix paths: `references/common-error-patterns.md`.
+Common patterns (`CrashLoopBackOff`, `ImagePullBackOff`, `OOMKilled`, probe/pending, `exec format error`) and fixes: `references/common-error-patterns.md`.
 
 ## Reporting findings
 
@@ -263,18 +245,15 @@ trace = httpx.get(f"{base}/otel/workload/{wid}/traces/{trace_id}/", headers=head
 
 ## Metrics + service stats
 
-Metrics unit conversions before display: `bytes` → MB (`/ 1024**2`); `nanocores` → cores (`/ 1_000_000`); `percentage` already a %.
-
-Service stats response shape:
+Convert before display: `bytes`→MB (`/1024**2`), `nanocores`→cores (`/1_000_000`), `percentage` already %.
 
 ```python
 stats = httpx.get(f"{base}/workloads/{wid}/stats/", headers=headers).json()
-# Returns {"period": {start, end}, "metrics": {totalRequests, serverErrors, userErrors,
-#   slowRequests, responseTime, requestsPerMinute, concurrentRequests, totalErrorRate,
-#   serverErrorRate, userErrorRate}}.  /workloads/stats/ (aggregate) same shape.
+# {"period": {...}, "metrics": {totalRequests, serverErrors, userErrors, slowRequests,
+#   responseTime, requestsPerMinute, concurrentRequests, *ErrorRate}}. /workloads/stats/ = aggregate.
 ```
 
-> **Warning — destructive.** `DELETE /workloads/{id}/stats/?metricName=<name>` zeroes a metric's history. Only call when the user explicitly asks to reset stats.
+> **Destructive:** `DELETE /workloads/{id}/stats/?metricName=<name>` zeroes a metric's history — only on explicit request.
 
 ## Presenting results
 
@@ -288,31 +267,25 @@ An **artifact** is the immutable-after-lock definition of what a workload runs (
 
 ## Picking the right path
 
-To change a running workload's image / env vars / probes / port, find its current artifact (`workload["artifactId"]`) and check `artifact["status"]`. A running workload does **not** auto-adopt a rebuild — it keeps its current image until you redeploy.
+Find the running artifact (`workload["artifactId"]`), check `artifact["status"]`. A running workload does **not** auto-adopt a rebuild until you redeploy.
 
-- **Draft — apply an in-place change or a rebuild to the *same* draft (the C2W loop).** PATCH/rebuild the draft, then roll the workload onto it with **`PATCH /workloads/{id}/settings/`**: re-send the runtime body (same shape `GET /workloads/{id}/settings/` returns — even re-sending the *current* values unchanged triggers the roll), and it redeploys re-reading the artifact's current spec + its latest `COMPLETED` build's `imageUri`. Returns `202`, rolling → zero-downtime at `replicaCount`/`minCount` ≥ 2 (brief gap on a single replica; fine for dev). **As of RAPTOR-18806 (workload-api #1074), `POST /replacement/` onto the *same* draft artifact also works** (and adds `warmupDurationMinutes`/`keepOldVersionMinutes` controls); until that ships it 422s for same-artifact — use the settings-PATCH.
-- **Locked, or switching to a *different* artifact.** `POST /replacement/` onto the other artifact ID. For locked-in-place edits: clone (`POST /artifacts/{id}/clone/`) → PATCH the clone → lock it → replace onto the clone. A locked artifact can **not** be replaced by itself.
+- **Same draft (the C2W loop) — in-place change or rebuild.** PATCH/rebuild the draft, then roll onto it with `PATCH /workloads/{id}/settings/`: re-send the runtime body (even unchanged values trigger a rolling `202` redeploy that re-reads the current spec + latest `COMPLETED` build). Zero-downtime at ≥2 replicas. (After RAPTOR-18806/#1074, `POST /replacement/` onto the same draft also works.)
+- **Different / locked artifact.** `POST /replacement/` onto the other artifact ID. Locked in-place edit: clone → PATCH clone → lock → replace onto the clone.
 
-**Lock an artifact:** `dr artifact lock <id>` (v0.2.74+) — equivalent to `PATCH /artifacts/{id}/ {"status": "locked"}`. No `POST /artifacts/{id}/lock/`. For a draft already running on a workload, use `promote` (no restart).
+**Lock:** `dr artifact lock <id>` (= `PATCH /artifacts/{id}/ {"status":"locked"}`). **Promote** (`POST /workloads/{wid}/promote/`, 200) locks the running draft in place, no restart. Runtime-only changes (replicas/resources/autoscaling) → `PATCH /settings/`; a PATCH to the artifact doesn't affect live workloads until you redeploy.
 
-**Replacement preconditions:** the candidate's status must match the running artifact's (draft↔draft / locked↔locked, else `400`); replacing an artifact with *itself* `422`s for locked always and for drafts until RAPTOR-18806 (#1074) ships (then drafts may self-replace). No `dr workload replacement` CLI — REST-only. Exact error strings, the version transition, and the full same-draft redeploy matrix are in `references/lifecycle-flows.md`.
-
-**Promote (no restart):** `POST /workloads/{wid}/promote/` (empty body, returns 200) locks the draft the workload is currently running, in place. No pod restart. Only valid if the workload already runs that artifact — for a *different* one, use replacement.
-
-For runtime-only changes (replicas / resources / autoscaling), use section 1's `PATCH /workloads/{id}/settings/`; don't touch the artifact. **Patching an artifact does NOT affect running workloads** — trigger a replacement (or `promote`) to apply changes to live workloads. Full code in `references/lifecycle-flows.md`.
+Preconditions (status-match, same-artifact rule + #1074) and the full redeploy matrix: `references/lifecycle-flows.md`.
 
 ## How does your image get to DataRobot?
 
-The Workload API does **not yet accept image-pull credentials at workload creation** — the artifact's `imageUri` must point at a registry DataRobot can already pull from. Two paths:
+The artifact's `imageUri` must point at a registry DataRobot can pull from (image-pull creds aren't accepted at workload creation yet). Two paths:
 
-1. **Bring your own image** — when the image lives in a public registry (`ghcr.io/org/app:tag`, Docker Hub public) or one the org admin pre-configured. Build locally with `docker buildx ... --platform linux/amd64`, push, reference via `imageUri`. The default flow used throughout this skill.
-2. **Code-to-Workload (C2W)** — when you can't publish (no local Docker, no public registry, admin can't add pull credentials). `dr` CLI v0.2.74+ uploads source (`dr artifact code init` + `sync`), `dr artifact build create` triggers a platform build that pushes to DataRobot's **internal** registry and populates `imageUri`. From there, identical to bring-your-own-image. Full flow in `references/code-to-workload.md`.
+1. **Bring your own image** — public registry or one the admin pre-configured. `docker buildx ... --platform linux/amd64`, push, set `imageUri`. Default flow.
+2. **Code-to-Workload (C2W)** — no local Docker / no public registry: `dr artifact code init` + `sync`, then `dr artifact build create` builds server-side, pushes to DataRobot's internal registry, and populates `imageUri`. Full flow in `references/code-to-workload.md`.
 
-Poll either path with `python scripts/wait_for_build.py <artifact_id> <build_id>`. Only drafts can build.
+Poll builds with `python scripts/wait_for_build.py <artifact_id> <build_id>`; only drafts build. **`imageUri` is build-managed** — never PATCH it by hand (`422` "not permitted on this cluster"), and never PATCH the spec *mid-build* (a whole-spec write clobbers the pending build image → redeploys the old one). Sequence spec edits before `build create` or after `COMPLETED`.
 
-**`imageUri` is build-managed:** the build auto-populates it on `COMPLETED` — never `PATCH` it by hand (`422` "not permitted on this cluster"), and never PATCH the artifact spec *while a build is in progress* (a whole-spec write sends back the pre-build `imageUri` and clobbers the pending update → redeploys the old image). Sequence spec edits before `build create` or after `COMPLETED` (re-`GET` first), and confirm `imageUri` advanced before redeploying. Detail in `references/lifecycle-flows.md`.
-
-> **C2W is preview / feature-flagged** — needs `ENABLE_WORKLOAD_API_CONTAINERS=true` on the org and `DATAROBOT_CLI_FEATURE_WORKLOAD=true` client-side. Steps may change before GA.
+> **C2W is preview / feature-flagged** — `ENABLE_WORKLOAD_API_CONTAINERS=true` (org) + `DATAROBOT_CLI_FEATURE_WORKLOAD=true` (client).
 
 ## Rolling artifact replacement
 
@@ -320,20 +293,12 @@ Poll either path with `python scripts/wait_for_build.py <artifact_id> <build_id>
 httpx.post(f"{base}/workloads/{wid}/replacement/", headers=headers, json={
     "artifactId": new_artifact_id,
     "strategy": "rolling",                   # only "rolling" supported
-    "config": {                              # OPTIONAL — omit for platform defaults
-        "warmupDurationMinutes": 2,          # warm caches; 0 to skip
-        "keepOldVersionMinutes": 5,          # rollback window; 0 to drop immediately
-    },
-    # Optional — change runtime in the same call (same shape as PATCH /settings/)
-    # "runtime": {"containerGroups": [{"name": "default", "replicaCount": 3}]}
+    "config": {"warmupDurationMinutes": 2, "keepOldVersionMinutes": 5},  # optional
+    # "runtime": {...}  # optional; same shape as PATCH /settings/
 })
 ```
 
-Then `python scripts/wait_for_replacement.py <workload_id>` to monitor.
-
-**Preconditions (see "Picking the right path"):** status must match (draft↔draft / locked↔locked, else `400`). Same-artifact replacement 422s for **locked** artifacts (and for drafts until RAPTOR-18806/#1074 ships in your cluster); after #1074 a draft may replace itself — the C2W iteration path. To roll the *same* draft onto its latest build without replacement, `PATCH /workloads/{id}/settings/` (re-send the runtime body — even unchanged values trigger the rolling redeploy).
-
-`GET /workloads/{id}/replacement/` returns **404** when no active replacement (body: `{"detail": "There is no active replacement for this workload."}`) — that's "no replacement in progress", not an error. Cancel an in-progress one with `DELETE`. **Not idempotent**: calling `POST` while one is in progress queues a second swap — always check via the script first.
+Monitor with `python scripts/wait_for_replacement.py <workload_id>`. Preconditions: status must match (draft↔draft / locked↔locked, else `400`); same-artifact replacement 422s for locked (and drafts until #1074/RAPTOR-18806) — to roll the same draft without replacement use `PATCH /settings/`. **Not idempotent** (a second `POST` queues another swap); `GET .../replacement/` `404` = none in progress; `DELETE` to cancel. Detail in `references/lifecycle-flows.md`.
 
 ---
 

--- a/skills/datarobot-workload-api/SKILL.md
+++ b/skills/datarobot-workload-api/SKILL.md
@@ -269,12 +269,12 @@ An **artifact** is the immutable-after-lock definition of what a workload runs (
 
 Find the running artifact (`workload["artifactId"]`), check `artifact["status"]`. A running workload does **not** auto-adopt a rebuild until you redeploy.
 
-- **Same draft (the C2W loop) — in-place change or rebuild.** PATCH/rebuild the draft, then roll onto it with `PATCH /workloads/{id}/settings/`: re-send the runtime body (even unchanged values trigger a rolling `202` redeploy that re-reads the current spec + latest `COMPLETED` build). Zero-downtime at ≥2 replicas. (After RAPTOR-18806/#1074, `POST /replacement/` onto the same draft also works.)
+- **Same draft (the C2W loop) — in-place change or rebuild.** PATCH/rebuild the draft, then roll onto it with `PATCH /workloads/{id}/settings/`: re-send the runtime body (even unchanged values trigger a rolling `202` redeploy that re-reads the current spec + latest `COMPLETED` build). Zero-downtime at ≥2 replicas. (`POST /replacement/` onto the same draft also works.)
 - **Different / locked artifact.** `POST /replacement/` onto the other artifact ID. Locked in-place edit: clone → PATCH clone → lock → replace onto the clone.
 
 **Lock:** `dr artifact lock <id>` (= `PATCH /artifacts/{id}/ {"status":"locked"}`). **Promote** (`POST /workloads/{wid}/promote/`, 200) locks the running draft in place, no restart. Runtime-only changes (replicas/resources/autoscaling) → `PATCH /settings/`; a PATCH to the artifact doesn't affect live workloads until you redeploy.
 
-Preconditions (status-match, same-artifact rule + #1074) and the full redeploy matrix: `references/lifecycle-flows.md`.
+Preconditions (status-match, same-artifact rule) and the full redeploy matrix: `references/lifecycle-flows.md`.
 
 ## How does your image get to DataRobot?
 
@@ -298,7 +298,7 @@ httpx.post(f"{base}/workloads/{wid}/replacement/", headers=headers, json={
 })
 ```
 
-Monitor with `python scripts/wait_for_replacement.py <workload_id>`. Preconditions: status must match (draft↔draft / locked↔locked, else `400`); same-artifact replacement 422s for locked (and drafts until #1074/RAPTOR-18806) — to roll the same draft without replacement use `PATCH /settings/`. **Not idempotent** (a second `POST` queues another swap); `GET .../replacement/` `404` = none in progress; `DELETE` to cancel. Detail in `references/lifecycle-flows.md`.
+Monitor with `python scripts/wait_for_replacement.py <workload_id>`. Preconditions: status must match (draft↔draft / locked↔locked, else `400`); same-artifact replacement 422s for locked but works for drafts — to roll the same draft without replacement use `PATCH /settings/`. **Not idempotent** (a second `POST` queues another swap); `GET .../replacement/` `404` = none in progress; `DELETE` to cancel. Detail in `references/lifecycle-flows.md`.
 
 ---
 

--- a/skills/datarobot-workload-api/references/code-to-workload.md
+++ b/skills/datarobot-workload-api/references/code-to-workload.md
@@ -152,10 +152,19 @@ The agent should default to `generated` unless the user explicitly asks otherwis
 
 User edits source → `dr artifact code sync` → `dr artifact build create` → wait for `COMPLETED` → **redeploy the running workload onto the new build.**
 
-How you redeploy depends on whether the artifact ID changes:
+`code sync` + `build create` keep the **same artifact ID** and just advance its `imageUri`. A workload already running does **not** auto-adopt the new build — it keeps its original image until you trigger a redeploy. Two rolling options (zero-downtime at `replicaCount`/`minCount` ≥ 2; a single replica has a brief gap — fine for dev/iteration):
 
-- **Rebuilding the SAME artifact (the usual C2W loop).** `code sync` + `build create` keep the same artifact ID and just advance its `imageUri` — so `POST /workloads/{wid}/replacement/` is **rejected** (`422` "candidate artifact ID matches current artifact"; replacement needs a *different* artifact). Redeploy with **`dr workload stop` → `dr workload start`**: start re-reads the artifact's current spec and its latest `COMPLETED` build. Brief downtime — fine for single-replica dev/iteration.
-- **Zero-downtime.** Create or clone a *new* draft artifact, sync+build it, then `POST /workloads/{wid}/replacement/` onto that new artifact ID (see SKILL.md section 4). This is the only way to roll without a stop.
+- **`PATCH /workloads/{wid}/settings/` (works on any cluster version).** Re-send the runtime body (same shape `GET /workloads/{wid}/settings/` returns); re-sending even the current values unchanged triggers a rolling redeploy that re-reads the artifact's current spec and its latest `COMPLETED` build's `imageUri`. Returns `202`.
+
+  ```
+  PATCH /api/v2/workloads/{wid}/settings/   → 202, rolling redeploy onto the rebuilt image
+  {"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+    "containers": [{"name": "main", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}]}]}}
+  ```
+
+- **`POST /workloads/{wid}/replacement/` onto the same draft artifact** — allowed for **draft** artifacts as of **RAPTOR-18806 (workload-api #1074)**; previously it was rejected with `422 "Cannot replace with the same artifact"`. Adds explicit `warmupDurationMinutes` / `keepOldVersionMinutes` controls (see SKILL.md section 4). Until #1074 ships in the target cluster, same-artifact replacement still 422s for drafts — use the settings-PATCH above. **Locked** artifacts always require a *different* artifact.
+
+Switching to a **different** artifact (promote a newly locked version to production, or a clone) is always `POST /workloads/{wid}/replacement/` onto the new artifact ID.
 
 Do **not** PATCH the artifact spec (env/probes) *between* `build create` and `COMPLETED` — it clobbers the pending `imageUri` auto-populate and you redeploy on the old image (see lifecycle-flows.md). Make spec edits before the build, or after `COMPLETED` with a fresh `GET`.
 

--- a/skills/datarobot-workload-api/references/code-to-workload.md
+++ b/skills/datarobot-workload-api/references/code-to-workload.md
@@ -150,7 +150,14 @@ The agent should default to `generated` unless the user explicitly asks otherwis
 
 ## Iteration loop
 
-User edits source → `dr artifact code sync` → `dr artifact build create` → wait for `COMPLETED` → `POST /workloads/{wid}/replacement/` to roll the running workload onto the new image (see SKILL.md section 4 for the replacement shape).
+User edits source → `dr artifact code sync` → `dr artifact build create` → wait for `COMPLETED` → **redeploy the running workload onto the new build.**
+
+How you redeploy depends on whether the artifact ID changes:
+
+- **Rebuilding the SAME artifact (the usual C2W loop).** `code sync` + `build create` keep the same artifact ID and just advance its `imageUri` — so `POST /workloads/{wid}/replacement/` is **rejected** (`422` "candidate artifact ID matches current artifact"; replacement needs a *different* artifact). Redeploy with **`dr workload stop` → `dr workload start`**: start re-reads the artifact's current spec and its latest `COMPLETED` build. Brief downtime — fine for single-replica dev/iteration.
+- **Zero-downtime.** Create or clone a *new* draft artifact, sync+build it, then `POST /workloads/{wid}/replacement/` onto that new artifact ID (see SKILL.md section 4). This is the only way to roll without a stop.
+
+Do **not** PATCH the artifact spec (env/probes) *between* `build create` and `COMPLETED` — it clobbers the pending `imageUri` auto-populate and you redeploy on the old image (see lifecycle-flows.md). Make spec edits before the build, or after `COMPLETED` with a fresh `GET`.
 
 Each `dr artifact code sync` creates a new catalog version. Each build produces a new image. The artifact tracks the current image. `dr artifact code versions` lists the catalog versions for an artifact (i.e. its code history); `dr artifact code checkout <version_id>` downloads a previous version into `.wapi/.checkouts/` for read-only inspection or rollback.
 

--- a/skills/datarobot-workload-api/references/code-to-workload.md
+++ b/skills/datarobot-workload-api/references/code-to-workload.md
@@ -152,21 +152,9 @@ The agent should default to `generated` unless the user explicitly asks otherwis
 
 User edits source → `dr artifact code sync` → `dr artifact build create` → wait for `COMPLETED` → **redeploy the running workload onto the new build.**
 
-`code sync` + `build create` keep the **same artifact ID** and just advance its `imageUri`. A workload already running does **not** auto-adopt the new build — it keeps its original image until you trigger a redeploy. Two rolling options (zero-downtime at `replicaCount`/`minCount` ≥ 2; a single replica has a brief gap — fine for dev/iteration):
+`code sync` + `build create` keep the **same artifact ID** and only advance its `imageUri`; a running workload does **not** auto-adopt the rebuild until you redeploy. Redeploy the same draft with a rolling `PATCH /workloads/{wid}/settings/` (re-send the runtime body — even unchanged values roll it onto the latest `COMPLETED` build), or, once RAPTOR-18806 (#1074) ships, `POST /workloads/{wid}/replacement/` onto the same draft; switching to a *different* artifact is always a replacement. Full same-draft redeploy matrix and preconditions: `references/lifecycle-flows.md`.
 
-- **`PATCH /workloads/{wid}/settings/` (works on any cluster version).** Re-send the runtime body (same shape `GET /workloads/{wid}/settings/` returns); re-sending even the current values unchanged triggers a rolling redeploy that re-reads the artifact's current spec and its latest `COMPLETED` build's `imageUri`. Returns `202`.
-
-  ```
-  PATCH /api/v2/workloads/{wid}/settings/   → 202, rolling redeploy onto the rebuilt image
-  {"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
-    "containers": [{"name": "main", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}]}]}}
-  ```
-
-- **`POST /workloads/{wid}/replacement/` onto the same draft artifact** — allowed for **draft** artifacts as of **RAPTOR-18806 (workload-api #1074)**; previously it was rejected with `422 "Cannot replace with the same artifact"`. Adds explicit `warmupDurationMinutes` / `keepOldVersionMinutes` controls (see SKILL.md section 4). Until #1074 ships in the target cluster, same-artifact replacement still 422s for drafts — use the settings-PATCH above. **Locked** artifacts always require a *different* artifact.
-
-Switching to a **different** artifact (promote a newly locked version to production, or a clone) is always `POST /workloads/{wid}/replacement/` onto the new artifact ID.
-
-Do **not** PATCH the artifact spec (env/probes) *between* `build create` and `COMPLETED` — it clobbers the pending `imageUri` auto-populate and you redeploy on the old image (see lifecycle-flows.md). Make spec edits before the build, or after `COMPLETED` with a fresh `GET`.
+Do **not** PATCH the artifact spec (env/probes) *between* `build create` and `COMPLETED` — it clobbers the pending `imageUri` auto-populate and you redeploy on the old image. Make spec edits before the build, or after `COMPLETED` with a fresh `GET`.
 
 Each `dr artifact code sync` creates a new catalog version. Each build produces a new image. The artifact tracks the current image. `dr artifact code versions` lists the catalog versions for an artifact (i.e. its code history); `dr artifact code checkout <version_id>` downloads a previous version into `.wapi/.checkouts/` for read-only inspection or rollback.
 

--- a/skills/datarobot-workload-api/references/code-to-workload.md
+++ b/skills/datarobot-workload-api/references/code-to-workload.md
@@ -152,7 +152,7 @@ The agent should default to `generated` unless the user explicitly asks otherwis
 
 User edits source → `dr artifact code sync` → `dr artifact build create` → wait for `COMPLETED` → **redeploy the running workload onto the new build.**
 
-`code sync` + `build create` keep the **same artifact ID** and only advance its `imageUri`; a running workload does **not** auto-adopt the rebuild until you redeploy. Redeploy the same draft with a rolling `PATCH /workloads/{wid}/settings/` (re-send the runtime body — even unchanged values roll it onto the latest `COMPLETED` build), or, once RAPTOR-18806 (#1074) ships, `POST /workloads/{wid}/replacement/` onto the same draft; switching to a *different* artifact is always a replacement. Full same-draft redeploy matrix and preconditions: `references/lifecycle-flows.md`.
+`code sync` + `build create` keep the **same artifact ID** and only advance its `imageUri`; a running workload does **not** auto-adopt the rebuild until you redeploy. Redeploy the same draft with a rolling `PATCH /workloads/{wid}/settings/` (re-send the runtime body — even unchanged values roll it onto the latest `COMPLETED` build), or `POST /workloads/{wid}/replacement/` onto the same draft; switching to a *different* artifact is always a replacement. Full same-draft redeploy matrix and preconditions: `references/lifecycle-flows.md`.
 
 Do **not** PATCH the artifact spec (env/probes) *between* `build create` and `COMPLETED` — it clobbers the pending `imageUri` auto-populate and you redeploy on the old image. Make spec edits before the build, or after `COMPLETED` with a fresh `GET`.
 

--- a/skills/datarobot-workload-api/references/common-error-patterns.md
+++ b/skills/datarobot-workload-api/references/common-error-patterns.md
@@ -140,3 +140,16 @@ When you don't know which pattern applies:
 4. **No specific signal anywhere?** Pull the latest events — the platform's perspective often has the answer the runtime view doesn't.
 
 If steps 1-4 don't yield a specific cause, the issue is in the application code — report logs to the user, don't guess.
+
+## Web UI served through the endpoint behaves wrong
+
+If the workload runs but a **browser-facing web app** served through
+`dr workload endpoint <id>` misbehaves — 404s on assets/API, redirects to the
+DataRobot login (`…?next=%2F`), `401 {"message":"Invalid API key"}` on API
+calls, a login that never sticks, `403 "XSRF cookie does not match"`, or a
+browser Basic-auth "Sign in" modal — the cause is the edge gateway, not a crash.
+Key tell: **a failing request that does NOT appear in `dr workload logs` was
+rejected by the edge before reaching the container** (auth/`Authorization`
+issue). See `references/web-uis-behind-the-edge.md` for the full symptom→fix
+table; the short version is: make the app sub-path aware, disable the app's own
+auth and CSRF, and let the DataRobot edge authenticate.

--- a/skills/datarobot-workload-api/references/lifecycle-flows.md
+++ b/skills/datarobot-workload-api/references/lifecycle-flows.md
@@ -15,12 +15,12 @@ create  →  iterate (PATCH while draft)  →  lock  →  rolling replacement
 - When `locked`: artifact becomes immutable. Any edit requires `POST /artifacts/{id}/clone/` (produces a new draft in the same artifact repository), then PATCH on the clone.
 - Once locked, to deploy changes you trigger a **rolling replacement** on the workload (`POST /workloads/{wid}/replacement/`). Promote is the alternative for the in-place draft→locked case.
 
-## Replacement preconditions — and the draft same-artifact exception (RAPTOR-18806)
+## Replacement preconditions — and the draft same-artifact exception
 
 `POST /workloads/{id}/replacement/` enforces two preconditions the spec doesn't spell out:
 
 1. **Status must match.** **HTTP 400** `{"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running artifact's (draft↔draft, locked↔locked).
-2. **Same-artifact rule — being relaxed for drafts.** Passing the *current* `artifactId` returns **HTTP 422** `{"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` for **locked** artifacts, always. For **drafts** it was also rejected, but workload-api **#1074 (RAPTOR-18806) allows same-artifact replacement when the artifact is a draft** — so the C2W rebuild-then-replace loop works. Until #1074 has shipped in the target cluster, treat draft same-artifact replacement as still-422 and roll via `PATCH /settings/` (below).
+2. **Same-artifact rule — drafts exempt.** Passing the *current* `artifactId` returns **HTTP 422** `{"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` for **locked** artifacts. **Drafts are exempt: same-artifact replacement is allowed when the artifact is a draft** — so the C2W rebuild-then-replace loop works.
 
 Neither rule is in the spec's path docs. There is no `dr workload replacement` CLI subcommand; replacement is REST-only.
 
@@ -31,7 +31,7 @@ Neither rule is in the spec's path docs. There is no `dr workload replacement` C
 | Goal | Do this |
 |---|---|
 | roll onto the latest build / spec (works on **any** cluster version) | `PATCH /workloads/{id}/settings/` — re-send the runtime body (same shape `GET /workloads/{id}/settings/` returns; even unchanged values trigger the roll). It re-reads the artifact's current spec + its latest `COMPLETED` build's `imageUri`. Returns `202`. |
-| same, but want explicit warmup / rollback-window controls | `POST /replacement/` onto the same draft — **after #1074/RAPTOR-18806**; 422s before it ships |
+| same, but want explicit warmup / rollback-window controls | `POST /replacement/` onto the same draft |
 | lock the running draft in place | `POST /workloads/{id}/promote/` (no restart) |
 | switch to a different / newly-locked artifact | `POST /replacement/` onto the other artifact ID |
 | locked → new content | clone → patch the draft → lock the new draft → `POST /replacement/` onto the clone |
@@ -44,7 +44,7 @@ Neither rule is in the spec's path docs. There is no `dr workload replacement` C
 - Workload's `artifactId` keeps pointing at the same artifact (now locked).
 - Running pods are NOT restarted. Traffic uninterrupted.
 
-If you also need a rolling *restart* to apply new env vars from a recent PATCH, roll the workload onto the (same) draft's current spec with `PATCH /workloads/{wid}/settings/` — re-send the runtime body (even unchanged values trigger the rolling redeploy). Same-artifact `POST /replacement/` also works for drafts once #1074/RAPTOR-18806 ships. The intent split: promote = "the running version IS production"; replacement = "deploy a *different* artifact" (or the same draft, post-#1074); settings-PATCH = "restart onto the same artifact's latest spec/build".
+If you also need a rolling *restart* to apply new env vars from a recent PATCH, roll the workload onto the (same) draft's current spec with `PATCH /workloads/{wid}/settings/` — re-send the runtime body (even unchanged values trigger the rolling redeploy). Same-artifact `POST /replacement/` also works for drafts. The intent split: promote = "the running version IS production"; replacement = "deploy a *different* artifact" (or the same draft); settings-PATCH = "restart onto the same artifact's latest spec/build".
 
 ## PATCH on multi-container artifacts replaces the whole `containerGroups` array
 

--- a/skills/datarobot-workload-api/references/lifecycle-flows.md
+++ b/skills/datarobot-workload-api/references/lifecycle-flows.md
@@ -15,21 +15,26 @@ create  →  iterate (PATCH while draft)  →  lock  →  rolling replacement
 - When `locked`: artifact becomes immutable. Any edit requires `POST /artifacts/{id}/clone/` (produces a new draft in the same artifact repository), then PATCH on the clone.
 - Once locked, to deploy changes you trigger a **rolling replacement** on the workload (`POST /workloads/{wid}/replacement/`). Promote is the alternative for the in-place draft→locked case.
 
-## Replacement preconditions — two rejections agents hit
+## Replacement preconditions — and the draft same-artifact exception (RAPTOR-18806)
 
-`POST /workloads/{id}/replacement/` enforces **two** preconditions the spec doesn't spell out. Both must hold or the call is rejected:
+`POST /workloads/{id}/replacement/` enforces two preconditions the spec doesn't spell out:
 
-1. **The candidate must be a DIFFERENT artifact than the one running.** Passing the current `artifactId` (e.g. after PATCH-ing or rebuilding the draft the workload already runs) returns **HTTP 422**: `{"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}`. Replacement means "swap to another artifact version" — it is never how you apply an in-place edit to the current one.
-2. **Status must match.** **HTTP 400** `{"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running artifact's.
+1. **Status must match.** **HTTP 400** `{"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running artifact's (draft↔draft, locked↔locked).
+2. **Same-artifact rule — being relaxed for drafts.** Passing the *current* `artifactId` returns **HTTP 422** `{"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}` for **locked** artifacts, always. For **drafts** it was also rejected, but workload-api **#1074 (RAPTOR-18806) allows same-artifact replacement when the artifact is a draft** — so the C2W rebuild-then-replace loop works. Until #1074 has shipped in the target cluster, treat draft same-artifact replacement as still-422 and roll via `PATCH /settings/` (below).
 
-| Workload currently runs | Goal | Do this |
-|---|---|---|
-| draft | apply an in-place change (env/probes/port or a new build) to the **same** draft | PATCH/rebuild that draft, then `stop` → `start` (NOT replacement — same artifact ID 422s) |
-| draft | zero-downtime swap | clone or create a **new** draft, change it, build it, `POST /replacement/` onto the **new** draft (draft↔draft) |
-| draft | lock the same artifact in place | `POST /workloads/{id}/promote/` (no restart) |
-| locked | deploy new content | clone → patch the draft → lock the new draft → `POST /replacement/` onto the clone (locked↔locked) |
+Neither rule is in the spec's path docs. There is no `dr workload replacement` CLI subcommand; replacement is REST-only.
 
-Neither rule is in the spec's path docs — agents have to know them from the error responses or from this reference. There is no `dr workload replacement` CLI subcommand; replacement is REST-only.
+### Applying a change to the SAME draft a workload runs
+
+`code sync` + `build create` (or a spec PATCH) keep the same artifact ID; a running workload does **not** auto-adopt the change — trigger a redeploy. Options, all rolling (zero-downtime at `replicaCount`/`minCount` ≥ 2; a single replica has a brief gap):
+
+| Goal | Do this |
+|---|---|
+| roll onto the latest build / spec (works on **any** cluster version) | `PATCH /workloads/{id}/settings/` — re-send the runtime body (same shape `GET /workloads/{id}/settings/` returns; even unchanged values trigger the roll). It re-reads the artifact's current spec + its latest `COMPLETED` build's `imageUri`. Returns `202`. |
+| same, but want explicit warmup / rollback-window controls | `POST /replacement/` onto the same draft — **after #1074/RAPTOR-18806**; 422s before it ships |
+| lock the running draft in place | `POST /workloads/{id}/promote/` (no restart) |
+| switch to a different / newly-locked artifact | `POST /replacement/` onto the other artifact ID |
+| locked → new content | clone → patch the draft → lock the new draft → `POST /replacement/` onto the clone |
 
 ## Promote — in-place lock without restart
 
@@ -39,7 +44,7 @@ Neither rule is in the spec's path docs — agents have to know them from the er
 - Workload's `artifactId` keeps pointing at the same artifact (now locked).
 - Running pods are NOT restarted. Traffic uninterrupted.
 
-If you also need a rolling *restart* to apply new env vars from a recent PATCH, do **not** reach for `POST /replacement/` with the same artifact ID — that 422s ("candidate artifact ID matches current artifact"). To restart the workload onto the same artifact's current spec, use `stop` → `start` (brief downtime). The intent split: promote = "the running version IS production"; replacement = "deploy a *different* artifact".
+If you also need a rolling *restart* to apply new env vars from a recent PATCH, roll the workload onto the (same) draft's current spec with `PATCH /workloads/{wid}/settings/` — re-send the runtime body (even unchanged values trigger the rolling redeploy). Same-artifact `POST /replacement/` also works for drafts once #1074/RAPTOR-18806 ships. The intent split: promote = "the running version IS production"; replacement = "deploy a *different* artifact" (or the same draft, post-#1074); settings-PATCH = "restart onto the same artifact's latest spec/build".
 
 ## PATCH on multi-container artifacts replaces the whole `containerGroups` array
 

--- a/skills/datarobot-workload-api/references/lifecycle-flows.md
+++ b/skills/datarobot-workload-api/references/lifecycle-flows.md
@@ -15,18 +15,21 @@ create  →  iterate (PATCH while draft)  →  lock  →  rolling replacement
 - When `locked`: artifact becomes immutable. Any edit requires `POST /artifacts/{id}/clone/` (produces a new draft in the same artifact repository), then PATCH on the clone.
 - Once locked, to deploy changes you trigger a **rolling replacement** on the workload (`POST /workloads/{wid}/replacement/`). Promote is the alternative for the in-place draft→locked case.
 
-## Replacement status-match rule
+## Replacement preconditions — two rejections agents hit
 
-The API rejects `POST /workloads/{id}/replacement/` with **HTTP 400** unless the new artifact's status matches the currently-running artifact's:
+`POST /workloads/{id}/replacement/` enforces **two** preconditions the spec doesn't spell out. Both must hold or the call is rejected:
 
-| Workload currently runs | New artifact must be | Use |
+1. **The candidate must be a DIFFERENT artifact than the one running.** Passing the current `artifactId` (e.g. after PATCH-ing or rebuilding the draft the workload already runs) returns **HTTP 422**: `{"detail": ["Cannot replace with the same artifact — candidate artifact ID matches current artifact."]}`. Replacement means "swap to another artifact version" — it is never how you apply an in-place edit to the current one.
+2. **Status must match.** **HTTP 400** `{"detail": "Artifact status mismatch: ..."}` unless the candidate's status matches the running artifact's.
+
+| Workload currently runs | Goal | Do this |
 |---|---|---|
-| draft | draft | `POST /workloads/{id}/replacement/` |
-| draft | want to lock the same artifact | `POST /workloads/{id}/promote/` (no restart) |
-| locked | locked | `POST /workloads/{id}/replacement/` |
-| locked | want new content | clone → patch the draft → lock the new draft → `POST /workloads/{id}/replacement/` |
+| draft | apply an in-place change (env/probes/port or a new build) to the **same** draft | PATCH/rebuild that draft, then `stop` → `start` (NOT replacement — same artifact ID 422s) |
+| draft | zero-downtime swap | clone or create a **new** draft, change it, build it, `POST /replacement/` onto the **new** draft (draft↔draft) |
+| draft | lock the same artifact in place | `POST /workloads/{id}/promote/` (no restart) |
+| locked | deploy new content | clone → patch the draft → lock the new draft → `POST /replacement/` onto the clone (locked↔locked) |
 
-This rule is enforced server-side but isn't called out in the spec's path documentation — agents have to know it from the error response or from this reference.
+Neither rule is in the spec's path docs — agents have to know them from the error responses or from this reference. There is no `dr workload replacement` CLI subcommand; replacement is REST-only.
 
 ## Promote — in-place lock without restart
 
@@ -36,7 +39,7 @@ This rule is enforced server-side but isn't called out in the spec's path docume
 - Workload's `artifactId` keeps pointing at the same artifact (now locked).
 - Running pods are NOT restarted. Traffic uninterrupted.
 
-If you also need a rolling restart in addition to the lock (e.g. to pick up new env vars from a recent PATCH), follow with `POST /workloads/{wid}/replacement/` using the same artifact ID. The intent split: promote = "the running version IS production"; replacement = "deploy a different version".
+If you also need a rolling *restart* to apply new env vars from a recent PATCH, do **not** reach for `POST /replacement/` with the same artifact ID — that 422s ("candidate artifact ID matches current artifact"). To restart the workload onto the same artifact's current spec, use `stop` → `start` (brief downtime). The intent split: promote = "the running version IS production"; replacement = "deploy a *different* artifact".
 
 ## PATCH on multi-container artifacts replaces the whole `containerGroups` array
 
@@ -48,7 +51,8 @@ Also: don't include `spec.type` in PATCH bodies — it's a read-only discriminat
 
 If the artifact was created with `imageBuildConfig` referencing source code in DataRobot Files, the platform can build the image. Triggered with `POST /artifacts/{id}/builds/`; poll via `scripts/wait_for_build.py`. Two non-spec behaviors:
 
-- On success, the platform **populates the artifact's `imageUri` automatically**. Re-`GET` the artifact to see it; don't PATCH it manually. If both `imageBuildConfig` and `imageUri` are supplied at create time, the build overwrites `imageUri` on completion.
+- On success, the platform **populates the artifact's `imageUri` automatically**. Re-`GET` the artifact to see it. Do **not** set `imageUri` by hand — a manual `PATCH` of it returns `422 {"detail": "Image URI '...' is not permitted on this cluster."}` (only build-produced images are allowed). If both `imageBuildConfig` and `imageUri` are supplied at create time, the build overwrites `imageUri` on completion.
+- **Do not PATCH the artifact spec while a build is in progress.** A spec PATCH is a whole-spec read-modify-write, so it sends back the *pre-build* `imageUri` and clobbers the completion's auto-populate — the artifact keeps pointing at the **old** image and the next deploy silently runs stale code. Sequence spec edits (env/probes) *before* `build create`, or *after* `COMPLETED` with a fresh `GET` so the PATCH carries the new `imageUri`. After `COMPLETED`, confirm `imageUri` advanced before redeploying.
 - Status sequence: `PENDING` → `IN_PROGRESS` → `BUILT` → `COMPLETED` (or → `FAILED`). **`BUILT` is intermediate** — image built locally but not yet pushed to the registry. Only `COMPLETED` is deployable; scheduling a workload on a `BUILT` artifact returns `422 runtime_image_uri ... None`. `wait_for_build.py` waits for `COMPLETED` specifically.
 - Only drafts can build. Builds for locked artifacts can't be triggered or deleted.
 

--- a/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
+++ b/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
@@ -58,9 +58,34 @@ responses. So the app has two seemingly contradictory needs:
 
 A thin **prefix shim** reconciles the two: tell the app its external mount point
 is the prefix (fixes outbound), and route on the stripped path the app actually
-received (fixes inbound). Pass the prefix in via an env var
-(`WORKLOAD_BASE_PATH`) set from `dr workload endpoint <id>` so the image stays
-generic.
+received (fixes inbound).
+
+**Derive the prefix from `WORKLOAD_ID` — don't pass it in.** The endpoint path is
+always `/api/v2/endpoints/workloads/<workload-id>`, and DataRobot **auto-injects
+the managed env var `WORKLOAD_ID`** into every workload container. Build the
+prefix from it at startup — no extra env var to plumb through, and it stays
+correct across rebuilds/replacements (the workload ID never changes):
+
+```python
+import os
+PREFIX = f"/api/v2/endpoints/workloads/{os.environ['WORKLOAD_ID']}"  # no trailing slash
+```
+
+(That's the same path `dr workload endpoint <id>` prints, minus scheme/host — no
+need to fetch or hardcode it.)
+
+> **Caveat — proton-id URL paths need an explicit override.** The
+> `WORKLOAD_ID`-derived prefix only matches the workload-id endpoint
+> (`/api/v2/endpoints/workloads/<workload-id>/`). The same workload is also
+> addressable by a **proton-id** path (`/protons/<proton-id>/…` — e.g. how
+> internal routing/health probes reach it), and that prefix is different *and*
+> changes on every replacement (each roll creates a new proton). The proton ID
+> is **not** injected into the container env, so it can't be derived at startup
+> like `WORKLOAD_ID` is. If you actually need to serve under the proton-id path,
+> set the base-path prefix **explicitly** via your own env var
+> (e.g. `WORKLOAD_BASE_PATH`) instead of deriving it — and update it whenever the
+> proton changes. For the normal browser-facing workload-id endpoint, the
+> `WORKLOAD_ID` derivation above is all you need.
 
 **Preferred: use the framework's mount setting (no custom code).** Most WSGI /
 ASGI apps already implement exactly this via `SCRIPT_NAME` / `root_path`:
@@ -69,8 +94,6 @@ ASGI apps already implement exactly this via `SCRIPT_NAME` / `root_path`:
 # WSGI (Flask/Django/Bottle/...). The edge already stripped the prefix, so
 # PATH_INFO is the in-mount path; SCRIPT_NAME tells the app its external mount,
 # and the framework prepends it to url_for()/redirect()/static URLs.
-PREFIX = os.environ["WORKLOAD_BASE_PATH"].rstrip("/")   # e.g. /api/v2/endpoints/workloads/<id>
-
 def prefix_shim(app):
     def wrapped(environ, start_response):
         environ["SCRIPT_NAME"] = PREFIX          # outbound URLs + redirects now carry PREFIX
@@ -81,9 +104,9 @@ application = prefix_shim(application)
 ```
 
 - **ASGI** (FastAPI/Starlette): the same idea is built in — run
-  `uvicorn --root-path "$WORKLOAD_BASE_PATH"` (or set `root_path` on the app).
-  Starlette prepends `root_path` to `url_for`/redirects and routes on the
-  received path.
+  `uvicorn --root-path "/api/v2/endpoints/workloads/$WORKLOAD_ID"` (or set
+  `root_path` on the app from the env var). Starlette prepends `root_path` to
+  `url_for`/redirects and routes on the received path.
 - **Streamlit / Shiny / SPA**: use the base-path option
   (`--server.baseUrlPath`, `server.rootUrl`, `<base href>`), no middleware.
 
@@ -206,8 +229,8 @@ app problem (sub-path/CSRF).
 
 ## Minimal checklist for "serve my web app through the endpoint"
 
-1. Read the prefix from `dr workload endpoint <id>`; feed it to the app as a
-   base-path env var.
+1. Build the prefix at startup from the auto-injected `WORKLOAD_ID`:
+   `/api/v2/endpoints/workloads/$WORKLOAD_ID` (no extra env var to pass).
 2. Set the app's base-path/root-path to that prefix; add an inbound
    prefix-restoring shim (or a reverse-proxy rewrite) if the framework couples
    inbound routing to the base-path.

--- a/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
+++ b/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
@@ -150,7 +150,7 @@ def fix_location(app):
         def sr(status, headers, exc=None):
             headers = [
                 (k, PREFIX + v if k.lower() == "location"
-                       and v.startswith("/") and not v.startswith(PREFIX + "/") else v)
+                       and v.startswith("/") and v != PREFIX and not v.startswith(PREFIX + "/") else v)
                 for k, v in headers
             ]
             return start_response(status, headers, exc)

--- a/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
+++ b/skills/datarobot-workload-api/references/web-uis-behind-the-edge.md
@@ -1,0 +1,221 @@
+# Serving a web UI (and its backend) through the workload endpoint
+
+Applies whenever a workload **exposes a port that serves a browser-facing web
+app** — a UI plus its own backend/API/WebSocket — and users reach it through
+`dr workload endpoint <id>`. This is framework-agnostic (Jupyter, Streamlit,
+Gradio, a SPA + REST/gRPC-web backend, Shiny, a plain Flask/Express app, …).
+It is NOT needed for headless services called machine-to-machine.
+
+## How the DataRobot edge gateway serves the endpoint
+
+`dr workload endpoint <id>` returns a URL under a **path prefix**, e.g.
+
+```
+https://app.datarobot.com/api/v2/endpoints/workloads/<id>/
+```
+
+Four behaviors of that edge gateway drive everything below. Verify them for the
+target cluster, but they held on MTSaaS as of this writing:
+
+1. **The prefix is STRIPPED inbound.** The browser requests
+   `…/workloads/<id>/lab`; the container receives `/lab`. Confirm from
+   `dr workload logs` — the app logs the *stripped* path.
+2. **The gateway authenticates access.** A user must be logged into DataRobot
+   to reach the endpoint at all; an unauthenticated request is met with the
+   platform's own challenge (you may see a browser Basic-auth "Sign in" modal
+   if the DataRobot session is missing/expired). The edge is the auth gate.
+3. **The `Authorization` header is consumed by the platform.** Because the
+   endpoint lives under `/api/v2/`, the edge treats an inbound `Authorization`
+   header as a *DataRobot* API key. An app (or app frontend) that sends
+   `Authorization: Bearer …`/`token …` to its own backend gets
+   `401 {"message": "Invalid API key"}` **from the edge — the request never
+   reaches the container** (it won't appear in `dr workload logs`).
+4. **Responses are NOT rewritten.** The edge does not re-add the prefix to the
+   app's redirect `Location` headers, HTML, or asset URLs; and it does not
+   inject `X-Forwarded-Prefix` you can rely on. What the app emits is what the
+   browser gets.
+
+**WebSockets are supported** — `wss://…/workloads/<id>/…` upgrades pass through
+to the container. Real-time UIs work; no special handling beyond the sub-path
+rules below.
+
+## The four things a web app must do
+
+### 1. Be prefix-aware — the "prefix shim"
+
+This is the non-obvious one; it cost the most time to figure out, so understand
+the shape before writing code.
+
+**The bind.** Every URL the app emits — asset tags, API/XHR calls, the
+WebSocket URL, and HTTP redirect `Location`s — must carry the endpoint prefix,
+or the browser resolves it against the origin root and it escapes the workload
+(→ 404, or a redirect that lands on the DataRobot app login). But the edge
+delivers requests with the prefix **stripped** and does **not** rewrite
+responses. So the app has two seemingly contradictory needs:
+
+- **emit** URLs *with* the prefix (so the browser stays inside the workload), yet
+- **match** inbound requests that arrive *without* it.
+
+A thin **prefix shim** reconciles the two: tell the app its external mount point
+is the prefix (fixes outbound), and route on the stripped path the app actually
+received (fixes inbound). Pass the prefix in via an env var
+(`WORKLOAD_BASE_PATH`) set from `dr workload endpoint <id>` so the image stays
+generic.
+
+**Preferred: use the framework's mount setting (no custom code).** Most WSGI /
+ASGI apps already implement exactly this via `SCRIPT_NAME` / `root_path`:
+
+```python
+# WSGI (Flask/Django/Bottle/...). The edge already stripped the prefix, so
+# PATH_INFO is the in-mount path; SCRIPT_NAME tells the app its external mount,
+# and the framework prepends it to url_for()/redirect()/static URLs.
+PREFIX = os.environ["WORKLOAD_BASE_PATH"].rstrip("/")   # e.g. /api/v2/endpoints/workloads/<id>
+
+def prefix_shim(app):
+    def wrapped(environ, start_response):
+        environ["SCRIPT_NAME"] = PREFIX          # outbound URLs + redirects now carry PREFIX
+        return app(environ, start_response)      # route on PATH_INFO (already stripped) = matches
+    return wrapped
+
+application = prefix_shim(application)
+```
+
+- **ASGI** (FastAPI/Starlette): the same idea is built in — run
+  `uvicorn --root-path "$WORKLOAD_BASE_PATH"` (or set `root_path` on the app).
+  Starlette prepends `root_path` to `url_for`/redirects and routes on the
+  received path.
+- **Streamlit / Shiny / SPA**: use the base-path option
+  (`--server.baseUrlPath`, `server.rootUrl`, `<base href>`), no middleware.
+
+**Fallback: frameworks that couple routing to the base-path (Tornado / Jupyter).**
+Here setting the base-path makes the server expect the prefix to be *present in
+the request path*, so the stripped inbound requests 404. Set the base-path to
+the prefix (for outbound) **and** re-add the prefix to the inbound request path
+before routing:
+
+```python
+# Tornado/Jupyter: base_url is set to PREFIX (outbound). This shim re-adds the
+# stripped prefix to the inbound path so base_url-mounted handlers match.
+# Idempotent: a request that already carries the prefix (e.g. an in-cluster
+# probe hitting the prefixed path) passes untouched.
+_orig = Application.find_handler
+def find_handler(self, request, **kw):
+    p = request.path or "/"
+    if p != PREFIX and not p.startswith(PREFIX + "/"):
+        request.path = PREFIX + p
+        request.uri  = request.path + (f"?{request.query}" if request.query else "")
+    return _orig(self, request, **kw)
+Application.find_handler = find_handler
+```
+
+A reverse proxy baked into the image (nginx `sub_filter`/rewrite, Traefik
+`StripPrefix`/`AddPrefix`) can play the same role. The shim also lets **health
+probes** hit either the bare or prefixed path (see #4).
+
+**Redirects specifically.** With the mount configured, framework-issued
+redirects already include the prefix. The trap is app code that hardcodes
+*root-relative* redirects or links (`redirect("/home")`, `href="/x"`): those
+bypass the mount and escape the prefix. Fix them to use the framework's URL
+builder / relative links, or rewrite stray outbound `Location`s as a last
+resort:
+
+```python
+# Prepend PREFIX to any root-relative Location the app emits (WSGI).
+# Guarded so links the framework already prefixed aren't doubled.
+def fix_location(app):
+    def wrapped(environ, start_response):
+        def sr(status, headers, exc=None):
+            headers = [
+                (k, PREFIX + v if k.lower() == "location"
+                       and v.startswith("/") and not v.startswith(PREFIX + "/") else v)
+                for k, v in headers
+            ]
+            return start_response(status, headers, exc)
+        return app(environ, sr)
+    return wrapped
+```
+
+### 2. Disable the app's built-in auth — let the edge be the gate
+
+The edge already requires a DataRobot login to reach the endpoint (behavior
+#2). Running the app's own token/password/cookie auth on top is redundant AND
+actively breaks here:
+
+- a bearer token the frontend sends is hijacked by the edge (behavior #3);
+- the app's own login **cookies often don't round-trip** through the gateway,
+  so the session never sticks (login POST returns a redirect, then every page
+  bounces back to the login screen).
+
+So configure the app to **trust the proxy / allow unauthenticated access**, and
+rely on the DataRobot edge for authentication. Concretely: turn off token auth
+(so no bearer header is ever sent), turn off password/login, and enable
+anonymous access. Framework examples: Jupyter
+`ServerApp.token=""` + `allow_unauthenticated_access=True`; Streamlit has no
+auth by default (fine); a FastAPI/Express app should skip its auth middleware
+on this deployment.
+
+> **Security — confirm the gate before disabling app auth.** Only disable the
+> app's auth once you have confirmed the endpoint genuinely requires a
+> DataRobot login (open the URL in a private window with no DataRobot session;
+> you should be blocked). If confirmed, access is gated by the DataRobot login
+> and RBAC on the workload. If NOT (endpoint publicly reachable), keeping the
+> app's auth is required — but then you must solve behaviors #3/#4 another way
+> (e.g. cookie-only auth with unique cookie names and no `Authorization`
+> header). Never leave a code-executing app both reachable and unauthenticated.
+
+### 3. Neutralize shared-origin cookie/CSRF collisions
+
+The app is served from the same origin as the DataRobot app (e.g.
+`app.datarobot.com`), which sets its own cookies (commonly `_xsrf`,
+session cookies). A same-named cookie from the app collides — the server may
+read the platform's value and fail its CSRF check (e.g. Jupyter's
+`403 "XSRF cookie does not match POST argument"`).
+
+- Prefer **disabling the app's CSRF check** when app auth is already disabled
+  and access is edge-gated (there is no app session to forge).
+- Renaming the app's CSRF cookie is often NOT viable: compiled frontends
+  frequently hard-code the cookie name (e.g. JupyterLab reads `_xsrf` to build
+  its `X-XSRFToken` header), so a rename blinds the frontend and every API call
+  then fails the check. Test before relying on a rename.
+
+### 4. Probe a path that exists WITHOUT auth
+
+Health probes hit the container directly (not through the edge). Once app auth
+is disabled, login routes may disappear (e.g. `/login` → 404), so a probe
+pointed at them fails and the workload never goes ready. Point
+`readinessProbe`/`livenessProbe` at a lightweight, always-available endpoint
+(a dedicated `/healthz`, or the app's status route). With the inbound shim in
+place, an unprefixed probe path works because the shim re-adds the prefix.
+
+## Diagnostic playbook (symptom → cause → fix)
+
+Always cross-check `dr workload logs <id>`: **if a failing request does NOT
+appear in the pod logs, the edge rejected it before the container** (an
+edge/auth problem — behaviors #2/#3); if it appears with a status code, it's an
+app problem (sub-path/CSRF).
+
+| Symptom in the browser | Root cause | Fix |
+|---|---|---|
+| After login you land on the DataRobot app login, URL `…?next=%2F` | App emitted a root-relative redirect (`Location: /`) that escaped the prefix | Set base-path to the prefix + inbound shim (#1) |
+| UI shell loads but assets/API 404; pod otherwise healthy | Proxy strips prefix; app base-path is `/` so generated URLs miss the prefix | #1 (base-path + shim) |
+| `401 {"message":"Invalid API key"}` on API/XHR; those requests **absent** from pod logs | Edge hijacked the app's `Authorization` header (#3) | Disable app token auth so no bearer header is sent (#2) |
+| Login "succeeds" (302) but every page bounces back to login | App login cookie not round-tripping through the edge | Disable app auth, trust the edge (#2) |
+| Browser-native username/password "Sign in" modal | Edge Basic challenge — no DataRobot session in the browser | Log into DataRobot first; the edge, not the app, is prompting |
+| `403 "XSRF cookie does not match"` on POST/login | `_xsrf` (or other) cookie collides with the DataRobot app's on the shared origin | Disable app CSRF check (#3) |
+| Workload never leaves `launching`; probe 404/401 on a login path | Probe points at a route that no longer exists (auth disabled) or is edge-gated | Point probes at an unauthenticated app path (#4) |
+
+## Minimal checklist for "serve my web app through the endpoint"
+
+1. Read the prefix from `dr workload endpoint <id>`; feed it to the app as a
+   base-path env var.
+2. Set the app's base-path/root-path to that prefix; add an inbound
+   prefix-restoring shim (or a reverse-proxy rewrite) if the framework couples
+   inbound routing to the base-path.
+3. Disable the app's own authentication and enable anonymous access — after
+   confirming the endpoint requires a DataRobot login.
+4. Disable the app's CSRF check (or verify a cookie rename doesn't break the
+   frontend).
+5. Point liveness/readiness probes at an unauthenticated path.
+6. Verify end to end: open the endpoint while logged into DataRobot; the UI
+   loads under the prefix, API calls return 2xx (visible in `dr workload logs`),
+   and any WebSocket connects.


### PR DESCRIPTION
## RATIONALE

It took awhile to resolve these issues when attempting to deploy a Jupyter notebook on Workload API and access the UI.  This improves the skill so future attempts go more smoothly for similar apps serving a UI and need to be configured to work with the DataRobot edge proxy.

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1784743149.239509 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent skills; no runtime or API behavior changes.
> 
> **Overview**
> Documents how to run **browser-facing web apps** (e.g. Jupyter) through `dr workload endpoint` via a new **`references/web-uis-behind-the-edge.md`**: path-prefix stripping vs outbound URLs, DataRobot as the auth gate, **`Authorization` hijacking**, CSRF/cookie collisions, prefix shims, probes, and a symptom→fix table. **`SKILL.md`** adds a short operational section and links the reference; **`common-error-patterns.md`** points edge/UI failures there.
> 
> **Corrects a common agent mistake** around artifact rollout: **`POST /workloads/{id}/replacement/` requires a different `artifactId`** than the one running (same ID → **422**). In-place updates on the **same draft** (PATCH/rebuild/C2W loop) should use **`dr workload stop` → `start`**, not replacement; zero-downtime still needs clone/new draft + replacement. Docs also note **no `dr workload replacement` CLI**, status-match **400**, and **`imageUri` is build-managed** (no manual PATCH; avoid spec PATCH during an in-flight build).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753f3aece79d9f052099bc8023d3393c84d2606a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->