### PR TITLE
[CFX-6981] Source LLM model selection from the DataRobot CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.3.10"
+      "version": "1.3.11"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.3.10"
+  "version": "1.3.11"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+- `datarobot-agent-assist`: Source model selection from the DataRobot CLI. `list_llm_models.py` now delegates to `dr llm-gateway list --output-format json` instead of calling the LLM Gateway catalog endpoint directly, so the skill and the CLI agree on what is available and pick up CLI-side catalog fixes for free. Project `.env` credentials are passed through to the CLI.
 - `datarobot-agent-assist`: Merge pre-coding spec gate into `pre-coding-checklist.md` Bootstrap step 2 (removes duplicate "Before Coding Begins" section). Add missing-spec recovery, path validation, session flags, workspace ask-don't-guess for Code, and journey deduplication. Trim `SKILL.md`: move CLI setup, helper scripts, plugin tool mapping, dress rehearsal prompt, path resolution, and agent_spec schema into references. Flow polish: Code-no-spec merges with Path resolution step 1, schema read hook in Spec Display, `design_to_code` guard and Windows stop in pre-coding, welcome menu resets `design_messy_cwd`.
 
 ## [1.3.9] - 2026-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
-- `datarobot-agent-assist`: Source model selection from the DataRobot CLI. `list_llm_models.py` now delegates to `dr llm-gateway list --output-format json` instead of calling the LLM Gateway catalog endpoint directly, so the skill and the CLI agree on what is available and pick up CLI-side catalog fixes for free. Project `.env` credentials are passed through to the CLI.
 - `datarobot-agent-assist`: Merge pre-coding spec gate into `pre-coding-checklist.md` Bootstrap step 2 (removes duplicate "Before Coding Begins" section). Add missing-spec recovery, path validation, session flags, workspace ask-don't-guess for Code, and journey deduplication. Trim `SKILL.md`: move CLI setup, helper scripts, plugin tool mapping, dress rehearsal prompt, path resolution, and agent_spec schema into references. Flow polish: Code-no-spec merges with Path resolution step 1, schema read hook in Spec Display, `design_to_code` guard and Windows stop in pre-coding, welcome menu resets `design_messy_cwd`.
+
+## [1.3.11] - 2026-07-29
+
+- `datarobot-agent-assist`: Source model selection from the DataRobot CLI. `list_llm_models.py` now delegates to `dr llm-gateway list --output-format json` instead of calling the LLM Gateway catalog endpoint directly, so the skill and the CLI agree on what is available and pick up CLI-side catalog fixes for free. Project `.env` credentials are passed through to the CLI.
 
 ## [1.3.9] - 2026-07-22
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-agent-assist/references/helper-scripts.md
+++ b/skills/datarobot-agent-assist/references/helper-scripts.md
@@ -16,6 +16,18 @@ Project `.env` belongs at `<target_dir>/.env` only. Scripts that read or create 
 
 Do not run `dr dotenv setup` manually in cwd when designing in a subdirectory.
 
+### list_llm_models.py
+
+Lists the LLMs available for the agent's `model` field. Delegates to `dr llm-gateway list --output-format json`, so the skill and the CLI never disagree about what is available — which makes the [DataRobot CLI](dr-cli-setup.md) a hard requirement of model selection, not just of deployment.
+
+```bash
+python <skill_scripts_dir>/list_llm_models.py \
+  --json \
+  --target-dir <target_dir>
+```
+
+`<target_dir>/.env` credentials are passed through to the CLI. When they are absent or stale the CLI falls back to its own authenticated profile, so verify `dr auth check` if the listing looks like the wrong DataRobot instance.
+
 ### clone_template.py
 
 Clones the DataRobot agent application template repository (URL and tag are defined in the script):

