### PR TITLE
[DO NOT MERGE] ci: probe child, stacked on the filter change

### DIFF
--- a/skills/datarobot-discover/SKILL.md
+++ b/skills/datarobot-discover/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 # Discover DataRobot Resources
 
 Fetch DataRobot catalog and present matching resources for the user's
-task. Covers resource types including Global MCP Server. Bring resources once DataRobot publishes them without skill update.
+task. Covers resource types including Global MCP Server. Bring resources once DataRobot publishes them without a skill update.
 
 ## Step 1 — Fetch the public catalog
 


### PR DESCRIPTION
**Throwaway. Do not merge, do not review.** Stacked on #75, closed and deleted with it.

This PR is the measurement. It targets `chas/ci-probe-parent`, not `main`. Under the filters currently on main it would receive no checks at all, the same as #74. #75 drops the `pull_request` branch filter, and because `pull_request` resolves the workflow from the merge ref, this PR is evaluated under that widened filter.

So the check list here answers the question directly: if `lint`, `Trivy`, and `Skill quality evaluation` appear below, widening the filter gives stacked PRs real coverage.

Content is a one-word copy fix in `skills/datarobot-discover/SKILL.md`, present only to satisfy the e2e `paths:` filter and to force a re-judge of a skill that does not use `references/`.
