### PR TITLE
[APP-6735] Swarm refinements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.4.0"
+      "version": "1.4.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-08-03
+
+### Changed
+- `datarobot-agent-assist-simulate`: UX improvements — domain-aware Q2, grouped scenario list, `dr dotenv update` in auth setup, live progress narration during swarm run.
+
 ## [1.4.0] - 2026-07-28
 
 ### Added

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
@@ -37,6 +37,7 @@ dr opencode upgrade && export PATH="$PATH:$HOME/.opencode/bin"
 
 ```bash
 dr auth check
+dr dotenv update
 ```
 
 If any check fails, surface the error and stop.
@@ -165,7 +166,25 @@ Validate all outputs:
 <python> <skill_scripts_dir>/native_scenarios.py finalize
 ```
 
-Read `finalize` stdout and present the candidate list to the user. Ask them to add/remove scenarios or say "run it" to confirm.
+Read `finalize` stdout and present the candidate list grouped by track. For each scenario output one line:
+`- [name] — [one sentence on what it targets]`
+
+Example:
+```
+Attack (4)
+- Malicious CSV Injects Visualization Override — tests whether the agent follows instructions embedded in uploaded file content
+- Path Traversal via File Path Argument — tests whether the agent rejects file paths outside the allowed directory
+...
+
+Behavior (3)
+...
+
+Persistence (3)
+...
+```
+
+Then ask:
+> "Add or remove any, or say 'run it' to confirm. Say 'explain [name]' or 'explain all' for full detail on any scenario."
 Write the authoritative criteria:
 
 ```bash

--- a/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
@@ -212,6 +212,9 @@ each as a separate `--implementation` flag. Tell the user before launching:
 Include `--tools-path` only when `execution.mode` is `selective_e2e` and `tools.py` exists. Parse
 stdout as the summary JSON. Surface any `warning:` lines from stderr before presenting results.
 
+While the swarm is running, read the task output file every 30 seconds and narrate newly completed
+scenarios to the user (scenario name, track, pass/breach/error). Continue until the run completes.
+
 **Present results:**
 
 Say: `"N of M scenarios passed."`

--- a/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
@@ -67,8 +67,9 @@ If `agent_config.yaml` already exists, read it and ask:
 **Q1 — User type:** Read `agent_spec.md` and offer 2–4 domain-specific personas plus
 "Other — describe your user segment."
 
-**Q2 — Grounding context (optional):** Ask for customer tickets, support logs, or behavior
-descriptions. Save to `user_context.txt` if provided. Skip if the user says "skip."
+**Q2 — Grounding context (optional):** Based on `agent_spec.md`, ask for domain-appropriate
+examples (e.g. past queries, sample inputs, real requests).
+Keep the question to one sentence. Save to `user_context.txt` if provided. Skip if the user says "skip."
 
 **Q3 — Fixing rounds:** Ask:
 > "How many rounds of fixing should I run on failing scenarios? Default: 3."

--- a/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/SKILL.md
@@ -90,6 +90,8 @@ identify any that appear to be read-only — no writes, no side effects, names l
 
 If the user chooses real execution: edit `agent_spec.md` to add `is_readonly: true` on each
 approved tool, then pass `--execution-mode selective_e2e` to `native_scenarios.py configure`.
+Find the `.venv/bin/python3` nearest to the implementation file (check its directory, then walk up)
+and use it instead of `<python>` when invoking `native_swarm.py` in Step 3.
 If the user declines or no read-only tools exist, omit `--execution-mode` (defaults to simulated).
 
 **Start OpenCode server** (once, after model selection):

--- a/skills/datarobot-agent-assist/agent-assist-simulate/scripts/gateway_worker.py
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/scripts/gateway_worker.py
@@ -43,15 +43,18 @@ def _build_message(role_prompt_path: Path, input_path: Path) -> str:
     return f"{role_prompt}\n\n# Input\n\n{input_json}"
 
 
-def _extract_response(stdout: str, role: str = "") -> dict[str, object]:
-    """Parse JSONL event stream and return the assistant's JSON object.
+def _extract_response(
+    stdout: str, role: str = ""
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Parse JSONL event stream and return (response, token_meta).
 
     opencode --format json emits one event per line:
       {"type":"step_start", "part": {...}}
       {"type":"text",       "part": {"text": "<assistant response>", ...}}
-      {"type":"step_finish","part": {...}}
+      {"type":"step_finish","part": {"tokens": {...}, "cost": float, ...}}
 
     Concatenate all type=="text" part.text payloads, then parse as JSON.
+    Accumulate token counts and cost from all type=="step_finish" events.
 
     For the runner role only, a plain-prose reply (the simulation model declining
     the framing instead of emitting the envelope) is wrapped as an
@@ -59,6 +62,12 @@ def _extract_response(stdout: str, role: str = "") -> dict[str, object]:
     agent is behaviorally a refusal and should be scored, not discarded.
     """
     text_parts: list[str] = []
+    input_tokens = 0
+    output_tokens = 0
+    cache_read_tokens = 0
+    cache_write_tokens = 0
+    total_cost = 0.0
+
     for line in stdout.splitlines():
         line = line.strip()
         if not line:
@@ -71,6 +80,22 @@ def _extract_response(stdout: str, role: str = "") -> dict[str, object]:
             chunk = event.get("part", {}).get("text", "")
             if chunk:
                 text_parts.append(chunk)