--- a/skills/datarobot-agent-assist/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/scripts/list_llm_models.py
@@ -4,8 +4,9 @@
 
 """List available LLM models from DataRobot LLM Gateway.
 
-This script fetches and displays active models from the DataRobot LLM Gateway catalog.
-Designed to be used by AI agents to discover available LLM models.
+This script fetches and displays active models from the DataRobot LLM Gateway catalog
+by delegating to the DataRobot CLI (`dr llm-gateway list`), so the skill and the CLI
+always agree on what "available" means.
 
 Usage:
     python list_llm_models.py [--json|--table] [--target-dir <directory>]
@@ -17,13 +18,27 @@ Environment Variables:
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
-from typing import TypedDict
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from typing import Any, TypedDict
 
 from env_utils import get_datarobot_credentials
+
+# `dr llm-gateway list --output-format json` prints {"llms": [...]} on stdout.
+DR_LLM_LIST_CMD = ["dr", "llm-gateway", "list", "--output-format", "json"]
+DR_LLM_LIST_ENVELOPE_KEY = "llms"
+
+# The CLI falls back to an interactive login when the credentials it is handed do
+# not verify. stdin is closed so that prompt fails fast instead of blocking, and
+# the timeout is the backstop for a prompt that ignores EOF.
+DR_LLM_LIST_TIMEOUT = 90
+
+# Kind discriminator on each CLI entry. Only gateway catalog models are returned
+# here; a `dr` predating the deployed-LLM support omits the field entirely, so a
+# missing value is read as "gateway".
+SOURCE_GATEWAY = "gateway"
 
 
 class LLMModel(TypedDict):
@@ -33,8 +48,99 @@ class LLMModel(TypedDict):
     context_size: int
 
 
+def _dr_environment(endpoint: str, api_token: str) -> dict[str, str]:
+    """Build the subprocess environment for a `dr` invocation.
+
+    The CLI prefers DATAROBOT_ENDPOINT / DATAROBOT_API_TOKEN over its own stored
+    profile, so passing the project's credentials through keeps the listing pointed
+    at the same DataRobot instance the project's .env targets. It only honors them
+    once they verify, and falls back to its stored profile otherwise -- so a stale
+    project .env yields the user's own catalog rather than a hard failure.
+    """
+    env = os.environ.copy()
+    env["DATAROBOT_ENDPOINT"] = endpoint
+    env["DATAROBOT_API_TOKEN"] = api_token
+    env["DATAROBOT_CLI_NON_INTERACTIVE"] = "True"
+
+    return env
+
+
+def fetch_cli_llms(endpoint: str, api_token: str) -> list[dict[str, Any]]:
+    """Return the raw `dr llm-gateway list` entries, unfiltered.
+
+    Args:
+        endpoint: DataRobot API endpoint URL
+        api_token: DataRobot API token for authentication
+
+    Returns:
+        List of CLI entry dicts (id, name, source, provider, model, description,
+        context_size, deployment_id, selected)
+
+    Raises:
+        RuntimeError: If the CLI is missing, fails, or returns unparseable output
+    """
+    try:
+        result = subprocess.run(
+            DR_LLM_LIST_CMD,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DR_LLM_LIST_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            env=_dr_environment(endpoint, api_token),
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "DataRobot CLI ('dr') not found. Install it with "
+            "'curl https://cli.datarobot.com/install | sh' and re-run."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"'{' '.join(DR_LLM_LIST_CMD)}' timed out after {DR_LLM_LIST_TIMEOUT}s. "
+            "Check DATAROBOT_ENDPOINT / DATAROBOT_API_TOKEN and 'dr auth check'."
+        ) from e
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(
+            f"'{' '.join(DR_LLM_LIST_CMD)}' failed with exit code {result.returncode}: {detail}"
+        )
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to parse CLI model list output: {e}") from e
+
+    entries = data.get(DR_LLM_LIST_ENVELOPE_KEY) if isinstance(data, dict) else None
+    if not isinstance(entries, list):
+        # RuntimeError, not TypeError: it is the single error channel this script's
+        # callers and main() handle, and a malformed envelope is a CLI contract
+        # failure rather than a caller bug.
+        raise RuntimeError(  # noqa: TRY004
+            f"Unexpected CLI output: no '{DR_LLM_LIST_ENVELOPE_KEY}' list in response"
+        )
+
+    return entries
+
+
+def _to_llm_model(entry: dict[str, Any]) -> LLMModel:
+    """Map one CLI entry onto the LLMModel shape used across the skill."""
+    model_name = entry.get("model") or ""
+    # Downstream consumers (agent_spec.md, LLM_DEFAULT_MODEL) expect the
+    # datarobot/ prefix; the CLI reports the bare gateway model id.
+    if model_name and not model_name.startswith("datarobot/"):
+        model_name = f"datarobot/{model_name}"
+
+    return {
+        "name": model_name,
+        "description": entry.get("description") or "",
+        "provider": entry.get("provider") or "Unknown",
+        "context_size": entry.get("context_size") or 0,
+    }
+
+
 def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
-    """Fetch active LLM models from DataRobot Gateway.
+    """Fetch active LLM Gateway models via the DataRobot CLI.
 
     Args:
         endpoint: DataRobot API endpoint URL
@@ -44,56 +150,20 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
         List of active LLMModel dictionaries with name, description, provider, and context_size
 
     Raises:
-        RuntimeError: If the API request fails
+        RuntimeError: If the CLI call fails or the catalog has no active models
     """
-    endpoint = endpoint.rstrip("/")
-    url = f"{endpoint}/genai/llmgw/catalog/"
+    entries = fetch_cli_llms(endpoint, api_token)
 
-    try:
-        request = Request(
-            url,
-            headers={"Authorization": f"Bearer {api_token}"},
-        )
-        with urlopen(request, timeout=30) as response:
-            data = json.loads(response.read().decode("utf-8"))
+    gateway = [
+        _to_llm_model(e)
+        for e in entries
+        if e.get("source", SOURCE_GATEWAY) == SOURCE_GATEWAY
+    ]
 
