### PR TITLE
Ignore the .datarobot/swarm scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ Thumbs.db
 # Swarm simulation reports
 eval_report.md
 evaluation_criteria.md
+.datarobot/swarm/
 


### PR DESCRIPTION
## Summary

Running the swarm-simulate scripts, or just the integration test suite, drops `.datarobot/swarm/swarm_temp` into the working tree as an untracked file. `gateway_worker.py` calls `resolve_swarm_dir()` at import time and the `native_*` scripts call it in argparse defaults, so `pytest tests/integration/` from repo root is enough to create it and it then sits in every contributor's `git status`. This ignores the scratch dir next to the other swarm outputs (`eval_report.md`, `evaluation_criteria.md`) already in `.gitignore`.

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1786486167.625719 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line `.gitignore` update with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds `.datarobot/swarm/` to `.gitignore` so the swarm simulation scratch directory no longer shows up as untracked after running swarm scripts or integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee878586eb8f6ec476555837e0c8124a5504a89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->