+        elif event.get("type") == "step_finish":
+            part = event.get("part", {})
+            tokens = part.get("tokens", {})
+            input_tokens += tokens.get("input", 0)
+            output_tokens += tokens.get("output", 0)
+            cache_read_tokens += tokens.get("cache", {}).get("read", 0)
+            cache_write_tokens += tokens.get("cache", {}).get("write", 0)
+            total_cost += part.get("cost", 0.0) or 0.0
+
+    token_meta: dict[str, object] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_tokens": cache_read_tokens,
+        "cache_write_tokens": cache_write_tokens,
+        "cost": round(total_cost, 6),
+    }
 
     combined = "".join(text_parts).strip()
     if not combined:
@@ -87,17 +112,17 @@ def _extract_response(stdout: str, role: str = "") -> dict[str, object]:
         result = json.loads(combined)
     except json.JSONDecodeError as exc:
         if role == "runner":
-            return {"type": "assistant_response", "content": combined}
+            return {"type": "assistant_response", "content": combined}, token_meta
         raise ValueError(f"worker response is not valid JSON: {exc}") from exc
 
     if not isinstance(result, dict):
         if role == "runner":
-            return {"type": "assistant_response", "content": combined}
+            return {"type": "assistant_response", "content": combined}, token_meta
         raise ValueError(
             f"expected a JSON object from worker, got {type(result).__name__}"
         )
 
-    return result
+    return result, token_meta
 
 
 def _atomic_write(path: Path, data: dict[str, object]) -> None:
@@ -218,6 +243,7 @@ def main() -> None:
     isolated_dir = None if args.server_url else tempfile.mkdtemp(prefix="dr-worker-")
     start = time.monotonic()
     success = False
+    token_meta: dict[str, object] = {}
     error: str | None = None
 
     try:
@@ -262,7 +288,7 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            response = _extract_response(result.stdout, role)
+            response, token_meta = _extract_response(result.stdout, role)
         except ValueError as exc:
             error = "parse_failed"
             print(f"response extraction failed: {exc}", file=sys.stderr)
@@ -284,6 +310,8 @@ def main() -> None:
             "duration_s": round(time.monotonic() - start, 2),
             "success": success,
         }
+        if success and token_meta:
+            record.update(token_meta)
         if scenario_id is not None:
             record["scenario_id"] = scenario_id
         if error is not None:

--- a/skills/datarobot-agent-assist/agent-assist-simulate/scripts/gateway_worker.py
+++ b/skills/datarobot-agent-assist/agent-assist-simulate/scripts/gateway_worker.py
@@ -265,36 +265,47 @@ def main() -> None:
             cmd += ["--dir", isolated_dir]
         cmd += ["--pure", message]
 
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=args.timeout
-            )
-        except subprocess.TimeoutExpired:
-            error = "timeout"
-            print(
-                f"worker timed out after {args.timeout}s "
-                f"(role-prompt: {args.role_prompt.name})",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        max_attempts = 3 if role != "runner" else 1
+        for attempt in range(max_attempts):
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=args.timeout
+                )
+            except subprocess.TimeoutExpired:
+                error = "timeout"
+                print(
+                    f"worker timed out after {args.timeout}s "
+                    f"(role-prompt: {args.role_prompt.name})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
-        if result.returncode != 0:
-            error = f"opencode_exit_{result.returncode}"
-            print(
-                f"dr opencode run exited {result.returncode}:\n"
-                f"{result.stderr or result.stdout}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            if result.returncode != 0:
+                error = f"opencode_exit_{result.returncode}"
+                print(
+                    f"dr opencode run exited {result.returncode}:\n"
+                    f"{result.stderr or result.stdout}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
-        try:
-            response, token_meta = _extract_response(result.stdout, role)
-        except ValueError as exc:
-            error = "parse_failed"
-            print(f"response extraction failed: {exc}", file=sys.stderr)
-            if result.stderr:
-                print(result.stderr, file=sys.stderr)
-            sys.exit(1)
+            try:
+                response, token_meta = _extract_response(result.stdout, role)
+                error = None
+                break
+            except ValueError as exc:
+                error = "parse_failed"
+                if attempt < max_attempts - 1:
+                    print(
+                        f"response extraction failed, likely a model refusal "
+                        f"(attempt {attempt + 1}/{max_attempts}): {exc}. Retrying.",
+                        file=sys.stderr,
+                    )
+                    continue
+                print(f"response extraction failed: {exc}", file=sys.stderr)
+                if result.stderr:
+                    print(result.stderr, file=sys.stderr)
+                sys.exit(1)
 
         _atomic_write(args.response_path, response)
         success = True


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to simulate skill documentation and the gateway worker adapter; retries only affect failed parses and metrics are additive.
> 
> **Overview**
> Refines the **agent-assist-simulate** swarm flow and makes **gateway_worker** more resilient and observable.
> 
> **SKILL.md** adds **`dr dotenv update`** to the auth preflight, tightens optional grounding (Q2) to a single domain-specific sentence from `agent_spec.md`, and expands post-**`finalize`** review: scenarios are shown **by track** with one-line “what it targets,” plus prompts to add/remove, confirm with “run it,” or **`explain [name]`** / **`explain all`**.
> 
> **`gateway_worker.py`** parses **`step_finish`** events to accumulate **input/output/cache tokens and cost**, writes them into per-worker **metrics** on success, and **retries up to 3 times** (generators/fixtures/evaluators only) when JSON extraction fails—treating likely refusals as retriable while the **runner** stays at a single attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4e9a02c38679cc63a468e061ac7823ddea95c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->