### PR TITLE
[DO NOT MERGE] ci: probe stacked-PR check coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-skills-e2e.yml
+++ b/.github/workflows/test-skills-e2e.yml
@@ -3,7 +3,6 @@ name: Test Skills E2E
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - skills/**
       - tests/e2e/**

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'

--- a/skills/datarobot-agent-assist/SKILL.md
+++ b/skills/datarobot-agent-assist/SKILL.md
@@ -292,7 +292,7 @@ Field definitions: [references/agent-spec-schema.md](references/agent-spec-schem
 - If it is unclear whether the request falls into one of the three categories, ask a clarifying question
 - If the user insists on a task outside these three categories, politely decline
 - If a user asks to code before designing, strongly encourage designing first
-- Before running any CLI command or helper script, provide a clear explanation in 2-5 sentences. The explanation must include why this specific command is needed now, what it will check/change/create.
+- Before running any CLI command or helper script, provide a clear explanation in 2-5 sentences. The explanation must include why this specific command is needed now, and what it will check/change/create.
 - **Template clone** — follow [Clone discipline](references/pre-coding-checklist.md#clone-discipline): spec-only workspaces get a brief notice then clone; messy workspaces require explicit subdirectory confirmation (step 7) before any clone; never treat **Code the agent** as that confirmation.
 - **Pre-coding spec validation** — on cold Code entry and deploy → coding handoff, Bootstrap step 2 must check every [spec complete](references/resume-design.md#spec-complete) field and report pass/fail to the user before workspace classification or template setup. Do not run `ls`, clone, or classify `<target_dir>` until validation passes or [Spec issues](references/pre-coding-checklist.md#spec-issues) is resolved.
 - **Pre-coding spec issues** — if `agent_spec.md` has gaps during Bootstrap step 2, do not fix inline; route to Design via [resume-design.md](references/resume-design.md). Exception: missing `tools` only may be waived when the user confirms no tools are needed.


### PR DESCRIPTION
**Throwaway. Do not merge, do not review.** This branch and its stacked child exist to measure CI behavior and will be closed and deleted once the three observations below are recorded.

Diagnostic for two problems on main, neither introduced by any open PR:

1. `Skill quality evaluation` is red on main since #71 merged, and on #67 and #73. Cause is a parser defect in `parse_verdict()` in `datarobot-agent-tester`, not the skill content. Detail in [this comment on #73](https://github.com/datarobot-oss/datarobot-agent-skills/pull/73#issuecomment-5119476553).
2. `lint`, `Trivy`, and `Skill quality evaluation` all trigger on `pull_request` with `branches: [main]`, so a stacked PR gets no checks at all and its green status is the absence of checks rather than a pass.

## What this branch does

- Drops the `branches: [main]` filter from the `pull_request` trigger in `lint.yml`, `test-skills-e2e.yml`, and `trivy-scan.yml`. The `push: branches: [main]` filters are untouched.
- One-word copy fix in `skills/datarobot-agent-assist/SKILL.md`, needed only to change the file's MD5 so the judge's hash cache re-evaluates it and to satisfy the e2e `paths:` filter.

## What is being measured

- Whether the stacked child PR gets `lint`, `Trivy`, and `Skill quality evaluation`. `pull_request` resolves the workflow from the merge ref, so the child is evaluated under the widened filter on this branch.
- Whether `Skill quality evaluation` is a required check. Rulesets, classic branch protection, and the GraphQL `branchProtectionRules` all read empty at my permission level, yet #73 reports `mergeStateStatus: BLOCKED`, so something is configured that I cannot see.
- Which heading level the judge emits for its verdict section this run. Four prior runs all emitted `## Overall Verdict` where the prompt asked for `### Overall verdict`, which is the specific mismatch that fails the build.

If the filter change measures out, it gets re-opened as its own reviewable PR off main rather than merged from here.