-        # Handle both list and dict responses
-        if isinstance(data, dict) and "data" in data:
-            models_list = data["data"]
-        elif isinstance(data, list):
-            models_list = data
-        else:
-            raise RuntimeError(f"Unexpected response format: {type(data)}")
+    if not gateway:
+        raise RuntimeError("No active models found in catalog")
 
-        # Client-side filtering for active models
-        active_models = [m for m in models_list if m.get("isActive", False)]
-
-        if not active_models:
-            raise RuntimeError("No active models found in catalog")
-
-        # Extract key information
-        result: list[LLMModel] = []
-        for m in active_models:
-            model_name = m.get("model", "")
-            # Ensure model name has datarobot/ prefix
-            if model_name and not model_name.startswith("datarobot/"):
-                model_name = f"datarobot/{model_name}"
-
-            result.append(
-                {
-                    "name": model_name,
-                    "description": m.get("description", ""),
-                    "provider": m.get("provider", "Unknown"),
-                    "context_size": m.get("contextSize", 0),
-                }
-            )
-
-        return result
-
-    except (HTTPError, URLError) as e:
-        raise RuntimeError(f"Failed to fetch model catalog: {e}") from e
-    except json.JSONDecodeError as e:
-        raise RuntimeError(f"Failed to parse model catalog response: {e}") from e
+    return gateway
 
 
 def format_as_table(models: list[LLMModel]) -> str:


### PR DESCRIPTION
## Summary

Model selection in the Agent Assist skill kept its own copy of the LLM Gateway catalog fetch, so it drifted from the DataRobot CLI on pagination, active-model filtering, and which fields it surfaced. The CLI now exposes the same data through `dr llm-gateway list --output-format json`, and the skill's Pre-requisite Check already installs, upgrades, and authenticates `dr`. This switches the skill to that single source, which also picks up CLI-side catalog fixes for free.

## How it works

`list_llm_models.py` runs the CLI as a subprocess instead of calling `/genai/llmgw/catalog/` itself, and maps the CLI's envelope onto the `LLMModel` shape the skill already used, so `rehearsal.py` needs no change. The project's `.env` credentials are passed through so the listing stays pointed at the instance the project targets.

Two failure modes are handled deliberately. The CLI drops into an interactive login when it has no usable credentials, so the call closes stdin and carries a 90s timeout, turning a would-be hang into a clear error. And a `dr` that predates deployed-LLM support omits the per-entry `source` field, so a missing value is read as `gateway`, keeping the listing correct on an older CLI.

One thing to know when reviewing: the CLI honors passed credentials only once they verify, and otherwise falls back to its own stored profile. That makes a stale project `.env` produce a listing from a different DataRobot instance. The stacked CFX-6980 PR makes that visible by forwarding the CLI's log lines.

## Technical Changes

- `skills/datarobot-agent-assist/scripts/list_llm_models.py`: replace the urllib catalog request with a `dr llm-gateway list --output-format json` subprocess call. `fetch_cli_llms` owns the transport and error funnel, `fetch_llm_models` keeps its signature and gateway-only contract.
- `skills/datarobot-agent-assist/references/helper-scripts.md`: document that model selection now hard-depends on the CLI, and what to check when the listing looks like the wrong instance.
- `CHANGELOG.md`: entry under `[Unreleased]`.

Verified against a `dr` built from the CLI's merged `main`: 65 gateway models with descriptions and context sizes, `rehearsal.py`'s catalog still builds, and the error paths for a missing `dr`, a non-zero exit, and a malformed envelope all report rather than traceback. `ruff`, `mypy`, and 168 integration tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to a design helper script and documentation; public output shape is preserved for downstream scripts like `rehearsal.py`.
> 
> **Overview**
> **Agent Assist design-time model selection** no longer calls the LLM Gateway catalog HTTP API directly. `list_llm_models.py` now runs `dr llm-gateway list --output-format json`, maps the `llms` envelope back to the existing `LLMModel` shape (including `datarobot/` prefixes), and keeps **gateway-only** entries via the CLI `source` field (missing `source` still counts as gateway for older `dr` builds).
> 
> Project `.env` credentials are injected into the subprocess (`DATAROBOT_ENDPOINT`, `DATAROBOT_API_TOKEN`, non-interactive mode). The call uses closed stdin and a 90s timeout so a CLI login prompt cannot hang the skill; missing `dr`, non-zero exit, and bad JSON all surface as `RuntimeError` messages. Docs in `helper-scripts.md` and `CHANGELOG.md` note that the CLI is now a **hard dependency** for model selection and that stale `.env` can yield a catalog from the CLI’s stored profile instead of the intended instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85aa1fc7216903c3a20ca498ae6a6fefdd4fb3c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->