### PR TITLE
test: behavioral scenarios — golden journey + all five README user journeys, fixtures, local dev loop, inert CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,11 @@
 # OpenCode plugin (theme, install scripts, metadata)
 /.opencode-plugin/ @datarobot-oss/agent-skills-maintainers
 
+# Behavioral test scenarios, fixtures, and CI (new scenarios add live-run cost)
+/tests/behavioral/ @datarobot-oss/agent-skills-maintainers
+/tests/behavioral/journeys/ @datarobot/core-modeling
+/.github/workflows/behavioral-e2e.yml @datarobot-oss/agent-skills-maintainers
+
 # Individual Contributor skills
 /skills/datarobot-discover/ @datarobot-oss/agent-skills-maintainers
 /skills/datarobot-external-agent-monitoring/ @vitali93

--- a/.github/workflows/behavioral-e2e.yml
+++ b/.github/workflows/behavioral-e2e.yml
@@ -15,6 +15,14 @@
 # the `behavioral-live` environment, and its secrets exist:
 #   BEHAVIORAL_DATAROBOT_API_TOKEN  (service-account token, test org only)
 #   BEHAVIORAL_DATAROBOT_ENDPOINT   (e.g. https://app.datarobot.com/api/v2)
+#
+# FIXTURE-DEPENDENT SCENARIOS: tests/behavioral/scenarios/ includes scenarios
+# that assert against long-lived bfix-* fixture resources (see
+# tests/behavioral/fixtures/provision_fixtures.py). They run only when the
+# `behavioral-live` environment defines the id VARIABLES (ids are not
+# secrets):
+#   BEHAVIORAL_FIXTURE_PROJECT_ID / _MODEL_ID / _DEPLOYMENT_ID
+# Until then, only tests/behavioral/journeys/ runs.
 name: Behavioral E2E
 
 on:
@@ -107,6 +115,9 @@ jobs:
     env:
       DATAROBOT_API_TOKEN: ${{ secrets.BEHAVIORAL_DATAROBOT_API_TOKEN }}
       DATAROBOT_ENDPOINT: ${{ secrets.BEHAVIORAL_DATAROBOT_ENDPOINT }}
+      BEHAVIORAL_FIXTURE_PROJECT_ID: ${{ vars.BEHAVIORAL_FIXTURE_PROJECT_ID }}
+      BEHAVIORAL_FIXTURE_MODEL_ID: ${{ vars.BEHAVIORAL_FIXTURE_MODEL_ID }}
+      BEHAVIORAL_FIXTURE_DEPLOYMENT_ID: ${{ vars.BEHAVIORAL_FIXTURE_DEPLOYMENT_ID }}
     steps:
       # PR head supplies skill_pr AND the scenarios/fixtures under test; on
       # schedule/dispatch this is just the default branch.
@@ -131,11 +142,22 @@ jobs:
         working-directory: pr
         run: uv sync --group behavioral
 
+      - name: Verify fixture resources (preflight)
+        if: env.BEHAVIORAL_FIXTURE_DEPLOYMENT_ID != ''
+        working-directory: pr
+        run: uv run --group behavioral python tests/behavioral/fixtures/provision_fixtures.py --check
+
       - name: Run behavioral evaluation (${{ matrix.condition }})
         working-directory: pr
         run: |
+          SCENARIOS="--scenarios tests/behavioral/journeys"
+          # Fixture-dependent per-skill scenarios only when the ids exist;
+          # with ids set but resources broken, the engine fails loudly.
+          if [ -n "$BEHAVIORAL_FIXTURE_DEPLOYMENT_ID" ]; then
+            SCENARIOS="$SCENARIOS --scenarios tests/behavioral/scenarios"
+          fi
           uv run --group behavioral dr-agent eval run-behavioral \
-            --scenarios tests/behavioral/journeys \
+            $SCENARIOS \
             --skills-main ../main/skills \
             --skills-pr ./skills \
             --conditions "${{ matrix.condition }}" \
@@ -192,12 +214,19 @@ jobs:
     env:
       DATAROBOT_API_TOKEN: ${{ secrets.BEHAVIORAL_DATAROBOT_API_TOKEN }}
       DATAROBOT_ENDPOINT: ${{ secrets.BEHAVIORAL_DATAROBOT_ENDPOINT }}
+      BEHAVIORAL_FIXTURE_DEPLOYMENT_ID: ${{ vars.BEHAVIORAL_FIXTURE_DEPLOYMENT_ID }}
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+      # The drat- prefix can never match the long-lived bfix-* fixtures.
       - name: Sweep leaked resources older than 24h
         run: |
           uv sync --group behavioral
           uv run --group behavioral dr-agent eval sweep \
             --prefix drat- --older-than-hours 24 --execute
+      # Drift windows age out; keep the fixture deployment's traffic fresh so
+      # the monitoring scenario always has drift data to report.
+      - name: Refresh fixture drift traffic
+        if: env.BEHAVIORAL_FIXTURE_DEPLOYMENT_ID != ''
+        run: uv run --group behavioral python tests/behavioral/fixtures/provision_fixtures.py --refresh-traffic

--- a/.github/workflows/behavioral-e2e.yml
+++ b/.github/workflows/behavioral-e2e.yml
@@ -1,0 +1,203 @@
+---
+# Behavioral end-to-end tests: drive a real coding agent (OpenCode) through
+# user journeys with this repo's skills installed, and verify outcomes against
+# a real DataRobot org. Design: docs/proposals/skill-behavioral-testing.md
+#
+# SECURITY: this workflow executes PR-authored skill content and
+# agent-generated code, so it MUST use plain `pull_request` (never
+# `pull_request_target`) — GitHub withholds all secrets from fork-PR
+# `pull_request` runs by construction. The `run-e2e` label is the
+# maintainers' cost opt-in for same-repo PRs; a guard below refuses fork PRs
+# explicitly (maintainers: push the branch to origin and re-label).
+#
+# INERT UNTIL ENABLED: every job gates on the repository variable
+# BEHAVIORAL_LIVE_ENABLED == 'true'. Flip it once the dedicated test org,
+# the `behavioral-live` environment, and its secrets exist:
+#   BEHAVIORAL_DATAROBOT_API_TOKEN  (service-account token, test org only)
+#   BEHAVIORAL_DATAROBOT_ENDPOINT   (e.g. https://app.datarobot.com/api/v2)
+name: Behavioral E2E
+
+on:
+  pull_request:
+    types: [labeled]
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+    inputs:
+      k:
+        description: Runs per scenario/condition cell
+        default: "3"
+      conditions:
+        description: Comma-separated conditions (no_skill,skill_main,skill_pr)
+        default: no_skill,skill_main,skill_pr
+
+permissions:
+  contents: read
+
+concurrency:
+  group: behavioral-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Keep in sync with dr_agents_tester/eval/drivers/versions.py — the engine
+  # refuses to run against any other version.
+  OPENCODE_VERSION: 1.17.11
+  RUN_PREFIX: drat-gh${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.decide.outputs.enabled }}
+      conditions: ${{ steps.decide.outputs.conditions }}
+      k: ${{ steps.decide.outputs.k }}
+    steps:
+      - name: Decide whether and what to run
+        id: decide
+        env:
+          LIVE_ENABLED: ${{ vars.BEHAVIORAL_LIVE_ENABLED }}
+          EVENT_NAME: ${{ github.event_name }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          INPUT_K: ${{ inputs.k }}
+          INPUT_CONDITIONS: ${{ inputs.conditions }}
+        run: |
+          if [ "$LIVE_ENABLED" != "true" ]; then
+            echo "Behavioral live runs are not enabled (vars.BEHAVIORAL_LIVE_ENABLED != 'true')."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$EVENT_NAME" in
+            pull_request)
+              if [ "$LABEL_NAME" != "run-e2e" ]; then
+                echo "Label '$LABEL_NAME' is not run-e2e; skipping."
+                echo "enabled=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if [ "$IS_FORK" = "true" ]; then
+                echo "::error::Fork PRs cannot run live behavioral tests (secrets are withheld). Maintainer: push the branch to origin and re-label."
+                exit 1
+              fi
+              echo 'conditions=["no_skill","skill_main","skill_pr"]' >> "$GITHUB_OUTPUT"
+              echo "k=3" >> "$GITHUB_OUTPUT"
+              ;;
+            schedule)
+              echo 'conditions=["no_skill","skill_main"]' >> "$GITHUB_OUTPUT"
+              echo "k=3" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_dispatch)
+              CONDS=$(echo "${INPUT_CONDITIONS:-no_skill,skill_main,skill_pr}" | python3 -c 'import json,sys; print(json.dumps([c.strip() for c in sys.stdin.read().split(",") if c.strip()]))')
+              echo "conditions=$CONDS" >> "$GITHUB_OUTPUT"
+              echo "k=${INPUT_K:-3}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+  run:
+    needs: gate
+    if: needs.gate.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: behavioral-live
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        condition: ${{ fromJSON(needs.gate.outputs.conditions) }}
+    env:
+      DATAROBOT_API_TOKEN: ${{ secrets.BEHAVIORAL_DATAROBOT_API_TOKEN }}
+      DATAROBOT_ENDPOINT: ${{ secrets.BEHAVIORAL_DATAROBOT_ENDPOINT }}
+    steps:
+      # PR head supplies skill_pr AND the scenarios/fixtures under test; on
+      # schedule/dispatch this is just the default branch.
+      - name: Checkout head (scenarios + skill_pr skills)
+        uses: actions/checkout@v4
+        with:
+          path: pr
+      - name: Checkout main (skill_main skills)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install pinned opencode
+        run: npm install -g "opencode-ai@${OPENCODE_VERSION}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install behavioral engine
+        working-directory: pr
+        run: uv sync --group behavioral
+
+      - name: Run behavioral evaluation (${{ matrix.condition }})
+        working-directory: pr
+        run: |
+          uv run --group behavioral dr-agent eval run-behavioral \
+            --scenarios tests/behavioral/journeys \
+            --skills-main ../main/skills \
+            --skills-pr ./skills \
+            --conditions "${{ matrix.condition }}" \
+            --n-runs "${{ needs.gate.outputs.k }}" \
+            --work-dir ../run-artifacts/${{ matrix.condition }} \
+            --output-dir ../run-artifacts/${{ matrix.condition }}/results \
+            --run-prefix "${RUN_PREFIX}"
+
+      - name: Teardown run resources
+        if: always()
+        working-directory: pr
+        run: |
+          uv run --group behavioral dr-agent eval sweep \
+            --prefix "${RUN_PREFIX}" --older-than-hours 0 --execute || true
+
+      - name: Upload artifacts (transcripts + results)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: behavioral-${{ matrix.condition }}
+          path: run-artifacts/
+          retention-days: 30
+
+  report:
+    needs: [gate, run]
+    if: needs.gate.outputs.enabled == 'true' && always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: false
+      - name: Compose job summary
+        run: |
+          {
+            echo "# Behavioral E2E results (advisory)"
+            echo
+            echo "Run prefix: \`${RUN_PREFIX}\`"
+            echo
+            for md in artifacts/behavioral-*/**/results/eval_report.md; do
+              [ -f "$md" ] || continue
+              echo "---"
+              cat "$md"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Nightly safety net: delete anything the per-run teardown missed.
+  sweep:
+    needs: gate
+    if: github.event_name == 'schedule' && needs.gate.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    environment: behavioral-live
+    env:
+      DATAROBOT_API_TOKEN: ${{ secrets.BEHAVIORAL_DATAROBOT_API_TOKEN }}
+      DATAROBOT_ENDPOINT: ${{ secrets.BEHAVIORAL_DATAROBOT_ENDPOINT }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Sweep leaked resources older than 24h
+        run: |
+          uv sync --group behavioral
+          uv run --group behavioral dr-agent eval sweep \
+            --prefix drat- --older-than-hours 24 --execute

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 *.csv
 *.parquet
 *.json
+!tests/behavioral/fixtures/*.csv
 !gemini-extension.json
 !.cursor-plugin/plugin.json
 !.claude-plugin/marketplace.json
@@ -53,4 +54,8 @@ Thumbs.db
 eval_report.md
 evaluation_criteria.md
 .datarobot/swarm/
+
+# Behavioral test runs (workspaces, transcripts, results)
+.behavioral-runs/
+.behavioral-results/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+### Added
+
+- Repo tooling: `tests/integration/test_sdk_conformance.py` resolves every DataRobot SDK
+  call in `SKILL.md` python fences and skill `scripts/*.py` against the installed
+  `datarobot` package and checks its signature, so methods that do not exist and calls
+  with wrong arguments fail `task lint`. Requires no DataRobot account.
+
 ## [1.5.0] - 2026-08-10
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ The easiest way to create a new skill is to start from an existing one close to 
 5. Add an entry for the new skill in `.well-known/ai-catalog.json`. Copy an existing entry and update the `identifier`, `displayName`, `url`, `description`, and `representativeQueries` fields. Write `representativeQueries` as natural-language phrases a user would type to discover the skill — these drive semantic search quality in ARD discovery services.
 6. Reinstall or reload the skill bundle in your coding agent so the updated skill is available.
 7. Test the skill with a prompt that exercises the workflow you expect users to follow.
+8. Add at least one behavioral scenario for your skill under `tests/behavioral/scenarios/<skill-name>/` (multi-skill journeys go in `tests/behavioral/journeys/`). A scenario is a realistic user prompt plus programmatic `success_checks` asserting the DataRobot state your skill should produce — see [tests/behavioral/README.md](tests/behavioral/README.md) for the schema and check-type library. Run it against your own account with `task test:behavioral` before opening the PR. (Encouraged today; required once behavioral CI covers your skill's area.)
 
 ## Workflow rules
 
@@ -114,6 +115,8 @@ We strongly prefer human-written skills. When assisting skill library authors, e
 - **Major** (`N.0.0`)&mdash;breaking changes to skill structure or interface.
 
 A PR that only bumps the version in some of these files (or bumps the version but forgets the changelog rename below) is incomplete.
+
+PRs that only touch `tests/behavioral/` scenarios/fixtures or CI workflows ship nothing to users: **no version bump and no changelog entry** for those.
 
 ## Changelog
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -88,6 +88,24 @@ tasks:
     cmds:
       - SKILLS_E2E_FORCE_ALL=1 uv run --group e2e pytest tests/e2e/ -v --tb=short
 
+  test:behavioral:
+    desc: Run the golden-journey behavioral test with working-tree skills (creates real, prefixed DataRobot resources; needs
+      DATAROBOT_API_TOKEN + pinned opencode)
+    cmds:
+      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --skills-pr skills --conditions
+        skill_pr --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results --run-prefix "drat-local-$(whoami)"
+
+  test:behavioral:baseline:
+    desc: Run the golden journey with NO skills installed (the no_skill baseline)
+    cmds:
+      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --conditions no_skill
+        --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results --run-prefix "drat-local-$(whoami)"
+
+  test:behavioral:clean:
+    desc: Delete any drat-* resources behavioral runs leaked in your DataRobot account
+    cmds:
+      - uv run --group behavioral dr-agent eval sweep --prefix drat- --older-than-hours 0 --execute
+
   default:
     desc: List all available tasks
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -89,20 +89,31 @@ tasks:
       - SKILLS_E2E_FORCE_ALL=1 uv run --group e2e pytest tests/e2e/ -v --tb=short
 
   test:behavioral:
-    desc: Run the golden-journey behavioral test with working-tree skills (creates real, prefixed DataRobot resources; needs
-      DATAROBOT_API_TOKEN + pinned opencode)
+    desc: Run all behavioral scenarios with working-tree skills (creates real, prefixed DataRobot resources; needs
+      DATAROBOT_API_TOKEN + pinned opencode + BEHAVIORAL_FIXTURE_* ids from test:behavioral:fixtures)
     cmds:
-      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --skills-pr skills --conditions
-        skill_pr --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results --run-prefix "drat-local-$(whoami)"
+      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --scenarios tests/behavioral/scenarios
+        --skills-pr skills --conditions skill_pr --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results
+        --run-prefix "drat-local-$(whoami)"
 
   test:behavioral:baseline:
-    desc: Run the golden journey with NO skills installed (the no_skill baseline)
+    desc: Run all behavioral scenarios with NO skills installed (the no_skill baseline)
     cmds:
-      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --conditions no_skill
-        --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results --run-prefix "drat-local-$(whoami)"
+      - uv run --group behavioral dr-agent eval run-behavioral --scenarios tests/behavioral/journeys --scenarios tests/behavioral/scenarios
+        --conditions no_skill --n-runs 1 --work-dir .behavioral-runs --output-dir .behavioral-results --run-prefix "drat-local-$(whoami)"
+
+  test:behavioral:fixtures:
+    desc: Provision (or reuse) the long-lived bfix-* fixture resources scenarios assert against; prints BEHAVIORAL_FIXTURE_* ids
+    cmds:
+      - uv run --group behavioral python tests/behavioral/fixtures/provision_fixtures.py
+
+  test:behavioral:fixtures:check:
+    desc: Validate the bfix-* fixture resources exist without creating anything (CI preflight)
+    cmds:
+      - uv run --group behavioral python tests/behavioral/fixtures/provision_fixtures.py --check
 
   test:behavioral:clean:
-    desc: Delete any drat-* resources behavioral runs leaked in your DataRobot account
+    desc: Delete any drat-* resources behavioral runs leaked in your DataRobot account (never touches bfix-* fixtures)
     cmds:
       - uv run --group behavioral dr-agent eval sweep --prefix drat- --older-than-hours 0 --execute
 

--- a/docs/proposals/skill-behavioral-testing.md
+++ b/docs/proposals/skill-behavioral-testing.md
@@ -454,12 +454,24 @@ Items are ordered roughly by dependency, not size.
 
 ### v2 — Coverage, selection, reporting
 
-- **Scenario coverage for remaining skills** (2–3 each; Appendix A is the
-  order of attack). Needs new check types in the engine as scenarios demand
-  them — next up: `dr_traces_received` (external-agent-monitoring),
-  `dr_use_case_exists`, `file_matches`. A fast every-PR scenario
-  (predictions against a **pre-provisioned long-lived deployment** in the
-  test org) removes AutoML from the loop.
+- **Scenario coverage for remaining skills** — ✅ first wave done
+  (2026-08-20): all five README user journeys have live-verified
+  single-skill scenarios under `tests/behavioral/scenarios/<skill>/`
+  (training-start-automl, predictions-template, feature-impact-report,
+  monitoring-drift-report, external-agent-otel). The check types this
+  demanded all landed in the engine: `dr_use_case_exists`, `file_matches`,
+  `dr_traces_received` (read side verified:
+  `GET otel/experiment_container/<use_case_id>/traces/`), plus
+  `dr_project_exists` stage/deadline params so "autopilot started" is
+  checkable without waiting for AutoML. The fast every-PR predictions
+  scenario exists via **pre-provisioned `bfix-` fixture resources**
+  (`tests/behavioral/fixtures/provision_fixtures.py`) injected through the
+  engine's `requires_env`/`{env:VAR}` mechanism; the engine also gained a
+  `skill_triggered_expected` metric after the feature-impact spike showed
+  `datarobot-model-explainability` organically claiming the journey.
+  Remaining: 2–3 scenarios per skill (each skill has 1), Appendix A items
+  4 (setup & recovery) and 5 (SHAP explainability), and scenarios for the
+  skills outside the README's five journeys.
 - **Dependency manifest + PR-scoped selection**: changed-files → skills
   mapping (path prefix), `skill_deps.yaml` for chained journeys, and
   scenario-edit → "run that scenario". Until this lands, every labeled run

--- a/docs/proposals/skill-behavioral-testing.md
+++ b/docs/proposals/skill-behavioral-testing.md
@@ -381,13 +381,13 @@ sibling package that depends on it and reuses `eval/stats.py` + `eval/report.py`
 
 ## 8. Phasing
 
-| Phase | Deliverable | Exit criterion |
-|---|---|---|
-| **v0** | `ExecutionBackend` refactor in dr_agents_tester; `PlanBackend` preserves current behavior; scenario schema v2 parser | Existing evals green under new interface |
-| **v1** | `ClaudeCodeDriver` + Docker sandbox; one golden journey (upload→train(Quick)→deploy→predict) with `success_checks` against the live test org; k=3; transcript artifacts; nightly + `run-e2e` label | Golden journey runs unattended end-to-end; manual testing optional for that path |
-| **v2** | Scenario coverage for remaining skills; dependency manifest + PR-scoped selection; PR comment reports; `no_skill` baseline condition | Most PRs need no manual testing |
-| **v3** | Trajectory judge + full efficiency metrics; second driver (Codex); baseline-regression gating | Behavioral checks become required (if flake rate allows) |
-| **v4** | Optimization advisor (§9) | First judge-guided skill improvement merged via human review |
+| Phase | Deliverable | Exit criterion | Status (2026-08-19) |
+|---|---|---|---|
+| **v0** | `ExecutionBackend` refactor in dr_agents_tester; `PlanBackend` preserves current behavior; scenario schema v2 parser | Existing evals green under new interface | ✅ Done — [tester PR #10](https://github.com/datarobot-oss/datarobot-agent-tester/pull/10) |
+| **v1** | Agent driver (OpenCode, per amendment 2) + sandbox; one golden journey (upload→train(Quick)→deploy→predict) with `success_checks`; k configurable; transcript artifacts; nightly + `run-e2e` label workflow (inert) | Golden journey runs unattended end-to-end | ✅ Done — golden journey **passed live** (all 4 checks, 21.5 min, all 3 skills triggered, zero leaked resources); `no_skill` baseline condition also landed early. CI workflow merged inert, pending the test org |
+| **v2** | Scenario coverage for remaining skills; dependency manifest + PR-scoped selection; PR comment reports | Most PRs need no manual testing | ⬜ See §10a roadmap |
+| **v3** | Trajectory judge; second driver (Claude Code); baseline-regression gating | Behavioral checks become required (if flake rate allows) | ⬜ See §10a roadmap |
+| **v4** | Optimization advisor (§9) | First judge-guided skill improvement merged via human review | ⬜ Distant aspiration |
 
 v1 alone removes most of the manual burden for the most-exercised path.
 
@@ -423,6 +423,96 @@ schema are designed so the optimizer is purely additive.
 | `dr_agents_tester` stewardship | Original author's appetite for this extension — this doc is the conversation starter. Fallback: sibling package (§7). |
 | Judge model choice | Existing cross-model pattern (generator ≠ judge) should carry over to trajectory judging. |
 | Scenario authoring cost | Each skill needs 2–3 scenarios + checks. Mitigation: check-type library keeps YAML small; scenario authoring becomes part of the skill-contribution checklist in CONTRIBUTING.md. |
+
+---
+
+## 10a. Roadmap: remaining work (updated 2026-08-19)
+
+**This section is the single source of truth for what is left to build.** v0 and
+v1 are implemented and live-verified ([tester PR #10](https://github.com/datarobot-oss/datarobot-agent-tester/pull/10),
+[skills PR #87](https://github.com/datarobot-oss/datarobot-agent-skills/pull/87));
+usage documentation lives in the engine's
+[docs/behavioral-evaluation.md](https://github.com/datarobot-oss/datarobot-agent-tester/blob/main/docs/behavioral-evaluation.md).
+Items are ordered roughly by dependency, not size.
+
+### R. Rollout (operational, not features)
+
+- **R1 — Merge the two PRs** (engine first; the skills-repo parse test and
+  `task test:behavioral` depend on it).
+- **R2 — Cut the engine's first release tag** (v0.2.0). Also settles the
+  `datarobot/` vs `datarobot-oss/` URL drift; tighten the skills repo's
+  `behavioral` (and `e2e`) uv-group pins from `@main` to the tag, then to a
+  PyPI `==` pin once published.
+- **R3 — Dedicated test org** (the only externally blocked step): org +
+  scoped service-account token + budget/quota alarms + a named owner. Then:
+  create the `behavioral-live` GitHub environment with
+  `BEHAVIORAL_DATAROBOT_API_TOKEN`/`BEHAVIORAL_DATAROBOT_ENDPOINT`, flip
+  `vars.BEHAVIORAL_LIVE_ENABLED`, one supervised `workflow_dispatch` run,
+  announce the `run-e2e` label.
+- **R4 — Accumulate the nightly baseline** (flake rate + cost per scenario;
+  the <5%-at-k=3 bar from §4.5 decides when checks can become required).
+
+### v2 — Coverage, selection, reporting
+
+- **Scenario coverage for remaining skills** (2–3 each; Appendix A is the
+  order of attack). Needs new check types in the engine as scenarios demand
+  them — next up: `dr_traces_received` (external-agent-monitoring),
+  `dr_use_case_exists`, `file_matches`. A fast every-PR scenario
+  (predictions against a **pre-provisioned long-lived deployment** in the
+  test org) removes AutoML from the loop.
+- **Dependency manifest + PR-scoped selection**: changed-files → skills
+  mapping (path prefix), `skill_deps.yaml` for chained journeys, and
+  scenario-edit → "run that scenario". Until this lands, every labeled run
+  executes all journeys — acceptable at current scenario count, the reason
+  scenario additions are CODEOWNERS-gated.
+- **PR comment reports** (v1 is job-summary only): per-scenario pass@k,
+  Δ vs. main, Δ vs. no-skill, efficiency deltas, artifact links.
+- **Sandbox hardening**: `DockerSandbox` (network-egress allowlist) and the
+  CI-parity image with a pre-warmed OpenCode home — build only if the
+  cold-start stall seen once in the spikes recurs on runners.
+- **Parallel throughput**: `opencode serve` + `--attach` per-run sessions if
+  sequential k=3 cells become the wall-clock bottleneck.
+- **Packaging-fidelity condition** (spike S8): install skills via the real
+  npm plugin (`"plugin": ["file:<repo>"]`) instead of the byte-identical
+  copy, as an occasional packaging test.
+
+### v3 — Judging, gating, second driver
+
+- **Trajectory judge**: rubric-driven soft scoring of *process* quality
+  (`rubric` + `common_pitfalls` are already parsed, stored, and waiting);
+  cross-model generator ≠ judge; extends `ScoreCard` — the six
+  hardcoded-dimension sites in the engine are the known blast radius.
+- **Second driver — Claude Code** (`claude -p --output-format stream-json`)
+  behind the existing `AgentDriver` protocol; needs an Anthropic API
+  credential path for CI, which is why OpenCode went first.
+- **Baseline-regression gating**: store per-(skill, scenario, driver)
+  baselines (nightly artifacts or a committed baselines file), gate on
+  regression vs. baseline rather than absolute thresholds, promote scenarios
+  to required as their flake rate clears the bar. Includes an agent-version
+  canary (nightly `latest` vs. pin).
+- **Cost accounting**: the LLM Gateway reports `cost: 0` in OpenCode's
+  stream — derive $ from token counts + a price table so nightly cost
+  tracking is real.
+
+### v4 — Optimization advisor (§9; unchanged, distant)
+
+Failing trajectories → judge critique → proposed SKILL.md diffs as draft PRs
+with evidence; held-out scenario rotation. Everything it needs (per-run JSON,
+transcripts, pass@k / trigger-rate metrics) is already being archived.
+
+### Known loose ends (small, unscheduled)
+
+- Nested sub-skill trigger naming: `skills_used` records whatever name the
+  `skill` tool reports — verify agent-assist sub-skills surface distinctly
+  (locks the trajectory-schema contract from amendment note; spike-level).
+- `dr_predictions_returned --verify_server` is best-effort corroboration
+  only; revisit if workspace-CSV assertions ever prove spoofable.
+- Spike S7 leftovers: fresh-deployment `service_health` semantics are
+  handled permissively (`unknown` passes); deployment deletion needed no
+  deactivation in the live run — formalize both once the test org exists.
+- `dr-agent eval report` regenerates behavioral markdown from saved JSON;
+  a small trajectory-diff helper (compare two runs' tool-call sequences)
+  would speed manual triage.
 
 ---
 

--- a/docs/proposals/skill-behavioral-testing.md
+++ b/docs/proposals/skill-behavioral-testing.md
@@ -1,0 +1,445 @@
+# Proposal: Automated Behavioral Testing for DataRobot Agent Skills
+
+**Status:** v0 + v1 implemented (see amendments below)
+**Author:** Matthew Hausknecht (drafted with Claude)
+**Date:** 2026-08-17 (amended 2026-08-18)
+**Related:** [datarobot-agent-skills](https://github.com/datarobot-oss/datarobot-agent-skills), [datarobot-agent-tester](https://github.com/datarobot-oss/datarobot-agent-tester)
+
+---
+
+## Amendments (2026-08-18, during v0/v1 implementation)
+
+1. **Scenario location (§4.1 amended).** Scenarios live in `tests/behavioral/`
+   (`journeys/` for multi-skill chains, `scenarios/<skill-name>/` for
+   single-skill scenarios), **not** co-located under `skills/<name>/scenarios/`
+   as originally proposed: everything under `skills/` ships to end users
+   through every packaging channel (npm `files`, Claude/Cursor
+   `skills_directory`, gemini extension), which would leak test internals to
+   customers and let the agent under test read its own `success_checks`.
+   CODEOWNERS entries on `tests/behavioral/` preserve co-review;
+   `skills_under_test` in the YAML drives selection.
+2. **v1 driver is OpenCode, not Claude Code (§4.2 amended).** Plain
+   `opencode` CLI (pinned version) configured against the DataRobot LLM
+   Gateway — reuses existing DataRobot credentials in CI instead of a separate
+   Anthropic API provisioning path. Verified: `opencode run --format json`
+   emits per-tool-call events with inputs/outputs/errors, tokens, and cost;
+   skills load through OpenCode's built-in `skill` tool so **skill triggering
+   is a first-class observable event**. Claude Code remains the natural second
+   driver behind the same `AgentDriver` protocol.
+3. **Sandbox (§4.2 refined).** v1 isolation is an isolated HOME/XDG tree plus
+   a from-scratch env allowlist (verified: OpenCode fully honors the
+   overrides, and headless mode auto-rejects file access outside the project
+   directory). Hosted CI runners are already ephemeral VMs; a Docker layer for
+   network-egress control is v2 hardening.
+4. **Resource naming.** Run ids follow
+   `drat-<context>-<condition>-r<n>-<timestamp><4hex>`; the `drat-` family
+   prefix is what the sweeper (`dr-agent eval sweep`) matches, and the
+   embedded timestamp is its age fallback.
+5. **Engine surface.** Implemented in `datarobot-agent-tester` as
+   `dr-agent eval run-behavioral` / `dr-agent eval sweep`, an
+   `ExecutionBackend` seam (the original plan eval is `PlanBackend`,
+   unchanged), scenario schema v2 (`kind: behavioral`), a success-check
+   registry, trajectory normalization with capability-honest metrics, and a
+   `[behavioral]` extra carrying the DataRobot SDK.
+
+---
+
+## 1. Problem & Motivation
+
+### The manual testing burden
+
+Every PR to `datarobot-agent-skills` is currently validated by hand: human developers
+install the changed skill into one or more coding agents (Claude Code, Cursor, Codex,
+Gemini CLI, …), prompt the agent through a representative user journey, and eyeball
+whether the agent reached a good outcome. This is:
+
+- **Slow** — a single train→deploy→predict journey takes tens of minutes per agent.
+- **Expensive** — it consumes senior developer time on every PR, for every affected skill.
+- **Inconsistent** — different testers use different prompts, agents, and success bars,
+  so "it worked for me" is not comparable across PRs or over time.
+- **Non-regressive** — a PR that improves one skill can silently break a linked journey
+  (e.g., a deployment-skill change that breaks the predictions skill's assumptions), and
+  nobody re-tests the unchanged skills.
+
+### What automated testing exists today doesn't cover the gap
+
+| Layer | What it checks | What it misses |
+|---|---|---|
+| `task lint` / `tests/integration/` | Naming, structure, frontmatter, Python lint | Anything about skill *content* |
+| `tests/e2e/` (LLM judge via `dr_agents_tester`) | An LLM reads SKILL.md and critiques clarity/completeness | Whether an agent *following* the skill actually succeeds |
+
+The e2e judge is static review: it catches confusing prose but cannot catch the failure
+modes that actually burn users:
+
+- **API drift** — the skill references an SDK method that was renamed/deprecated
+  (this class of bug is why `datarobot-model-explainability` had to pin
+  `datarobot>=3.6.0` and steer away from the legacy `ShapMatrix` path).
+- **Trigger failure** — the skill's `description` frontmatter doesn't match how users
+  phrase the task, so the agent never loads it and freelances.
+- **Trajectory waste** — the agent eventually succeeds, but only after dead ends,
+  hallucinated methods, and retries that a better-written skill would prevent.
+- **Broken chains** — individually fine skills that hand off badly
+  (train → deploy → predict).
+
+### Why this matters strategically
+
+These skills are customer-facing and distributed through multiple marketplaces
+(Claude plugin marketplace, Cursor, Gemini extensions, the universal installer). A skill
+that fails in a customer's IDE is a product defect, not a docs typo. Additionally, this
+repo's own admission criteria (CLAUDE.md) ask of every skill: *"Is the task complex
+enough? Can an LLM with basic tools achieve the same result?"* — a question we currently
+cannot answer with data.
+
+### What we want instead
+
+A harness that, for any skill (or linked set of skills):
+
+1. Spins up a sandboxed coding agent with the skills installed the same way users
+   install them.
+2. Prompts it through a defined user journey.
+3. **Verifies the outcome programmatically** against real DataRobot state.
+4. Scores the trajectory: time, tokens, turns, dead ends, whether the skill triggered.
+5. Runs automatically when a PR touches the relevant skill, and compares
+   PR-branch vs. main vs. no-skill-at-all.
+6. Produces metrics stable enough that a future optimization loop can search over
+   skill text to maximize outcomes.
+
+---
+
+## 2. Goals & Non-Goals
+
+**Goals**
+
+- Replace the bulk of manual PR testing with automated behavioral runs.
+- Ground-truth outcome verification (DataRobot API state), not judge vibes.
+- Quantified efficiency metrics per (skill, scenario, agent, condition).
+- PR-scoped test selection: only re-run what a change can affect.
+- Statistical honesty about nondeterminism (k trials, pass@k, significance tests).
+- A metrics substrate that a later skill-optimization loop can consume.
+
+**Non-Goals (for now)**
+
+- Automated skill rewriting. The repo strongly prefers human-written skills; any
+  optimization loop proposes diffs for human review (see §9).
+- Testing every coding agent from day one. v1 is Claude Code headless; the driver
+  interface keeps others cheap to add (§5.2).
+- Replacing `task lint` or the static LLM judge — those stay as fast, cheap first lines.
+
+---
+
+## 3. Current State of `dr_agents_tester`
+
+The natural home for this harness already exists. `dr_agents_tester` (hackathon-origin,
+OSS) has two halves:
+
+1. **Skill-text judge** (`skills.py`, `pytest_plugin.py`) — what `tests/e2e/` here uses
+   today. Static SKILL.md critique with an MD5 hash cache (`HashCache`) so CI only pays
+   for changed skills.
+2. **Eval framework** (`eval/`) — a scenario-based A/B evaluation harness with exactly
+   the right skeleton:
+   - Scenario YAML (`prompt`, `expected_files`, `expected_approach`,
+     `common_pitfalls`, `acceptance_criteria`, difficulty tiers) — `eval/scenarios.py`
+   - **Conditions**: each scenario runs under `no_context` / `generated` / `refined`
+     AGENTS.md variants — `eval/models.py: ConditionType`
+   - **n runs per cell**, mean/std, and pairwise t-tests with p-values — `eval/stats.py`
+   - Token and duration tracking per run; Markdown + JSON reports — `eval/report.py`
+
+**The gap is one function.** `eval/runner.py:_run_single` implements the "agent" as a
+single LLM call that writes an *implementation plan* against a static `repo_tree.txt`,
+and a second LLM scores the plan. There is no tool use, no filesystem, no execution, and
+no DataRobot backend. Everything upstream (scenarios, conditions) and downstream
+(scoring, stats, reports) survives; the middle needs to become "drive a real coding
+agent in a sandbox and assert real outcomes."
+
+---
+
+## 4. Proposed Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ CI trigger (PR label / nightly / manual)                         │
+│   └─ changed-files → skill mapping → scenario selection          │
+├──────────────────────────────────────────────────────────────────┤
+│ Evaluator (exists: eval/runner.py)                               │
+│   scenarios × conditions × k runs                                │
+│   ┌────────────────────────────────────────────────────────────┐ │
+│   │ ExecutionBackend (NEW)                                     │ │
+│   │   PlanBackend      — today's single-LLM-call plan eval     │ │
+│   │   AgentBackend     — headless coding agent in sandbox      │ │
+│   │   AgentLiveBackend — AgentBackend + real DataRobot org     │ │
+│   │       ┌──────────────────────────────────────────────┐     │ │
+│   │       │ AgentDriver (NEW)                            │     │ │
+│   │       │   ClaudeCodeDriver (v1) │ CodexDriver │ …    │     │ │
+│   │       └──────────────────────────────────────────────┘     │ │
+│   └────────────────────────────────────────────────────────────┘ │
+│   Outcome checks (NEW, programmatic, vs. DataRobot API)          │
+│   Trajectory normalization (NEW) → metrics                       │
+│   Trajectory judge (adapted from existing scoring prompts)       │
+├──────────────────────────────────────────────────────────────────┤
+│ Scoring / stats / reports (exists: scoring.py, stats.py,         │
+│   report.py — extended with hard outcome fields)                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 4.1 Scenario schema v2
+
+Scenarios live **in this repo**, co-located with the skill they test
+(`skills/<name>/scenarios/*.yaml`), so CODEOWNERS covers skill + tests together.
+`dr_agents_tester` stays the engine. New fields on top of the existing schema:
+
+```yaml
+scenarios:
+  - id: train-deploy-predict-golden
+    name: "Golden journey: train, deploy, predict"
+    difficulty: medium
+    skills_under_test:            # NEW — drives PR→scenario selection
+      - datarobot-model-training
+      - datarobot-model-deployment
+      - datarobot-predictions
+    prompt: |
+      Train a model to predict churn using ./fixtures/churn_small.csv,
+      deploy the best model, and score ./fixtures/churn_holdout.csv with it.
+    fixtures:                     # NEW — files copied into the sandbox workspace
+      - fixtures/churn_small.csv
+      - fixtures/churn_holdout.csv
+    env:                          # NEW — constraints injected into the run
+      automl_mode: quick          # keep runs fast/cheap
+      resource_prefix: "{run_id}" # all created DR resources must carry this
+    success_checks:               # NEW — programmatic, authoritative
+      - type: dr_project_exists
+        name_contains: "{run_id}"
+      - type: dr_deployment_healthy
+        name_contains: "{run_id}"
+      - type: dr_predictions_returned
+        min_rows: 50
+      - type: file_exists
+        path: predictions.csv
+    rubric: |                     # judge guidance for *process* quality only
+      Penalize: legacy Project.start() API era, retries caused by hallucinated
+      SDK methods, skipping the Use Case linkage the training skill mandates.
+    common_pitfalls: [...]        # kept from v1 — feeds the rubric
+    timeout_minutes: 25
+```
+
+**Design rule:** `success_checks` decide pass/fail; the LLM judge only scores *how* the
+agent got there. Judges are unreliable on "did it work"; the DataRobot API is
+authoritative. Check types are a small library of Python assertions
+(`dr_project_exists`, `dr_deployment_healthy`, `dr_predictions_returned`,
+`dr_traces_received` for the monitoring skill, `file_exists`/`file_matches` for local
+outputs, …) — extended as new skills need them.
+
+### 4.2 AgentDriver interface
+
+```python
+class AgentDriver(Protocol):
+    name: str            # "claude-code", "codex", ...
+    version: str         # pinned CLI version, recorded in results
+
+    def run(
+        self,
+        workspace: Path,          # sandbox dir with fixtures + skills installed
+        prompt: str,
+        env: dict[str, str],      # scoped DR credentials, endpoint
+        timeout: timedelta,
+    ) -> RawTranscript: ...
+```
+
+**v1 = `ClaudeCodeDriver`** using `claude -p --output-format stream-json` inside a
+Docker container. Rationale: its JSONL stream is the richest and most stable —
+per-event tool calls with full inputs, tool results including errors, an init event
+listing loaded skills, and a final result with `num_turns`, durations, token usage, and
+cost. Two things fall out for free:
+
+- **Exact skill-trigger detection** — skill activation is an observable transcript
+  event, so "the skill never fired" (a `description` frontmatter bug) is a first-class,
+  measurable failure mode.
+- **Efficiency metrics without instrumentation** — turns, tool calls, error/retry
+  counts, wasted work (edit-then-revert), tokens, wall time.
+
+Codex (`codex exec --json`) is the natural second driver; Gemini CLI and cursor-agent
+emit coarser output, so their adapters will mark some metrics unavailable rather than
+fake them.
+
+**Sandbox contract:** fresh container per run; pinned agent CLI version; skills
+installed via the same installer users run (this also tests packaging); a scoped
+DataRobot API token; the workspace pre-seeded with scenario fixtures; no network access
+beyond the DataRobot endpoint and the agent's model API.
+
+### 4.3 Normalized trajectory schema
+
+Per-driver adapters convert raw transcripts into a common event stream the scoring layer
+consumes, so scoring never knows which agent ran:
+
+```
+TrajectoryEvent = turn_start | tool_call{name, input_digest} | tool_result{ok, error}
+                | skill_triggered{skill_name, turn} | tokens{in, out} | done{...}
+```
+
+Derived metrics per run: `outcome_pass` (from success_checks), `wall_seconds`,
+`total_tokens`, `num_turns`, `num_tool_calls`, `num_errors`, `num_retries`,
+`skill_triggered` (bool + turn), `judge_score` (soft, 0–1). Raw transcripts are archived
+as CI artifacts — over time this becomes the dataset that powers regression triage and
+any optimization work.
+
+### 4.4 Conditions: measuring skill lift
+
+Repoint the existing `ConditionType` mechanism from AGENTS.md variants to skill
+variants:
+
+| Condition | Question it answers |
+|---|---|
+| `no_skill` | Baseline — can the agent do this with just the SDK? Directly operationalizes CLAUDE.md's "is the task complex enough to be a skill?" criterion. |
+| `skill_main` | Current released behavior. |
+| `skill_pr` | The PR under review. |
+
+A PR run is then a pairwise comparison the existing `stats.py` t-test machinery already
+computes: *did `skill_pr` beat `skill_main`, and does either beat `no_skill`?*
+
+### 4.5 Nondeterminism & gating
+
+- k trials per cell: **k=3 on PR runs, k=5–10 nightly.**
+- Report pass@k and mean efficiency with std; gate on **regression vs. the stored
+  baseline** for (skill, scenario, agent), not absolute thresholds — this also catches
+  drift when an agent CLI version bump changes behavior.
+- Behavioral tests start **advisory** (comment on the PR, don't block merge) until
+  observed flake rates justify making them required.
+
+---
+
+## 5. DataRobot Backend Strategy
+
+Skills create real projects, deployments, and AutoML runs, so outcome checks need a real
+backend. Three tiers:
+
+| Tier | Backend | When | Cost/fidelity |
+|---|---|---|---|
+| Smoke | Lightweight fake DR API server (records calls, canned responses) | Every PR, fast | Cheap; validates call shapes only, drifts from real API |
+| **Live (primary)** | **Dedicated test org on app.datarobot.com** | PR label + nightly | Real outcomes; Quick-mode AutoML on toy datasets keeps runs ~minutes |
+| Pre-release | staging.datarobot.com | Optional, before releases | Highest internal fidelity |
+
+**Why app.datarobot.com over staging as the CI backbone:** staging requires Global VPN,
+which vanilla GitHub Actions runners cannot reach. The alternatives — self-hosted
+runners inside the VPC — are a known security footgun on a *public* repo (fork PRs
+executing on internal infrastructure), and an internal mirror pipeline adds coupling.
+A dedicated prod test org is reachable from hosted runners, and is arguably the more
+honest environment: it's what customers' agents actually hit. Staging becomes a
+nice-to-have pre-release check run from inside the network, not the CI path.
+
+**Hygiene requirements:**
+
+- Fresh, scoped, org-isolated **service-account credentials** minted for this harness —
+  never tokens copied from wiki pages (several internal Confluence pages are known to
+  contain pasted live credentials; treat those as radioactive).
+- Every created resource carries a `{run_id}` prefix; a teardown job deletes by prefix
+  after each run, plus a nightly sweeper for leaked resources older than 24h.
+- Quota/budget alarms on the test org.
+
+**Record/replay (VCR cassettes) considered and rejected** as the primary strategy:
+agents don't make deterministic call sequences, so cassette misses would dominate.
+
+---
+
+## 6. CI Integration
+
+- **Changed-files → skills mapping:** the `skills/<name>/` layout makes this a path
+  prefix match; the existing `HashCache` pattern already proves the approach.
+- **Dependency manifest** (`tests/e2e/skill_deps.yaml` or similar): predictions depends
+  on deployment depends on training; agent-assist sub-skills link. A change to a skill
+  re-runs its own scenarios **plus chained journeys that pass through it**.
+- Changes to shared infra (CLAUDE.md, plugin configs, installer paths) trigger a sampled
+  subset, not the full matrix.
+- **Triggers:** fake-server smoke on every PR; live runs on a `run-e2e` PR label
+  (maintainer-applied — this also protects the test-org credentials from fork PRs, since
+  labels require maintainer action); full matrix nightly.
+- **Output:** a PR comment table — per scenario: pass@k, Δ vs. main, Δ vs. no-skill,
+  efficiency deltas, links to transcript artifacts.
+
+---
+
+## 7. Relationship to `dr_agents_tester`
+
+Proposed as an extension, pending the original author's input. Concrete extension
+points:
+
+| Change | Where | Nature |
+|---|---|---|
+| `ExecutionBackend` protocol; `_run_single` delegates to it | `eval/runner.py` | The core surgery — today's LLM call becomes `PlanBackend` |
+| `AgentDriver` + `ClaudeCodeDriver` + sandbox management | new `eval/drivers/` | New code |
+| Scenario schema v2 fields (`skills_under_test`, `fixtures`, `success_checks`, `env`) | `eval/scenarios.py`, `eval/models.py` | Additive |
+| Skill-variant `ConditionType` (`no_skill`/`skill_main`/`skill_pr`) | `eval/models.py` | Additive |
+| Outcome-check library (DR API assertions) | new `eval/checks/` | New code |
+| Trajectory normalization + metrics | new `eval/trajectory.py` | New code |
+| `ScoreCard` gains hard fields (`outcome_pass`, efficiency metrics) | `eval/models.py`, `eval/scoring.py` | Additive; gate moves to hard fields |
+| Reports gain pass@k + baseline-delta sections | `eval/report.py`, `eval/stats.py` | Additive |
+
+Scenario YAML, fixtures, and the dependency manifest live in **datarobot-agent-skills**;
+the engine, drivers, and check library live in **datarobot-agent-tester**. If the
+original author prefers to keep the package scoped to AGENTS.md work, the fallback is a
+sibling package that depends on it and reuses `eval/stats.py` + `eval/report.py`.
+
+---
+
+## 8. Phasing
+
+| Phase | Deliverable | Exit criterion |
+|---|---|---|
+| **v0** | `ExecutionBackend` refactor in dr_agents_tester; `PlanBackend` preserves current behavior; scenario schema v2 parser | Existing evals green under new interface |
+| **v1** | `ClaudeCodeDriver` + Docker sandbox; one golden journey (upload→train(Quick)→deploy→predict) with `success_checks` against the live test org; k=3; transcript artifacts; nightly + `run-e2e` label | Golden journey runs unattended end-to-end; manual testing optional for that path |
+| **v2** | Scenario coverage for remaining skills; dependency manifest + PR-scoped selection; PR comment reports; `no_skill` baseline condition | Most PRs need no manual testing |
+| **v3** | Trajectory judge + full efficiency metrics; second driver (Codex); baseline-regression gating | Behavioral checks become required (if flake rate allows) |
+| **v4** | Optimization advisor (§9) | First judge-guided skill improvement merged via human review |
+
+v1 alone removes most of the manual burden for the most-exercised path.
+
+---
+
+## 9. Future: Skill Optimization Loop
+
+With scalar rewards per (skill, scenario) — pass@k, efficiency, trigger rate — a
+textual-optimization loop (GEPA/OPRO-style) is mechanically straightforward: failing
+trajectories → judge critique → proposer edits SKILL.md → re-eval → keep if better. Two
+governing constraints:
+
+1. **Advisor, not auto-committer.** This repo explicitly prefers human-written skills.
+   The loop emits proposed diffs *with evidence* ("this edit raised pass rate 60%→90%
+   over 10 trials; transcripts attached") as draft PRs for human review.
+2. **Held-out scenarios.** Skill text optimized against 3 scenarios will Goodhart them.
+   Maintain a held-out scenario set the optimizer never sees, and rotate it.
+
+Nothing in v1–v3 needs to change to enable this; the transcript archive and metrics
+schema are designed so the optimizer is purely additive.
+
+---
+
+## 10. Risks & Open Questions
+
+| Risk / question | Notes |
+|---|---|
+| Live-run cost & duration | Quick-mode AutoML + toy datasets targets <15 min/scenario; budget alarms on the test org. Needs a measured baseline in v1. |
+| Flakiness blocking merges | Start advisory; promote to required per-scenario once flake rate <~5% at k=3. |
+| Test-org provisioning & ownership | Who owns the org, quota, and the service account? Needs an owner before v1. |
+| Fork-PR credential safety | Live runs only via maintainer-applied label; secrets never exposed to fork workflows. |
+| Agent CLI version drift | Pin versions in the sandbox image; version recorded per result; nightly canary against `latest`. |
+| `dr_agents_tester` stewardship | Original author's appetite for this extension — this doc is the conversation starter. Fallback: sibling package (§7). |
+| Judge model choice | Existing cross-model pattern (generator ≠ judge) should carry over to trajectory judging. |
+| Scenario authoring cost | Each skill needs 2–3 scenarios + checks. Mitigation: check-type library keeps YAML small; scenario authoring becomes part of the skill-contribution checklist in CONTRIBUTING.md. |
+
+---
+
+## Appendix A: Candidate golden journeys (v1–v2)
+
+1. **Train→deploy→predict chain** (`datarobot-model-training`,
+   `datarobot-model-deployment`, `datarobot-predictions`) — the highest-traffic path;
+   checks: project exists, deployment healthy, predictions returned.
+2. **Predictions against a fixture deployment** (`datarobot-predictions` alone) — a
+   pre-provisioned long-lived deployment in the test org removes AutoML from the loop;
+   fast enough for every-PR live runs.
+3. **External agent monitoring** (`datarobot-external-agent-monitoring`) — instrument a
+   toy LangGraph agent in the sandbox; check: OTel traces arrive under the Use Case
+   (`dr_traces_received`).
+4. **Setup & recovery** (`datarobot-setup`) — sandbox with deliberately missing/invalid
+   credentials; check: SDK client authenticates by the end. Exercises the
+   auto-invocation contract in CLAUDE.md.
+5. **SHAP explainability** (`datarobot-model-explainability`) — checks the modern
+   `datarobot.insights` API path is used (trajectory rubric) and a SHAP matrix is
+   computed (outcome check); this is the skill where API drift already bit once.

--- a/docs/proposals/skill-behavioral-testing.md
+++ b/docs/proposals/skill-behavioral-testing.md
@@ -1,8 +1,8 @@
 # Proposal: Automated Behavioral Testing for DataRobot Agent Skills
 
-**Status:** v0 + v1 implemented (see amendments below)
+**Status:** v0 + v1 implemented; v2 first-wave scenario coverage implemented (see amendments below)
 **Author:** Matthew Hausknecht (drafted with Claude)
-**Date:** 2026-08-17 (amended 2026-08-18)
+**Date:** 2026-08-17 (amended 2026-08-18, 2026-08-20)
 **Related:** [datarobot-agent-skills](https://github.com/datarobot-oss/datarobot-agent-skills), [datarobot-agent-tester](https://github.com/datarobot-oss/datarobot-agent-tester)
 
 ---
@@ -41,6 +41,37 @@
    unchanged), scenario schema v2 (`kind: behavioral`), a success-check
    registry, trajectory normalization with capability-honest metrics, and a
    `[behavioral]` extra carrying the DataRobot SDK.
+
+## Amendments (2026-08-20, during v2 first-wave implementation)
+
+6. **Fixture-id injection (§4.1 extended).** Scenarios that assert against
+   pre-provisioned resources declare `requires_env:
+   [BEHAVIORAL_FIXTURE_...]` and reference the ids as `{env:VAR}` tokens in
+   the prompt, `env` values, and string check params. Fail-loud at three
+   layers: parse time (references must be declared; names must match
+   `BEHAVIORAL_*`/`DRAT_*` so credentials can never be templated), run start
+   (missing variables abort before any agent tokens are spent), and
+   substitution. Long-lived fixtures are built by
+   `tests/behavioral/fixtures/provision_fixtures.py` and named with the
+   **`bfix-` prefix** — deliberately outside the `drat-` family so teardown
+   and the sweeper can never delete them.
+7. **Trace read API verified.** `GET
+   api/v2/otel/experiment_container/<use_case_id>/traces/` returns trace
+   summaries (traceId, spansCount, errorSpansCount, …); observed ingestion
+   latency is under a minute. `dr_traces_received` therefore shipped with
+   checks wave 1 instead of a follow-up PR, polling with a deadline.
+8. **Expected-trigger metric (§4.3 extended).** The live feature-impact spike
+   showed `datarobot-model-explainability` organically claiming "analyze the
+   feature importance for my model" (and passing the outcome via SHAP) —
+   the trigger collision §4.3's `skill_triggered` boolean cannot see. Runs
+   now also record `skill_triggered_expected` (any triggered skill ∈
+   `skills_under_test`) and reports aggregate an expected-skill trigger
+   rate. Report-only, never gated.
+9. **Multi-directory scenario discovery.** `--scenarios` is repeatable and
+   each directory is scanned one subdirectory level deep, so
+   `tests/behavioral/scenarios` picks up every `scenarios/<skill>/` dir in
+   one invocation (one aggregated report); duplicate scenario ids across
+   directories are rejected.
 
 ---
 
@@ -381,11 +412,11 @@ sibling package that depends on it and reuses `eval/stats.py` + `eval/report.py`
 
 ## 8. Phasing
 
-| Phase | Deliverable | Exit criterion | Status (2026-08-19) |
+| Phase | Deliverable | Exit criterion | Status (2026-08-20) |
 |---|---|---|---|
 | **v0** | `ExecutionBackend` refactor in dr_agents_tester; `PlanBackend` preserves current behavior; scenario schema v2 parser | Existing evals green under new interface | ✅ Done — [tester PR #10](https://github.com/datarobot-oss/datarobot-agent-tester/pull/10) |
 | **v1** | Agent driver (OpenCode, per amendment 2) + sandbox; one golden journey (upload→train(Quick)→deploy→predict) with `success_checks`; k configurable; transcript artifacts; nightly + `run-e2e` label workflow (inert) | Golden journey runs unattended end-to-end | ✅ Done — golden journey **passed live** (all 4 checks, 21.5 min, all 3 skills triggered, zero leaked resources); `no_skill` baseline condition also landed early. CI workflow merged inert, pending the test org |
-| **v2** | Scenario coverage for remaining skills; dependency manifest + PR-scoped selection; PR comment reports | Most PRs need no manual testing | ⬜ See §10a roadmap |
+| **v2** | Scenario coverage for remaining skills; dependency manifest + PR-scoped selection; PR comment reports | Most PRs need no manual testing | ◐ First wave done — all five README journeys live-verified 6/6 in one aggregated run (amendments 6–9); selection + PR comments remain. See §10a |
 | **v3** | Trajectory judge; second driver (Claude Code); baseline-regression gating | Behavioral checks become required (if flake rate allows) | ⬜ See §10a roadmap |
 | **v4** | Optimization advisor (§9) | First judge-guided skill improvement merged via human review | ⬜ Distant aspiration |
 
@@ -446,9 +477,13 @@ Items are ordered roughly by dependency, not size.
 - **R3 — Dedicated test org** (the only externally blocked step): org +
   scoped service-account token + budget/quota alarms + a named owner. Then:
   create the `behavioral-live` GitHub environment with
-  `BEHAVIORAL_DATAROBOT_API_TOKEN`/`BEHAVIORAL_DATAROBOT_ENDPOINT`, flip
-  `vars.BEHAVIORAL_LIVE_ENABLED`, one supervised `workflow_dispatch` run,
-  announce the `run-e2e` label.
+  `BEHAVIORAL_DATAROBOT_API_TOKEN`/`BEHAVIORAL_DATAROBOT_ENDPOINT`, run
+  `provision_fixtures.py` against the test org and set the printed
+  `BEHAVIORAL_FIXTURE_{PROJECT,MODEL,DEPLOYMENT}_ID` values as environment
+  **variables** (ids aren't secrets; fixture-dependent scenarios stay out of
+  CI until they exist), flip `vars.BEHAVIORAL_LIVE_ENABLED`, one supervised
+  `workflow_dispatch` run, announce the `run-e2e` label. Until R3, the
+  fixtures live in a developer account (bootstrapped 2026-08-20).
 - **R4 — Accumulate the nightly baseline** (flake rate + cost per scenario;
   the <5%-at-k=3 bar from §4.5 decides when checks can become required).
 
@@ -517,6 +552,10 @@ transcripts, pass@k / trigger-rate metrics) is already being archived.
 - Nested sub-skill trigger naming: `skills_used` records whatever name the
   `skill` tool reports — verify agent-assist sub-skills surface distinctly
   (locks the trajectory-schema contract from amendment note; spike-level).
+  Data point (2026-08-20): across six live runs, reported names always
+  matched top-level skill directory names (including a chained
+  `datarobot-data-preparation` sub-use); agent-assist sub-skills remain
+  unexercised.
 - `dr_predictions_returned --verify_server` is best-effort corroboration
   only; revisit if workspace-CSV assertions ever prove spoofable.
 - Spike S7 leftovers: fresh-deployment `service_health` semantics are
@@ -530,18 +569,31 @@ transcripts, pass@k / trigger-rate metrics) is already being archived.
 
 ## Appendix A: Candidate golden journeys (v1–v2)
 
-1. **Train→deploy→predict chain** (`datarobot-model-training`,
+1. ✅ **Train→deploy→predict chain** (`datarobot-model-training`,
    `datarobot-model-deployment`, `datarobot-predictions`) — the highest-traffic path;
    checks: project exists, deployment healthy, predictions returned.
-2. **Predictions against a fixture deployment** (`datarobot-predictions` alone) — a
+   (`journeys/train-deploy-predict.yaml`, v1)
+2. ✅ **Predictions against a fixture deployment** (`datarobot-predictions` alone) — a
    pre-provisioned long-lived deployment in the test org removes AutoML from the loop;
    fast enough for every-PR live runs.
-3. **External agent monitoring** (`datarobot-external-agent-monitoring`) — instrument a
+   (`scenarios/datarobot-predictions/prediction-template.yaml`, ~2 min live)
+3. ✅ **External agent monitoring** (`datarobot-external-agent-monitoring`) — instrument a
    toy LangGraph agent in the sandbox; check: OTel traces arrive under the Use Case
    (`dr_traces_received`).
-4. **Setup & recovery** (`datarobot-setup`) — sandbox with deliberately missing/invalid
+   (`scenarios/datarobot-external-agent-monitoring/instrument-toy-agent.yaml`)
+4. ⬜ **Setup & recovery** (`datarobot-setup`) — sandbox with deliberately missing/invalid
    credentials; check: SDK client authenticates by the end. Exercises the
    auto-invocation contract in CLAUDE.md.
-5. **SHAP explainability** (`datarobot-model-explainability`) — checks the modern
+5. ⬜ **SHAP explainability** (`datarobot-model-explainability`) — checks the modern
    `datarobot.insights` API path is used (trajectory rubric) and a SHAP matrix is
    computed (outcome check); this is the skill where API drift already bit once.
+   Note: a live run showed this skill *organically* triggering on plain
+   "analyze the feature importance" phrasing (amendment 8), so its scenario
+   should also pin down the description boundary with
+   `datarobot-feature-engineering`.
+
+The 2026-08-20 first wave additionally covered three journeys beyond this
+list, straight from the README's published examples: training-start-automl
+(start Quick AutoML without waiting — `dr_project_exists` with
+`stage: modeling`), feature-impact-report, and monitoring-drift-report (both
+against the pre-provisioned fixtures).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dev = [
 ]
 integration = [
     "datarobot-genai",
+    # Required by test_sdk_conformance.py: skills are validated against the real SDK.
+    "datarobot>=3.6",
     "python-frontmatter>=1.1",
     "pytest>=8.0",
     "codeowners>=0.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,16 @@ e2e = [
     "pytest",
     "pytest-asyncio",
 ]
+behavioral = [
+    # Behavioral test engine (agent driver, DataRobot outcome checks, teardown).
+    # TODO: tighten to a version tag once datarobot-agent-tester cuts its first
+    # release (the engine's [behavioral] extra then replaces the direct
+    # datarobot pin below). For local development against an engine checkout:
+    #   uv pip install -e '../datarobot-agent-tester[behavioral]'
+    "datarobot-agent-tester @ git+https://github.com/datarobot/datarobot-agent-tester@main",
+    "datarobot>=3.6",
+    "python-dotenv>=1.2.2",
+]
 
 [tool.pytest.ini_options]
 

--- a/tests/behavioral/README.md
+++ b/tests/behavioral/README.md
@@ -1,0 +1,96 @@
+# Behavioral scenarios
+
+Behavioral tests drive a **real coding agent** (OpenCode, pinned version)
+through a realistic user journey with this repo's skills installed the same
+way users install them, then verify the outcome **programmatically** against
+real DataRobot state. They complement the static LLM judge in `tests/e2e/`
+(which reviews skill *text*) by testing skill *behavior*: API drift, trigger
+failures, trajectory waste, and broken skill chains.
+
+The engine lives in
+[datarobot-agent-tester](https://github.com/datarobot-oss/datarobot-agent-tester)
+(`dr-agent eval run-behavioral`); this directory holds the scenarios and
+fixtures. Design doc: [docs/proposals/skill-behavioral-testing.md](../../docs/proposals/skill-behavioral-testing.md).
+
+## Layout
+
+```
+tests/behavioral/
+  journeys/            # multi-skill user journeys (2+ skills_under_test)
+  scenarios/<skill>/   # single-skill scenarios, one directory per skill name
+  fixtures/            # committed CSVs + the seeded generator that made them
+```
+
+Scenarios live here — **never under `skills/`** — because everything in
+`skills/` ships to end users through every packaging channel, and the agent
+under test must not be able to read its own `success_checks`.
+
+## Scenario schema (`kind: behavioral`)
+
+```yaml
+scenarios:
+  - id: my-scenario                 # unique, kebab-case
+    kind: behavioral                # required — plan-eval scenarios omit it
+    name: "Human-readable name"
+    difficulty: easy|medium|hard|expert
+    prompt: |                       # what a real user would type — keep it natural;
+      ...                           # {run_id} is substituted per run
+    skills_under_test:              # drives (future) PR-scoped selection
+      - datarobot-model-training
+    fixtures:                       # copied into the sandbox workspace
+      - source: ../fixtures/churn_train.csv   # relative to this YAML's directory
+        dest: data/churn_train.csv            # path inside the workspace
+    env:                            # injected into the agent's environment
+      resource_prefix: "{run_id}"   # ALSO appends a prompt epilogue telling the
+                                    # agent to prefix every DataRobot resource name
+    success_checks:                 # programmatic, authoritative pass/fail
+      - type: dr_project_exists
+        name_contains: "{run_id}"
+    rubric: |                       # guidance for the (future) trajectory judge —
+      ...                           # process quality only, never pass/fail
+    common_pitfalls: [...]
+    timeout_minutes: 30
+```
+
+### Check types
+
+| Type | Params | Asserts |
+|---|---|---|
+| `file_exists` | `path` (workspace-relative, glob ok), `min_bytes` | a file the agent was asked to produce exists |
+| `dr_project_exists` | `name_contains` | a DataRobot project matching the run prefix exists |
+| `dr_deployment_healthy` | `name_contains` | a matching deployment exists, has a model, isn't `failing` |
+| `dr_predictions_returned` | `path`, `min_rows`, `prediction_column`, `verify_server` | a predictions CSV with enough rows and a prediction column |
+
+New check types are added in the engine
+(`dr_agents_tester/eval/checks/`) — keep scenario YAML small.
+
+## Running locally
+
+Behavioral runs create **real, run-prefixed resources in your DataRobot
+account** and tear them down afterwards. You need `DATAROBOT_API_TOKEN` /
+`DATAROBOT_ENDPOINT` (a `.env` works) and the pinned OpenCode version
+(`npm install -g opencode-ai@<pinned>` — the run tells you the pin on mismatch).
+
+```bash
+task test:behavioral            # golden journey, your working-tree skills, k=1
+task test:behavioral:baseline   # same scenario with NO skills installed
+task test:behavioral:clean      # delete any leaked drat-* resources now
+```
+
+Per-run artifacts (raw transcript, normalized trajectory, check evidence)
+land in `.behavioral-runs/<run_id>/`.
+
+## Authoring guidelines
+
+- **Prompts stay realistic.** Write what a user would actually type; never
+  mention run ids or naming rules — `env.resource_prefix` injects that.
+- **Checks decide pass/fail; the rubric never does.** If you can't assert it
+  against the DataRobot API or the workspace, it belongs in `rubric`.
+- Fixture data: commit small CSVs (DataRobot needs ≥20 rows to create a
+  project; stay near a few hundred rows so Quick-mode AutoML stays fast) and
+  regenerate them only via `fixtures/generate_fixtures.py` (seeded).
+  `.gitignore` blanket-ignores `*.csv` — new fixture files need a negation
+  entry (`!tests/behavioral/fixtures/*.csv` already covers this directory).
+- One skill → `scenarios/<skill-name>/`; a chain of skills → `journeys/`.
+- Scenario-only changes don't ship in any plugin package: **no plugin version
+  bump, no CHANGELOG entry.**

--- a/tests/behavioral/README.md
+++ b/tests/behavioral/README.md
@@ -18,7 +18,9 @@ fixtures. Design doc: [docs/proposals/skill-behavioral-testing.md](../../docs/pr
 tests/behavioral/
   journeys/            # multi-skill user journeys (2+ skills_under_test)
   scenarios/<skill>/   # single-skill scenarios, one directory per skill name
-  fixtures/            # committed CSVs + the seeded generator that made them
+  fixtures/            # committed CSVs, the toy_agent/ project, the seeded
+                       # generator, and provision_fixtures.py (long-lived
+                       # DataRobot fixture resources)
 ```
 
 Scenarios live here — **never under `skills/`** — because everything in
@@ -43,6 +45,8 @@ scenarios:
     env:                            # injected into the agent's environment
       resource_prefix: "{run_id}"   # ALSO appends a prompt epilogue telling the
                                     # agent to prefix every DataRobot resource name
+    requires_env:                   # host env vars holding pre-provisioned
+      - BEHAVIORAL_FIXTURE_DEPLOYMENT_ID   # fixture-resource ids (see below)
     success_checks:                 # programmatic, authoritative pass/fail
       - type: dr_project_exists
         name_contains: "{run_id}"
@@ -57,12 +61,47 @@ scenarios:
 | Type | Params | Asserts |
 |---|---|---|
 | `file_exists` | `path` (workspace-relative, glob ok), `min_bytes` | a file the agent was asked to produce exists |
-| `dr_project_exists` | `name_contains` | a DataRobot project matching the run prefix exists |
+| `file_matches` | `path` (glob ok), `pattern` (regex on raw text), `ignorecase`, `min_count`, `max_bytes` | a produced file's *content* — works on non-CSV output and `#`-commented CSVs |
+| `dr_project_exists` | `name_contains`, `stage` (e.g. `modeling` = autopilot started), `deadline_seconds` + `poll_seconds` (poll for state still settling) | a DataRobot project matching the run prefix exists (optionally at a lifecycle stage) |
+| `dr_use_case_exists` | `name_contains` | a Use Case matching the run prefix exists (the Use-Case-first flow) |
 | `dr_deployment_healthy` | `name_contains` | a matching deployment exists, has a model, isn't `failing` |
 | `dr_predictions_returned` | `path`, `min_rows`, `prediction_column`, `verify_server` | a predictions CSV with enough rows and a prediction column |
+| `dr_traces_received` | `use_case_name_contains`, `min_traces`, `deadline_seconds`, `poll_seconds` | OTel traces arrived under the Use Case (polls; ingestion is async) |
 
 New check types are added in the engine
 (`dr_agents_tester/eval/checks/`) — keep scenario YAML small.
+
+### Pre-provisioned fixture resources (`requires_env` / `{env:VAR}`)
+
+Read-only journeys (a prediction template, feature impact, drift) assert
+against **long-lived DataRobot resources** instead of paying for AutoML in
+every run. `fixtures/provision_fixtures.py` builds them once per account —
+Use Case → dataset → Quick-AutoML project → recommended model with Feature
+Impact computed → deployment with drift tracking and scored holdout traffic —
+and prints their ids:
+
+```bash
+task test:behavioral:fixtures        # provision (idempotent) and print ids
+task test:behavioral:fixtures:check  # validate-only (CI preflight)
+```
+
+Export the printed `BEHAVIORAL_FIXTURE_{PROJECT,MODEL,DEPLOYMENT}_ID` lines
+(e.g. append them to your `.env`). Scenarios declare what they need in
+`requires_env` and reference the ids as `{env:VAR}` tokens in the prompt,
+`env` values, or check params. Guard rails, all fail-loud:
+
+- Every `{env:VAR}` reference must be declared in `requires_env`, and names
+  must start with `BEHAVIORAL_` or `DRAT_` — a scenario can never template
+  credentials into a prompt.
+- A missing/empty declared variable aborts the whole invocation **before**
+  any agent tokens are spent. Drop the scenario directory from `--scenarios`
+  to skip fixture-dependent scenarios instead.
+
+Everything the script creates is named with the **`bfix-` prefix** —
+deliberately outside the `drat-` family that per-run teardown and
+`dr-agent eval sweep` match, so cleanup can never delete the fixtures.
+Rebuild them with `--recreate`; rescore drift traffic with
+`--refresh-traffic` (nightly CI does this so drift windows stay populated).
 
 ## Running locally
 
@@ -72,8 +111,9 @@ account** and tear them down afterwards. You need `DATAROBOT_API_TOKEN` /
 (`npm install -g opencode-ai@<pinned>` — the run tells you the pin on mismatch).
 
 ```bash
-task test:behavioral            # golden journey, your working-tree skills, k=1
-task test:behavioral:baseline   # same scenario with NO skills installed
+task test:behavioral:fixtures   # one-time: provision bfix-* fixture resources
+task test:behavioral            # all scenarios, your working-tree skills, k=1
+task test:behavioral:baseline   # same scenarios with NO skills installed
 task test:behavioral:clean      # delete any leaked drat-* resources now
 ```
 

--- a/tests/behavioral/fixtures/churn_holdout.csv
+++ b/tests/behavioral/fixtures/churn_holdout.csv
@@ -1,0 +1,61 @@
+customer_id,tenure_months,monthly_charges,total_charges,contract_type,payment_method,internet_service,num_support_tickets,has_paperless_billing
+CUST-00300,40,27.90,1107.18,Two year,Mailed check,Fiber optic,0,Yes
+CUST-00301,56,93.00,5128.04,Month-to-month,Electronic check,No,0,Yes
+CUST-00302,23,31.94,713.16,One year,Mailed check,Fiber optic,0,No
+CUST-00303,17,94.98,1594.23,One year,Electronic check,Fiber optic,0,No
+CUST-00304,9,46.29,415.57,One year,Credit card,Fiber optic,0,No
+CUST-00305,22,56.77,1155.91,Month-to-month,Electronic check,DSL,1,Yes
+CUST-00306,2,44.46,84.22,Month-to-month,Mailed check,DSL,5,Yes
+CUST-00307,54,42.45,2119.98,Two year,Bank transfer,DSL,0,No
+CUST-00308,7,37.93,260.31,Two year,Credit card,DSL,1,No
+CUST-00309,40,52.73,2014.94,Month-to-month,Mailed check,DSL,2,Yes
+CUST-00310,64,119.78,7494.12,One year,Mailed check,DSL,5,Yes
+CUST-00311,45,83.59,3646.24,Month-to-month,Bank transfer,DSL,2,No
+CUST-00312,68,118.31,7578.32,Two year,Mailed check,Fiber optic,0,Yes
+CUST-00313,67,61.31,4064.88,Month-to-month,Electronic check,Fiber optic,1,No
+CUST-00314,8,63.50,506.18,Month-to-month,Bank transfer,No,5,No
+CUST-00315,42,51.81,2017.60,Month-to-month,Mailed check,DSL,2,Yes
+CUST-00316,22,64.96,1331.09,Month-to-month,Bank transfer,No,0,No
+CUST-00317,16,29.04,455.70,Month-to-month,Electronic check,DSL,3,Yes
+CUST-00318,32,116.84,3513.14,Month-to-month,Bank transfer,DSL,8,Yes
+CUST-00319,58,75.60,4187.54,Month-to-month,Electronic check,No,0,Yes
+CUST-00320,29,33.07,942.12,Month-to-month,Electronic check,Fiber optic,0,Yes
+CUST-00321,9,39.78,345.35,Two year,Electronic check,No,3,No
+CUST-00322,60,25.06,1492.19,Month-to-month,Credit card,Fiber optic,0,No
+CUST-00323,28,110.83,2878.25,Month-to-month,Mailed check,DSL,1,Yes
+CUST-00324,64,61.20,3740.81,Month-to-month,Bank transfer,DSL,1,Yes
+CUST-00325,70,99.48,6956.22,One year,Bank transfer,Fiber optic,2,No
+CUST-00326,65,52.16,3143.05,Month-to-month,Mailed check,DSL,3,No
+CUST-00327,61,72.94,4345.60,Two year,Mailed check,DSL,2,No
+CUST-00328,8,96.40,767.17,One year,Credit card,DSL,3,Yes
+CUST-00329,41,100.62,4000.68,Two year,Electronic check,Fiber optic,0,Yes
+CUST-00330,25,103.67,2542.61,Two year,Bank transfer,DSL,0,Yes
+CUST-00331,29,21.99,604.42,Month-to-month,Mailed check,No,0,Yes
+CUST-00332,42,25.96,997.39,One year,Mailed check,Fiber optic,3,No
+CUST-00333,48,90.45,4194.91,One year,Bank transfer,DSL,0,Yes
+CUST-00334,56,99.18,5532.23,One year,Mailed check,Fiber optic,1,No
+CUST-00335,23,57.84,1294.93,Month-to-month,Mailed check,Fiber optic,5,No
+CUST-00336,5,38.21,178.02,Two year,Mailed check,Fiber optic,0,No
+CUST-00337,10,43.80,437.23,Month-to-month,Electronic check,No,2,No
+CUST-00338,34,40.97,1350.24,Month-to-month,Electronic check,Fiber optic,0,No
+CUST-00339,22,108.46,2265.16,Month-to-month,Credit card,DSL,1,Yes
+CUST-00340,10,99.92,902.62,Month-to-month,Bank transfer,No,0,Yes
+CUST-00341,21,93.20,1868.55,Two year,Electronic check,DSL,8,No
+CUST-00342,56,114.24,5863.25,Two year,Mailed check,DSL,0,Yes
+CUST-00343,71,92.20,6369.44,Month-to-month,Bank transfer,DSL,0,No
+CUST-00344,63,35.36,2085.29,Month-to-month,Bank transfer,No,1,No
+CUST-00345,4,40.70,156.91,Two year,Credit card,No,0,No
+CUST-00346,34,29.11,944.62,Month-to-month,Credit card,DSL,1,No
+CUST-00347,34,42.62,1343.09,Month-to-month,Electronic check,DSL,0,No
+CUST-00348,30,75.36,2224.81,Two year,Credit card,No,2,No
+CUST-00349,31,67.63,1903.43,Two year,Electronic check,Fiber optic,5,Yes
+CUST-00350,58,37.29,2159.44,Two year,Mailed check,DSL,1,No
+CUST-00351,19,103.41,1818.98,Two year,Electronic check,DSL,1,No
+CUST-00352,67,65.82,4354.14,One year,Credit card,DSL,0,Yes
+CUST-00353,13,98.57,1264.43,Two year,Credit card,DSL,2,No
+CUST-00354,36,60.30,2087.93,One year,Credit card,DSL,3,No
+CUST-00355,7,94.57,656.75,Two year,Electronic check,DSL,2,No
+CUST-00356,63,105.82,6456.56,Two year,Mailed check,DSL,8,No
+CUST-00357,42,46.94,1856.50,One year,Mailed check,Fiber optic,5,No
+CUST-00358,67,106.72,7022.26,One year,Mailed check,DSL,2,No
+CUST-00359,68,107.93,6626.56,Month-to-month,Mailed check,No,0,No

--- a/tests/behavioral/fixtures/churn_train.csv
+++ b/tests/behavioral/fixtures/churn_train.csv
@@ -1,0 +1,301 @@
+customer_id,tenure_months,monthly_charges,total_charges,contract_type,payment_method,internet_service,num_support_tickets,has_paperless_billing,churn
+CUST-00000,15,22.50,313.03,Month-to-month,Electronic check,Fiber optic,3,Yes,Yes
+CUST-00001,5,22.98,105.92,One year,Electronic check,Fiber optic,2,No,No
+CUST-00002,36,100.94,3272.82,Two year,Credit card,DSL,0,No,No
+CUST-00003,49,29.67,1431.66,One year,Electronic check,Fiber optic,1,No,No
+CUST-00004,38,102.94,3762.50,Two year,Mailed check,Fiber optic,0,Yes,No
+CUST-00005,11,105.53,1145.33,Month-to-month,Credit card,Fiber optic,0,No,Yes
+CUST-00006,35,90.18,3056.42,Month-to-month,Mailed check,Fiber optic,0,No,Yes
+CUST-00007,72,41.96,2816.98,One year,Electronic check,DSL,0,No,No
+CUST-00008,9,41.10,367.79,Two year,Bank transfer,DSL,1,No,No
+CUST-00009,18,44.66,768.62,Month-to-month,Credit card,No,0,Yes,Yes
+CUST-00010,18,70.95,1161.00,Month-to-month,Electronic check,DSL,0,No,No
+CUST-00011,50,58.16,2906.87,One year,Electronic check,Fiber optic,0,No,No
+CUST-00012,44,31.16,1293.54,Month-to-month,Bank transfer,No,2,Yes,Yes
+CUST-00013,39,104.17,3862.61,Month-to-month,Bank transfer,Fiber optic,1,Yes,Yes
+CUST-00014,63,21.95,1373.05,Two year,Bank transfer,DSL,0,Yes,No
+CUST-00015,63,101.60,6386.71,One year,Mailed check,DSL,1,Yes,No
+CUST-00016,55,116.44,6358.67,One year,Mailed check,Fiber optic,0,No,No
+CUST-00017,67,65.15,4036.76,Month-to-month,Electronic check,Fiber optic,0,Yes,No
+CUST-00018,8,42.89,339.87,Two year,Electronic check,Fiber optic,0,No,No
+CUST-00019,17,92.34,1551.32,One year,Mailed check,Fiber optic,3,Yes,No
+CUST-00020,56,55.43,2921.28,Two year,Electronic check,Fiber optic,8,Yes,Yes
+CUST-00021,44,100.06,4010.48,Month-to-month,Credit card,DSL,0,No,No
+CUST-00022,10,64.31,634.18,One year,Electronic check,Fiber optic,1,Yes,Yes
+CUST-00023,31,36.63,1077.12,Month-to-month,Credit card,No,0,Yes,Yes
+CUST-00024,34,112.65,3747.80,Month-to-month,Credit card,DSL,0,Yes,Yes
+CUST-00025,70,26.10,1701.60,Month-to-month,Credit card,Fiber optic,3,Yes,No
+CUST-00026,66,28.01,1698.15,One year,Mailed check,Fiber optic,5,Yes,No
+CUST-00027,6,81.94,463.09,One year,Bank transfer,No,0,No,No
+CUST-00028,51,33.09,1627.77,Month-to-month,Electronic check,DSL,1,Yes,No
+CUST-00029,28,70.59,1805.05,Month-to-month,Electronic check,No,0,Yes,No
+CUST-00030,70,90.35,6078.91,Two year,Electronic check,Fiber optic,1,Yes,No
+CUST-00031,18,46.45,826.88,One year,Mailed check,DSL,1,No,No
+CUST-00032,34,70.54,2218.75,Two year,Electronic check,DSL,1,No,No
+CUST-00033,43,97.11,4024.20,Month-to-month,Credit card,Fiber optic,1,Yes,Yes
+CUST-00034,20,74.56,1466.53,One year,Mailed check,Fiber optic,0,No,No
+CUST-00035,6,109.89,607.26,Month-to-month,Electronic check,DSL,1,No,Yes
+CUST-00036,20,112.58,2079.74,Month-to-month,Mailed check,No,0,No,Yes
+CUST-00037,53,100.22,5239.46,Two year,Bank transfer,DSL,2,No,Yes
+CUST-00038,61,42.24,2529.38,Month-to-month,Bank transfer,No,3,Yes,No
+CUST-00039,25,59.85,1388.31,Month-to-month,Bank transfer,DSL,1,No,Yes
+CUST-00040,15,107.70,1496.15,One year,Bank transfer,DSL,1,No,No
+CUST-00041,41,63.64,2605.13,Month-to-month,Mailed check,DSL,2,Yes,Yes
+CUST-00042,69,88.69,6083.05,One year,Mailed check,DSL,0,No,No
+CUST-00043,16,91.98,1368.71,Month-to-month,Credit card,DSL,2,Yes,Yes
+CUST-00044,49,87.73,4256.99,One year,Bank transfer,Fiber optic,3,No,No
+CUST-00045,56,98.58,5303.34,Month-to-month,Credit card,Fiber optic,0,No,Yes
+CUST-00046,22,85.89,1754.25,One year,Bank transfer,DSL,5,Yes,Yes
+CUST-00047,29,100.66,2670.24,Month-to-month,Credit card,Fiber optic,2,No,Yes
+CUST-00048,25,91.83,2154.33,Month-to-month,Mailed check,Fiber optic,0,Yes,Yes
+CUST-00049,29,37.59,1085.53,One year,Electronic check,Fiber optic,5,Yes,No
+CUST-00050,60,86.76,5199.30,One year,Credit card,Fiber optic,2,No,Yes
+CUST-00051,71,64.59,4200.29,Two year,Credit card,DSL,0,No,No
+CUST-00052,67,68.46,4237.88,Month-to-month,Bank transfer,DSL,0,Yes,No
+CUST-00053,30,58.30,1600.83,Month-to-month,Credit card,Fiber optic,1,No,No
+CUST-00054,54,58.95,3110.02,Two year,Electronic check,No,2,No,No
+CUST-00055,46,49.86,2153.65,Two year,Credit card,Fiber optic,2,Yes,No
+CUST-00056,35,63.58,2009.23,Month-to-month,Credit card,Fiber optic,3,Yes,Yes
+CUST-00057,69,22.70,1471.39,One year,Electronic check,DSL,1,No,No
+CUST-00058,34,57.91,1813.72,Month-to-month,Credit card,DSL,5,No,Yes
+CUST-00059,11,67.03,718.82,Month-to-month,Bank transfer,DSL,0,Yes,Yes
+CUST-00060,32,39.94,1152.88,Month-to-month,Mailed check,Fiber optic,0,Yes,No
+CUST-00061,33,96.69,2925.23,One year,Electronic check,Fiber optic,0,No,No
+CUST-00062,4,112.89,432.40,Two year,Credit card,DSL,2,Yes,Yes
+CUST-00063,32,30.19,944.10,Two year,Electronic check,Fiber optic,1,Yes,No
+CUST-00064,55,86.15,4297.10,One year,Electronic check,No,3,Yes,No
+CUST-00065,47,83.56,3860.05,One year,Credit card,DSL,1,No,No
+CUST-00066,69,97.46,6364.88,Two year,Bank transfer,DSL,0,Yes,No
+CUST-00067,58,44.39,2436.80,One year,Credit card,DSL,1,No,No
+CUST-00068,28,55.48,1438.23,Month-to-month,Bank transfer,Fiber optic,1,Yes,No
+CUST-00069,53,68.86,3561.32,One year,Credit card,Fiber optic,0,No,No
+CUST-00070,32,50.62,1552.06,Month-to-month,Bank transfer,Fiber optic,2,No,No
+CUST-00071,59,47.09,2570.33,Month-to-month,Mailed check,DSL,2,Yes,No
+CUST-00072,62,47.65,2833.05,One year,Bank transfer,No,3,No,No
+CUST-00073,23,50.23,1121.56,Month-to-month,Electronic check,No,1,Yes,Yes
+CUST-00074,63,30.26,1718.08,Month-to-month,Credit card,Fiber optic,0,Yes,No
+CUST-00075,62,31.41,1765.40,Month-to-month,Electronic check,DSL,3,No,No
+CUST-00076,32,31.85,995.19,One year,Mailed check,Fiber optic,0,No,No
+CUST-00077,55,50.54,2674.36,One year,Electronic check,No,0,Yes,No
+CUST-00078,11,35.71,360.36,Month-to-month,Electronic check,Fiber optic,2,No,Yes
+CUST-00079,30,48.81,1359.27,Two year,Electronic check,Fiber optic,5,Yes,No
+CUST-00080,70,42.48,2720.54,Month-to-month,Mailed check,DSL,0,No,No
+CUST-00081,37,63.92,2239.38,Month-to-month,Credit card,No,1,No,No
+CUST-00082,6,108.94,636.29,One year,Electronic check,DSL,5,Yes,Yes
+CUST-00083,35,77.62,2652.34,Month-to-month,Credit card,No,0,No,No
+CUST-00084,63,116.91,6974.98,Month-to-month,Bank transfer,Fiber optic,3,No,Yes
+CUST-00085,64,48.82,3107.36,Two year,Electronic check,Fiber optic,0,No,No
+CUST-00086,52,106.49,5440.53,Month-to-month,Credit card,Fiber optic,0,No,Yes
+CUST-00087,64,82.54,5155.77,Month-to-month,Mailed check,No,1,No,No
+CUST-00088,31,90.98,2625.99,Month-to-month,Credit card,DSL,8,Yes,Yes
+CUST-00089,16,84.77,1241.57,Two year,Bank transfer,Fiber optic,0,No,No
+CUST-00090,32,65.68,1921.98,Month-to-month,Mailed check,No,0,No,No
+CUST-00091,65,46.72,2733.90,One year,Credit card,No,1,No,No
+CUST-00092,71,96.29,6410.81,Two year,Mailed check,No,0,No,No
+CUST-00093,53,24.36,1258.12,One year,Credit card,DSL,2,Yes,No
+CUST-00094,5,32.62,162.53,Month-to-month,Electronic check,No,1,No,Yes
+CUST-00095,19,61.00,1118.99,Month-to-month,Credit card,Fiber optic,0,No,No
+CUST-00096,43,105.23,4461.24,Month-to-month,Bank transfer,Fiber optic,3,No,Yes
+CUST-00097,5,81.75,377.47,One year,Bank transfer,No,2,No,Yes
+CUST-00098,13,64.37,811.20,Two year,Electronic check,DSL,0,No,No
+CUST-00099,19,44.42,794.36,One year,Mailed check,DSL,0,No,No
+CUST-00100,31,69.77,2072.71,Month-to-month,Bank transfer,Fiber optic,2,No,Yes
+CUST-00101,70,35.80,2366.10,Month-to-month,Bank transfer,Fiber optic,1,No,No
+CUST-00102,39,39.92,1461.08,Month-to-month,Mailed check,DSL,0,No,Yes
+CUST-00103,38,22.19,828.89,Month-to-month,Electronic check,Fiber optic,2,Yes,Yes
+CUST-00104,64,103.28,6545.76,One year,Mailed check,Fiber optic,0,Yes,No
+CUST-00105,18,82.82,1476.36,One year,Bank transfer,Fiber optic,0,No,No
+CUST-00106,12,110.96,1241.87,Month-to-month,Mailed check,DSL,1,No,Yes
+CUST-00107,35,103.05,3338.76,Two year,Credit card,No,0,No,No
+CUST-00108,60,116.29,6377.87,Two year,Credit card,No,3,No,No
+CUST-00109,51,21.39,1040.34,Month-to-month,Bank transfer,Fiber optic,3,No,Yes
+CUST-00110,30,67.15,1937.86,Two year,Bank transfer,No,0,Yes,No
+CUST-00111,60,110.94,6191.91,Month-to-month,Mailed check,DSL,0,No,No
+CUST-00112,31,108.73,3079.29,Month-to-month,Credit card,Fiber optic,2,No,Yes
+CUST-00113,63,81.57,5107.59,Month-to-month,Bank transfer,DSL,1,Yes,Yes
+CUST-00114,13,118.09,1438.05,Two year,Bank transfer,DSL,0,Yes,No
+CUST-00115,59,29.17,1585.43,One year,Electronic check,DSL,0,Yes,No
+CUST-00116,27,26.86,708.19,Month-to-month,Mailed check,No,0,Yes,No
+CUST-00117,1,47.73,47.65,Two year,Bank transfer,Fiber optic,0,Yes,No
+CUST-00118,46,99.00,4206.95,Month-to-month,Mailed check,DSL,0,No,Yes
+CUST-00119,9,67.62,595.07,One year,Electronic check,Fiber optic,0,Yes,No
+CUST-00120,67,50.16,3240.86,Month-to-month,Credit card,No,1,Yes,No
+CUST-00121,57,27.35,1415.65,One year,Electronic check,DSL,1,No,No
+CUST-00122,68,49.49,3198.92,Month-to-month,Electronic check,No,2,Yes,Yes
+CUST-00123,30,61.38,1809.62,Month-to-month,Electronic check,DSL,0,No,No
+CUST-00124,20,88.68,1680.36,Month-to-month,Electronic check,DSL,0,No,Yes
+CUST-00125,72,26.00,1863.88,One year,Electronic check,Fiber optic,3,No,No
+CUST-00126,7,116.84,785.20,Month-to-month,Mailed check,DSL,1,Yes,Yes
+CUST-00127,72,56.76,3989.70,One year,Credit card,No,8,Yes,Yes
+CUST-00128,35,22.90,743.25,One year,Bank transfer,DSL,0,Yes,No
+CUST-00129,52,26.96,1365.61,Two year,Electronic check,Fiber optic,0,No,No
+CUST-00130,21,57.01,1163.88,One year,Electronic check,No,0,Yes,No
+CUST-00131,35,64.31,2121.20,One year,Credit card,DSL,2,Yes,No
+CUST-00132,15,48.32,701.50,Month-to-month,Bank transfer,DSL,0,Yes,No
+CUST-00133,39,114.53,4362.75,One year,Bank transfer,DSL,0,No,No
+CUST-00134,49,73.26,3313.37,One year,Bank transfer,DSL,3,Yes,No
+CUST-00135,59,112.12,6523.86,One year,Credit card,Fiber optic,1,Yes,No
+CUST-00136,42,37.19,1553.80,Month-to-month,Bank transfer,DSL,3,Yes,Yes
+CUST-00137,52,72.40,3537.32,Month-to-month,Bank transfer,DSL,2,Yes,Yes
+CUST-00138,15,73.06,1007.56,One year,Bank transfer,Fiber optic,3,Yes,No
+CUST-00139,19,45.60,794.79,Month-to-month,Electronic check,DSL,2,No,Yes
+CUST-00140,58,88.11,5050.10,One year,Bank transfer,No,1,Yes,No
+CUST-00141,61,64.22,3644.31,Month-to-month,Electronic check,DSL,0,No,No
+CUST-00142,8,56.87,422.52,One year,Electronic check,Fiber optic,1,No,No
+CUST-00143,6,64.97,382.41,One year,Bank transfer,Fiber optic,1,Yes,No
+CUST-00144,44,118.24,4726.18,One year,Electronic check,DSL,1,No,No
+CUST-00145,21,56.39,1174.47,Month-to-month,Bank transfer,Fiber optic,0,No,No
+CUST-00146,13,75.80,924.95,Month-to-month,Mailed check,DSL,1,Yes,Yes
+CUST-00147,40,116.77,4529.97,Month-to-month,Electronic check,DSL,0,No,Yes
+CUST-00148,68,29.35,1930.03,One year,Electronic check,DSL,0,Yes,No
+CUST-00149,63,39.20,2469.59,Month-to-month,Bank transfer,No,0,Yes,No
+CUST-00150,17,79.72,1240.62,Month-to-month,Mailed check,Fiber optic,0,No,No
+CUST-00151,31,116.96,3484.57,One year,Credit card,DSL,0,No,No
+CUST-00152,25,56.78,1412.00,Two year,Credit card,Fiber optic,2,No,No
+CUST-00153,26,100.13,2379.07,Month-to-month,Credit card,No,1,Yes,Yes
+CUST-00154,67,105.12,6539.51,One year,Bank transfer,Fiber optic,1,No,No
+CUST-00155,29,101.67,2914.41,Two year,Credit card,DSL,1,Yes,No
+CUST-00156,11,57.49,570.93,Two year,Bank transfer,Fiber optic,0,No,No
+CUST-00157,61,89.61,4995.46,One year,Credit card,Fiber optic,5,Yes,Yes
+CUST-00158,20,74.88,1456.75,One year,Electronic check,Fiber optic,0,Yes,No
+CUST-00159,54,83.90,4359.71,Month-to-month,Credit card,Fiber optic,0,Yes,No
+CUST-00160,38,62.92,2298.86,Month-to-month,Credit card,DSL,2,No,No
+CUST-00161,68,74.41,4951.81,One year,Electronic check,DSL,1,No,No
+CUST-00162,33,94.73,2925.11,Month-to-month,Mailed check,Fiber optic,1,No,Yes
+CUST-00163,46,74.60,3367.60,Month-to-month,Credit card,No,1,Yes,Yes
+CUST-00164,9,91.60,819.75,Month-to-month,Mailed check,DSL,0,Yes,Yes
+CUST-00165,40,71.54,2858.49,One year,Bank transfer,DSL,1,No,No
+CUST-00166,7,106.58,696.22,Month-to-month,Bank transfer,Fiber optic,1,No,Yes
+CUST-00167,50,53.90,2475.85,One year,Bank transfer,No,1,Yes,No
+CUST-00168,11,63.06,693.32,Month-to-month,Bank transfer,DSL,0,No,Yes
+CUST-00169,55,36.66,1904.18,Month-to-month,Bank transfer,Fiber optic,1,Yes,No
+CUST-00170,52,56.33,2870.90,One year,Electronic check,DSL,1,No,No
+CUST-00171,9,43.60,378.48,Month-to-month,Electronic check,Fiber optic,2,No,Yes
+CUST-00172,10,77.39,737.48,Month-to-month,Bank transfer,DSL,0,Yes,Yes
+CUST-00173,50,111.35,5076.31,One year,Credit card,DSL,1,No,No
+CUST-00174,18,105.28,1791.20,Two year,Credit card,No,3,No,Yes
+CUST-00175,9,75.00,627.10,Month-to-month,Mailed check,Fiber optic,5,Yes,Yes
+CUST-00176,66,42.42,2795.56,One year,Mailed check,Fiber optic,0,No,No
+CUST-00177,71,32.98,2314.48,Month-to-month,Credit card,No,2,No,Yes
+CUST-00178,10,32.53,303.08,Month-to-month,Credit card,Fiber optic,0,Yes,Yes
+CUST-00179,17,63.26,1065.82,Month-to-month,Electronic check,Fiber optic,0,Yes,No
+CUST-00180,29,54.60,1574.04,Two year,Electronic check,DSL,1,No,No
+CUST-00181,39,81.44,2888.22,One year,Mailed check,DSL,1,No,No
+CUST-00182,6,102.52,555.35,Month-to-month,Bank transfer,Fiber optic,2,No,Yes
+CUST-00183,4,69.80,268.79,Month-to-month,Bank transfer,Fiber optic,3,No,Yes
+CUST-00184,10,88.86,813.79,Month-to-month,Credit card,DSL,1,No,Yes
+CUST-00185,41,93.42,3776.89,Two year,Mailed check,Fiber optic,1,Yes,No
+CUST-00186,60,32.25,1828.50,Month-to-month,Electronic check,DSL,0,No,No
+CUST-00187,21,101.35,2114.25,One year,Mailed check,Fiber optic,1,No,No
+CUST-00188,40,69.74,2535.76,Month-to-month,Credit card,No,0,No,No
+CUST-00189,37,69.49,2540.88,One year,Credit card,DSL,0,Yes,No
+CUST-00190,34,92.75,3079.03,Month-to-month,Credit card,DSL,1,No,Yes
+CUST-00191,10,58.63,554.07,One year,Electronic check,DSL,0,No,No
+CUST-00192,44,75.78,3122.79,Month-to-month,Credit card,Fiber optic,0,Yes,No
+CUST-00193,61,71.93,4014.31,Two year,Mailed check,DSL,1,Yes,No
+CUST-00194,39,79.37,2942.92,One year,Credit card,Fiber optic,0,Yes,No
+CUST-00195,15,117.99,1696.17,One year,Electronic check,Fiber optic,0,Yes,No
+CUST-00196,62,37.05,2211.88,One year,Credit card,DSL,2,Yes,No
+CUST-00197,15,39.08,553.43,Month-to-month,Credit card,Fiber optic,1,No,Yes
+CUST-00198,8,90.58,689.76,One year,Credit card,Fiber optic,0,Yes,No
+CUST-00199,69,54.23,3500.25,One year,Bank transfer,Fiber optic,0,Yes,No
+CUST-00200,39,42.49,1652.62,Month-to-month,Bank transfer,Fiber optic,2,No,No
+CUST-00201,45,76.05,3399.83,One year,Bank transfer,DSL,2,No,No
+CUST-00202,51,101.84,5170.26,Two year,Bank transfer,DSL,5,Yes,Yes
+CUST-00203,57,85.60,4755.92,Month-to-month,Bank transfer,No,2,Yes,Yes
+CUST-00204,31,44.25,1326.46,One year,Mailed check,DSL,1,No,No
+CUST-00205,18,20.52,352.75,Two year,Credit card,Fiber optic,3,No,No
+CUST-00206,26,95.59,2308.20,Month-to-month,Electronic check,No,0,Yes,Yes
+CUST-00207,5,111.32,510.68,Two year,Mailed check,No,0,No,Yes
+CUST-00208,24,113.66,2717.51,Two year,Electronic check,DSL,1,Yes,No
+CUST-00209,43,48.46,2081.51,One year,Credit card,No,0,No,No
+CUST-00210,15,53.07,774.65,One year,Mailed check,DSL,0,No,No
+CUST-00211,25,37.55,925.25,Two year,Credit card,Fiber optic,0,Yes,No
+CUST-00212,18,67.75,1211.67,Month-to-month,Credit card,DSL,2,No,No
+CUST-00213,2,46.16,86.41,Month-to-month,Electronic check,Fiber optic,0,No,Yes
+CUST-00214,38,56.75,1988.48,Two year,Credit card,DSL,2,No,No
+CUST-00215,71,111.28,7709.17,Two year,Mailed check,Fiber optic,2,Yes,No
+CUST-00216,68,90.38,5579.26,One year,Electronic check,No,5,Yes,Yes
+CUST-00217,20,36.45,718.39,Month-to-month,Mailed check,Fiber optic,1,No,Yes
+CUST-00218,59,33.19,1843.74,One year,Credit card,Fiber optic,0,Yes,No
+CUST-00219,1,94.58,90.59,Month-to-month,Bank transfer,Fiber optic,1,Yes,Yes
+CUST-00220,9,118.61,1011.13,Month-to-month,Mailed check,Fiber optic,2,No,Yes
+CUST-00221,49,64.85,3151.31,Month-to-month,Electronic check,Fiber optic,2,Yes,Yes
+CUST-00222,45,31.86,1432.67,Month-to-month,Mailed check,Fiber optic,0,Yes,No
+CUST-00223,39,66.30,2513.07,Month-to-month,Credit card,No,0,No,No
+CUST-00224,25,113.74,2765.31,Month-to-month,Credit card,Fiber optic,5,Yes,Yes
+CUST-00225,9,30.09,244.64,One year,Electronic check,DSL,0,No,No
+CUST-00226,28,95.44,2612.48,Month-to-month,Bank transfer,DSL,5,No,Yes
+CUST-00227,42,43.69,1812.27,Two year,Mailed check,Fiber optic,0,Yes,No
+CUST-00228,55,75.59,3761.20,Month-to-month,Credit card,Fiber optic,0,No,No
+CUST-00229,39,57.65,2193.13,Month-to-month,Mailed check,DSL,2,No,Yes
+CUST-00230,72,61.27,4154.04,One year,Credit card,DSL,0,Yes,No
+CUST-00231,48,29.25,1365.33,Month-to-month,Bank transfer,DSL,1,Yes,Yes
+CUST-00232,25,100.47,2408.16,One year,Mailed check,Fiber optic,3,No,No
+CUST-00233,2,41.18,75.69,One year,Credit card,No,2,Yes,No
+CUST-00234,31,75.21,2279.17,Month-to-month,Bank transfer,DSL,0,No,No
+CUST-00235,61,96.16,5467.03,Month-to-month,Bank transfer,Fiber optic,1,Yes,Yes
+CUST-00236,3,46.08,137.34,One year,Credit card,DSL,0,Yes,No
+CUST-00237,32,69.93,2160.47,One year,Bank transfer,Fiber optic,1,No,No
+CUST-00238,46,36.93,1651.27,Month-to-month,Electronic check,Fiber optic,3,Yes,Yes
+CUST-00239,7,96.43,635.35,Two year,Mailed check,DSL,0,Yes,No
+CUST-00240,48,26.05,1205.10,Two year,Credit card,Fiber optic,0,No,No
+CUST-00241,68,92.22,5979.82,Month-to-month,Credit card,No,5,Yes,Yes
+CUST-00242,68,34.89,2180.80,One year,Bank transfer,DSL,0,No,No
+CUST-00243,59,76.50,4509.09,Month-to-month,Electronic check,Fiber optic,3,Yes,No
+CUST-00244,49,57.72,2680.08,One year,Mailed check,DSL,3,No,No
+CUST-00245,13,109.48,1411.73,Month-to-month,Credit card,DSL,5,No,Yes
+CUST-00246,5,37.94,186.86,Month-to-month,Mailed check,Fiber optic,2,No,Yes
+CUST-00247,39,36.25,1306.37,Two year,Credit card,Fiber optic,1,No,No
+CUST-00248,18,99.05,1727.51,Month-to-month,Bank transfer,DSL,1,Yes,Yes
+CUST-00249,51,116.89,5559.82,One year,Credit card,Fiber optic,0,No,No
+CUST-00250,49,28.57,1346.54,One year,Electronic check,DSL,0,Yes,No
+CUST-00251,41,56.07,2090.02,Two year,Credit card,DSL,0,Yes,No
+CUST-00252,56,64.88,3471.50,Month-to-month,Electronic check,DSL,1,No,Yes
+CUST-00253,2,49.18,92.34,Month-to-month,Mailed check,Fiber optic,0,No,Yes
+CUST-00254,35,50.11,1664.95,Month-to-month,Credit card,DSL,0,Yes,No
+CUST-00255,32,92.09,2798.30,One year,Credit card,DSL,0,No,No
+CUST-00256,49,100.41,4590.22,Month-to-month,Mailed check,DSL,1,Yes,Yes
+CUST-00257,23,116.46,2670.20,Month-to-month,Credit card,No,2,No,Yes
+CUST-00258,51,56.50,2861.93,Month-to-month,Mailed check,Fiber optic,1,No,Yes
+CUST-00259,27,63.85,1601.78,One year,Credit card,Fiber optic,0,No,No
+CUST-00260,20,91.52,1791.79,Month-to-month,Credit card,Fiber optic,1,No,Yes
+CUST-00261,47,90.16,4157.98,One year,Electronic check,DSL,0,No,No
+CUST-00262,6,76.32,441.67,One year,Bank transfer,No,1,Yes,No
+CUST-00263,29,71.07,1961.85,One year,Mailed check,Fiber optic,0,Yes,No
+CUST-00264,4,68.28,253.88,Two year,Electronic check,DSL,5,Yes,Yes
+CUST-00265,44,65.53,2654.63,Month-to-month,Credit card,DSL,2,No,No
+CUST-00266,39,24.47,926.73,Month-to-month,Bank transfer,Fiber optic,2,Yes,Yes
+CUST-00267,32,71.60,2188.53,Month-to-month,Credit card,No,0,No,No
+CUST-00268,24,84.05,1902.65,Month-to-month,Mailed check,Fiber optic,1,Yes,Yes
+CUST-00269,27,47.83,1253.15,One year,Electronic check,Fiber optic,1,No,No
+CUST-00270,59,31.40,1791.59,Month-to-month,Bank transfer,Fiber optic,1,Yes,No
+CUST-00271,59,81.74,4732.83,One year,Bank transfer,No,1,Yes,No
+CUST-00272,31,50.54,1438.74,One year,Credit card,Fiber optic,0,No,No
+CUST-00273,63,83.55,5102.28,One year,Mailed check,Fiber optic,1,Yes,No
+CUST-00274,58,81.94,4688.61,Two year,Credit card,DSL,3,No,No
+CUST-00275,63,61.56,3816.19,Month-to-month,Electronic check,Fiber optic,2,Yes,No
+CUST-00276,36,42.48,1420.50,One year,Credit card,Fiber optic,0,Yes,No
+CUST-00277,70,102.33,6709.58,Two year,Electronic check,Fiber optic,1,Yes,No
+CUST-00278,14,93.60,1265.02,Month-to-month,Electronic check,Fiber optic,0,Yes,Yes
+CUST-00279,16,97.56,1441.85,Two year,Bank transfer,No,1,No,No
+CUST-00280,18,98.48,1739.59,Two year,Bank transfer,Fiber optic,1,Yes,No
+CUST-00281,38,48.93,1723.11,Two year,Electronic check,DSL,2,No,No
+CUST-00282,36,106.70,3505.82,Two year,Mailed check,DSL,0,Yes,No
+CUST-00283,51,68.95,3367.85,Month-to-month,Credit card,DSL,0,Yes,No
+CUST-00284,36,89.47,3181.40,Month-to-month,Credit card,DSL,0,Yes,Yes
+CUST-00285,59,83.48,4776.23,Two year,Credit card,DSL,1,Yes,No
+CUST-00286,42,102.83,4032.85,One year,Credit card,Fiber optic,3,Yes,No
+CUST-00287,59,21.63,1267.16,Month-to-month,Credit card,DSL,5,Yes,Yes
+CUST-00288,17,108.21,1711.14,Two year,Bank transfer,DSL,0,Yes,No
+CUST-00289,22,25.18,533.22,One year,Mailed check,Fiber optic,0,Yes,No
+CUST-00290,62,27.79,1652.97,One year,Credit card,DSL,2,Yes,No
+CUST-00291,55,89.40,4660.19,Month-to-month,Electronic check,Fiber optic,0,No,Yes
+CUST-00292,39,33.71,1284.91,One year,Mailed check,Fiber optic,2,Yes,No
+CUST-00293,2,81.03,148.51,Month-to-month,Mailed check,Fiber optic,0,No,Yes
+CUST-00294,57,106.00,5490.18,Month-to-month,Electronic check,Fiber optic,0,No,Yes
+CUST-00295,18,44.78,777.39,Month-to-month,Bank transfer,Fiber optic,2,No,No
+CUST-00296,66,38.86,2408.76,One year,Mailed check,Fiber optic,0,No,No
+CUST-00297,10,72.83,726.68,Two year,Bank transfer,DSL,3,No,No
+CUST-00298,23,96.27,2204.12,One year,Electronic check,Fiber optic,0,Yes,No
+CUST-00299,8,114.87,863.64,Month-to-month,Credit card,Fiber optic,1,Yes,Yes

--- a/tests/behavioral/fixtures/generate_fixtures.py
+++ b/tests/behavioral/fixtures/generate_fixtures.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regenerate the committed churn fixture CSVs (deterministic, seed 42).
+
+The datasets are sized for behavioral test runs: large enough that Quick-mode
+AutoML partitioning is stable (DataRobot needs >=20 rows; tiny datasets flake
+on minority-class-per-fold), small enough that runtime is dominated by fixed
+AutoML overhead rather than rows. A signal is planted (month-to-month
+contracts + low tenure + high charges + support tickets => churn) so
+leaderboards measure something real instead of noise.
+
+Run from this directory:  python3 generate_fixtures.py
+"""
+
+from __future__ import annotations
+
+import csv
+import random
+from pathlib import Path
+
+SEED = 42
+TRAIN_ROWS = 300
+HOLDOUT_ROWS = 60
+
+CONTRACTS = ["Month-to-month", "One year", "Two year"]
+PAYMENT_METHODS = ["Electronic check", "Mailed check", "Bank transfer", "Credit card"]
+INTERNET = ["DSL", "Fiber optic", "No"]
+
+HEADER = [
+    "customer_id",
+    "tenure_months",
+    "monthly_charges",
+    "total_charges",
+    "contract_type",
+    "payment_method",
+    "internet_service",
+    "num_support_tickets",
+    "has_paperless_billing",
+    "churn",
+]
+
+
+def _row(rng: random.Random, index: int, with_target: bool) -> list[str]:
+    tenure = rng.randint(1, 72)
+    monthly = round(rng.uniform(20.0, 120.0), 2)
+    total = round(monthly * tenure * rng.uniform(0.9, 1.0), 2)
+    contract = rng.choices(CONTRACTS, weights=[5, 3, 2])[0]
+    payment = rng.choice(PAYMENT_METHODS)
+    internet = rng.choices(INTERNET, weights=[4, 4, 2])[0]
+    tickets = rng.choices([0, 1, 2, 3, 5, 8], weights=[40, 25, 15, 10, 7, 3])[0]
+    paperless = rng.choice(["Yes", "No"])
+
+    # Planted signal so the target is learnable on a small dataset.
+    churn_score = (
+        (1.4 if contract == "Month-to-month" else 0.0)
+        + (1.0 if tenure < 12 else 0.0)
+        + (0.8 if monthly > 85 else 0.0)
+        + 0.35 * tickets
+        + rng.uniform(0.0, 1.4)
+    )
+    churn = "Yes" if churn_score > 2.6 else "No"
+
+    row = [
+        f"CUST-{index:05d}",
+        str(tenure),
+        f"{monthly:.2f}",
+        f"{total:.2f}",
+        contract,
+        payment,
+        internet,
+        str(tickets),
+        paperless,
+    ]
+    if with_target:
+        row.append(churn)
+    return row
+
+
+def _write(
+    path: Path, rows: int, start_index: int, with_target: bool, rng: random.Random
+) -> None:
+    header = HEADER if with_target else HEADER[:-1]
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(header)
+        for i in range(rows):
+            writer.writerow(_row(rng, start_index + i, with_target))
+    print(f"wrote {path} ({rows} rows)")
+
+
+def main() -> None:
+    here = Path(__file__).parent
+    rng = random.Random(SEED)
+    _write(here / "churn_train.csv", TRAIN_ROWS, 0, with_target=True, rng=rng)
+    _write(
+        here / "churn_holdout.csv", HOLDOUT_ROWS, TRAIN_ROWS, with_target=False, rng=rng
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/behavioral/fixtures/provision_fixtures.py
+++ b/tests/behavioral/fixtures/provision_fixtures.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provision the long-lived DataRobot fixture resources behavioral scenarios need.
+
+Some scenarios assert against pre-existing DataRobot state instead of paying
+for AutoML inside every run: the predictions-template scenario needs a healthy
+deployment, feature-impact needs a trained model with Feature Impact computed,
+and drift needs a deployment that has actually served predictions. This script
+builds that state once per account and prints the resource ids as
+``BEHAVIORAL_FIXTURE_*`` env-var lines that scenarios consume via their
+``requires_env`` declarations.
+
+Everything is named with the ``bfix-`` prefix — deliberately OUTSIDE the
+``drat-`` family that per-run teardown and ``dr-agent eval sweep`` match, so
+cleanup can never delete the fixtures. Delete them with ``--recreate`` or by
+hand.
+
+Requires DATAROBOT_API_TOKEN / DATAROBOT_ENDPOINT and the datarobot SDK
+(``uv run --group behavioral``). The full pipeline waits on a Quick-mode
+AutoML run (~15-20 min) the first time; subsequent runs find and reuse
+everything by name in seconds.
+
+Usage (from the repo root):
+    uv run --group behavioral python tests/behavioral/fixtures/provision_fixtures.py
+        [--check]            validate-only: exit 0 iff every fixture exists and
+                             is healthy (CI preflight; prints the id lines)
+        [--recreate]         delete existing bfix- fixtures first, then build
+        [--refresh-traffic]  rescore the holdout through the deployment so
+                             drift windows have recent traffic, then exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+FIXTURES_DIR = Path(__file__).resolve().parent
+TRAIN_CSV = FIXTURES_DIR / "churn_train.csv"
+HOLDOUT_CSV = FIXTURES_DIR / "churn_holdout.csv"
+
+#: bfix- = "behavioral fixture". Must never start with "drat-" (the sweeper's
+#: family prefix) or these resources would be deleted by cleanup.
+PREFIX = "bfix-"
+USE_CASE_NAME = f"{PREFIX}churn-use-case"
+DATASET_NAME = f"{PREFIX}churn-train"
+PROJECT_NAME = f"{PREFIX}churn-project"
+DEPLOYMENT_NAME = f"{PREFIX}churn-deployment"
+TARGET = "churn"
+
+
+def _resilient(
+    fn: Callable[[], Any], attempts: int = 5, delay_seconds: int = 20
+) -> Any:
+    """Retry through transient connection drops during long server-side waits."""
+    import requests
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except requests.exceptions.ConnectionError as exc:
+            if attempt == attempts:
+                raise
+            print(f"transient connection error (attempt {attempt}/{attempts}): {exc}")
+            time.sleep(delay_seconds)
+
+
+def _client() -> Any:
+    import datarobot as dr
+
+    token = os.environ.get("DATAROBOT_API_TOKEN")
+    endpoint = os.environ.get("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")
+    if not token:
+        sys.exit("DATAROBOT_API_TOKEN is not set")
+    dr.Client(token=token, endpoint=endpoint)
+    return dr
+
+
+def _find_use_case(dr: Any) -> Any:
+    return next((u for u in dr.UseCase.list() if u.name == USE_CASE_NAME), None)
+
+
+def _find_project(dr: Any) -> Any:
+    matches = dr.Project.list(search_params={"project_name": PROJECT_NAME})
+    return next((p for p in matches if p.project_name == PROJECT_NAME), None)
+
+
+def _find_deployment(dr: Any) -> Any:
+    matches = dr.Deployment.list(search=DEPLOYMENT_NAME)
+    return next((d for d in matches if d.label == DEPLOYMENT_NAME), None)
+
+
+def _recommended_model(dr: Any, project: Any) -> Any:
+    return dr.ModelRecommendation.get(project.id).get_model()
+
+
+def _ensure_use_case(dr: Any) -> Any:
+    use_case = _find_use_case(dr)
+    if use_case is None:
+        use_case = dr.UseCase.create(
+            name=USE_CASE_NAME,
+            description="Long-lived fixture for behavioral scenario runs — do not delete.",
+        )
+        print(f"created use case {use_case.id}")
+    else:
+        print(f"reusing use case {use_case.id}")
+    return use_case
+
+
+def _ensure_project(dr: Any, use_case: Any) -> Any:
+    project = _find_project(dr)
+    if project is not None:
+        project = dr.Project.get(project.id)
+        print(f"reusing project {project.id} (stage={project.stage})")
+        if project.stage != "modeling":
+            # Target-setting may still be resolving from an interrupted run.
+            deadline = time.monotonic() + 300
+            while project.stage != "modeling" and time.monotonic() < deadline:
+                print(f"  stage={project.stage!r}; waiting for target-setting ...")
+                time.sleep(20)
+                project = dr.Project.get(project.id)
+            if project.stage != "modeling":
+                sys.exit(
+                    f"project {project.id} stuck at stage {project.stage!r}; "
+                    "run --recreate to rebuild it"
+                )
+        _resilient(lambda: project.wait_for_autopilot())
+        print("autopilot finished")
+        return project
+
+    print(f"uploading {TRAIN_CSV.name} ...")
+    dataset = dr.Dataset.create_from_file(
+        file_path=str(TRAIN_CSV), use_cases=[use_case]
+    )
+    dataset.modify(name=DATASET_NAME)
+    print(f"created dataset {dataset.id}")
+
+    project = dr.Project.create_from_dataset(
+        dataset_id=dataset.id, project_name=PROJECT_NAME, use_case=use_case
+    )
+    print(f"created project {project.id}; starting Quick autopilot on {TARGET!r} ...")
+    _resilient(
+        lambda: project.analyze_and_model(target=TARGET, mode="quick", worker_count=-1)
+    )
+    _resilient(lambda: project.wait_for_autopilot())
+    print("autopilot finished")
+    return dr.Project.get(project.id)
+
+
+def _ensure_feature_impact(dr: Any, project: Any) -> Any:
+    model = _recommended_model(dr, project)
+    print(f"recommended model {model.id} ({model.model_type})")
+    # The feature-impact scenario asserts on a model whose Feature Impact is
+    # already computed — the skill under test never calls
+    # request_feature_impact itself.
+    model.get_or_request_feature_impact(max_wait=600)
+    print("feature impact computed")
+    return model
+
+
+def _ensure_deployment(dr: Any, model: Any) -> Any:
+    deployment = _find_deployment(dr)
+    if deployment is None:
+        version = dr.RegisteredModelVersion.create_for_leaderboard_item(
+            model_id=model.id,
+            registered_model_name=f"{PREFIX}churn-registered-model",
+        )
+        servers = dr.PredictionServer.list()
+        deployment = dr.Deployment.create_from_registered_model_version(
+            model_package_id=version.id,
+            label=DEPLOYMENT_NAME,
+            description="Long-lived fixture for behavioral scenario runs — do not delete.",
+            default_prediction_server_id=servers[0].id if servers else None,
+        )
+        print(f"created deployment {deployment.id}")
+    else:
+        print(f"reusing deployment {deployment.id}")
+    deployment.update_drift_tracking_settings(
+        target_drift_enabled=True, feature_drift_enabled=True
+    )
+    print("drift tracking enabled (target + feature)")
+    return deployment
+
+
+def _score_holdout(dr: Any, deployment: Any) -> None:
+    """Push the holdout through the deployment so drift windows have traffic."""
+    print(f"scoring {HOLDOUT_CSV.name} through deployment {deployment.id} ...")
+    started = time.monotonic()
+    predictions = deployment.predict_batch(str(HOLDOUT_CSV))
+    print(f"scored {len(predictions)} rows in {time.monotonic() - started:.0f}s")
+
+
+def _emit_ids(project_id: str, model_id: str, deployment_id: str) -> None:
+    print()
+    print("# Export these (e.g. append to .env) for fixture-dependent scenarios:")
+    print(f"BEHAVIORAL_FIXTURE_PROJECT_ID={project_id}")
+    print(f"BEHAVIORAL_FIXTURE_MODEL_ID={model_id}")
+    print(f"BEHAVIORAL_FIXTURE_DEPLOYMENT_ID={deployment_id}")
+
+
+def cmd_check(dr: Any) -> int:
+    """Validate-only: report each fixture; exit non-zero if any is missing."""
+    use_case = _find_use_case(dr)
+    project = _find_project(dr)
+    deployment = _find_deployment(dr)
+    ok = True
+
+    for label, resource in (
+        ("use case", use_case),
+        ("project", project),
+        ("deployment", deployment),
+    ):
+        if resource is None:
+            print(f"MISSING: {label} ({PREFIX}...)")
+            ok = False
+        else:
+            print(f"ok: {label} {resource.id}")
+
+    model_id = None
+    if project is not None:
+        try:
+            model_id = _recommended_model(dr, project).id
+            print(f"ok: recommended model {model_id}")
+        except Exception as exc:  # autopilot unfinished / project broken
+            print(f"MISSING: recommended model ({type(exc).__name__}: {exc})")
+            ok = False
+
+    if not ok or project is None or deployment is None or model_id is None:
+        print("\nRun provision_fixtures.py (no flags) to build the missing fixtures.")
+        return 1
+    _emit_ids(project.id, str(model_id), deployment.id)
+    return 0
+
+
+def cmd_recreate(dr: Any) -> None:
+    """Delete existing bfix- fixtures (children before parents)."""
+    deployment = _find_deployment(dr)
+    if deployment is not None:
+        print(f"deleting deployment {deployment.id}")
+        deployment.delete()
+    project = _find_project(dr)
+    if project is not None:
+        print(f"deleting project {project.id}")
+        project.delete()
+    for dataset in dr.Dataset.list():
+        if (dataset.name or "").startswith(PREFIX):
+            print(f"deleting dataset {dataset.id}")
+            dr.Dataset.delete(dataset.id)
+    use_case = _find_use_case(dr)
+    if use_case is not None:
+        print(f"deleting use case {use_case.id}")
+        dr.UseCase.delete(use_case.id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="validate-only (CI preflight)"
+    )
+    parser.add_argument(
+        "--recreate", action="store_true", help="delete and rebuild fixtures"
+    )
+    parser.add_argument(
+        "--refresh-traffic",
+        action="store_true",
+        help="rescore the holdout through the fixture deployment, then exit",
+    )
+    args = parser.parse_args()
+
+    dr = _client()
+
+    if args.check:
+        sys.exit(cmd_check(dr))
+
+    if args.refresh_traffic:
+        deployment = _find_deployment(dr)
+        if deployment is None:
+            sys.exit(f"no deployment labelled {DEPLOYMENT_NAME!r}; provision first")
+        _score_holdout(dr, deployment)
+        return
+
+    if args.recreate:
+        cmd_recreate(dr)
+
+    use_case = _ensure_use_case(dr)
+    project = _ensure_project(dr, use_case)
+    model = _ensure_feature_impact(dr, project)
+    deployment = _ensure_deployment(dr, model)
+    _score_holdout(dr, deployment)
+    _emit_ids(project.id, model.id, deployment.id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/behavioral/fixtures/toy_agent/agent.py
+++ b/tests/behavioral/fixtures/toy_agent/agent.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A deliberately tiny LangGraph agent used as a behavioral-test fixture.
+
+The external-agent-monitoring scenario copies this project into the sandbox
+and asks the agent under test to instrument it for DataRobot OTel monitoring.
+The LLM is a FakeListChatModel so the graph runs (and emits instrumentation
+callbacks) with no network access and no model API key.
+"""
+
+from typing import TypedDict
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langgraph.graph import END, StateGraph
+
+
+class AgentState(TypedDict):
+    question: str
+    context: str
+    answer: str
+
+
+llm = FakeListChatModel(
+    responses=[
+        "Month-to-month customers with short tenure and high charges churn most."
+    ]
+)
+
+
+def lookup(state: AgentState) -> dict:
+    """Stand-in for a retrieval tool."""
+    return {"context": "contract_type=Month-to-month correlates strongly with churn"}
+
+
+def respond(state: AgentState) -> dict:
+    reply = llm.invoke(f"{state['question']}\n\nContext: {state['context']}")
+    return {"answer": reply.content}
+
+
+def build_graph():
+    graph = StateGraph(AgentState)
+    graph.add_node("lookup", lookup)
+    graph.add_node("respond", respond)
+    graph.set_entry_point("lookup")
+    graph.add_edge("lookup", "respond")
+    graph.add_edge("respond", END)
+    return graph.compile()

--- a/tests/behavioral/fixtures/toy_agent/main.py
+++ b/tests/behavioral/fixtures/toy_agent/main.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entrypoint for the toy churn Q&A agent (behavioral-test fixture)."""
+
+from agent import build_graph
+
+
+def main() -> None:
+    app = build_graph()
+    result = app.invoke(
+        {"question": "Why do customers churn?", "context": "", "answer": ""}
+    )
+    print(result["answer"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/behavioral/fixtures/toy_agent/requirements.txt
+++ b/tests/behavioral/fixtures/toy_agent/requirements.txt
@@ -1,0 +1,2 @@
+langgraph>=0.2
+langchain-core>=0.3

--- a/tests/behavioral/journeys/train-deploy-predict.yaml
+++ b/tests/behavioral/journeys/train-deploy-predict.yaml
@@ -1,0 +1,47 @@
+---
+scenarios:
+  - id: train-deploy-predict-golden
+    kind: behavioral
+    name: "Golden journey: upload, train (Quick), deploy, predict"
+    difficulty: medium
+    skills_under_test:
+      - datarobot-model-training
+      - datarobot-model-deployment
+      - datarobot-predictions
+    prompt: |
+      I have customer churn data in ./data/churn_train.csv. Train a model in
+      DataRobot to predict the "churn" column — use Quick autopilot mode so it
+      doesn't take forever. Once training finishes, deploy the best model,
+      then score ./data/churn_holdout.csv against that deployment and save the
+      results to ./predictions.csv.
+    fixtures:
+      - source: ../fixtures/churn_train.csv
+        dest: data/churn_train.csv
+      - source: ../fixtures/churn_holdout.csv
+        dest: data/churn_holdout.csv
+    env:
+      automl_mode: quick
+      resource_prefix: "{run_id}"
+    success_checks:
+      - type: dr_project_exists
+        name_contains: "{run_id}"
+      - type: dr_deployment_healthy
+        name_contains: "{run_id}"
+      - type: dr_predictions_returned
+        path: predictions.csv
+        min_rows: 50
+      - type: file_exists
+        path: predictions.csv
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      skipping the Use Case linkage the training skill mandates; hallucinated
+      SDK methods followed by retries; tight-loop autopilot polling instead of
+      wait_for_autopilot/max_wait; scoring via raw HTTP requests when
+      deployment.predict_batch is available.
+    common_pitfalls:
+      - Forgetting to create/link a Use Case before creating the project
+      - Legacy Project.start()-era API instead of the use-case-first flow
+      - Passing the CSV path where an uploaded dataset ID is required
+      - Deploying before autopilot has produced a recommended model
+      - Writing predictions to stdout instead of ./predictions.csv
+    timeout_minutes: 30

--- a/tests/behavioral/scenarios/datarobot-external-agent-monitoring/instrument-toy-agent.yaml
+++ b/tests/behavioral/scenarios/datarobot-external-agent-monitoring/instrument-toy-agent.yaml
@@ -1,0 +1,52 @@
+---
+scenarios:
+  - id: external-agent-otel
+    kind: behavioral
+    name: "External agent monitoring: instrument a LangGraph agent with OTel"
+    difficulty: hard
+    skills_under_test:
+      - datarobot-external-agent-monitoring
+    prompt: |
+      Here's my little LangGraph agent project (main.py, agent.py,
+      requirements.txt). Instrument it to send OpenTelemetry traces to
+      DataRobot so we can monitor it. I don't have a Use Case yet — create
+      one. I approve the plan up front: make all the changes without waiting
+      for me to confirm each step. When you're done, run the OTel connection
+      verification and save its JSON output to ./otel_verification.json, then
+      run the agent once (python main.py) so real traces get sent.
+    fixtures:
+      - source: ../../fixtures/toy_agent/main.py
+        dest: main.py
+      - source: ../../fixtures/toy_agent/agent.py
+        dest: agent.py
+      - source: ../../fixtures/toy_agent/requirements.txt
+        dest: requirements.txt
+    env:
+      resource_prefix: "{run_id}"
+    success_checks:
+      - type: file_exists
+        path: dr_otel_config.py
+      - type: dr_use_case_exists
+        name_contains: "{run_id}"
+      - type: file_matches
+        path: requirements.txt
+        pattern: "opentelemetry-exporter-otlp-proto-http"
+      - type: file_matches
+        path: otel_verification.json
+        pattern: "\"status\":\\s*\"success\""
+      - type: dr_traces_received
+        use_case_name_contains: "{run_id}"
+        min_traces: 1
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      pasting the API token into files other than the gitignored .env;
+      setting OTEL_EXPORTER_OTLP_* env vars (the skill forbids them);
+      skipping the framework doc and hand-rolling exporter wiring; calling
+      configure_otel() after agent imports instead of before.
+    common_pitfalls:
+      - Wiring the auto-instrumentor before configure_otel(), losing spans
+      - Forgetting DATAROBOT_ENTITY_ID/DATAROBOT_OTEL_ENDPOINT when running
+        the verify script or the agent, so traces go nowhere
+      - Echoing or committing the API token instead of using the .env file
+      - Stalling to ask for approval that the user already granted up front
+    timeout_minutes: 25

--- a/tests/behavioral/scenarios/datarobot-feature-engineering/feature-impact-report.yaml
+++ b/tests/behavioral/scenarios/datarobot-feature-engineering/feature-impact-report.yaml
@@ -1,0 +1,39 @@
+---
+scenarios:
+  - id: feature-impact-report
+    kind: behavioral
+    name: "Feature engineering: analyze feature importance for a trained model"
+    difficulty: medium
+    skills_under_test:
+      - datarobot-feature-engineering
+    requires_env:
+      - BEHAVIORAL_FIXTURE_PROJECT_ID
+      - BEHAVIORAL_FIXTURE_MODEL_ID
+    prompt: |
+      We're doing feature engineering on our churn model and I want to know
+      which features actually matter. It's project
+      {env:BEHAVIORAL_FIXTURE_PROJECT_ID}, model
+      {env:BEHAVIORAL_FIXTURE_MODEL_ID} in DataRobot. Analyze the feature
+      importance and write a short report to ./feature_impact.md listing the
+      top features by impact with their scores, flagging any low-impact
+      features we could drop, plus a sentence on what drives churn according
+      to the model.
+    success_checks:
+      - type: file_exists
+        path: feature_impact.md
+        min_bytes: 100
+      - type: file_matches
+        path: feature_impact.md
+        pattern: "(?i)(tenure_months|contract_type|monthly_charges|num_support_tickets)"
+        min_count: 2
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      calling SDK functions that don't exist (get_feature_importance,
+      export_feature_list) and retrying; recomputing Feature Impact when it is
+      already available; reporting raw impactUnnormalized values without
+      normalization context.
+    common_pitfalls:
+      - Calling nonexistent SDK helpers instead of model.get_feature_impact()
+      - Assuming Feature Impact must be recomputed when it is already available
+      - Reporting the feature list without impact scores
+    timeout_minutes: 15

--- a/tests/behavioral/scenarios/datarobot-model-monitoring/drift-report.yaml
+++ b/tests/behavioral/scenarios/datarobot-model-monitoring/drift-report.yaml
@@ -1,0 +1,40 @@
+---
+scenarios:
+  - id: monitoring-drift-report
+    kind: behavioral
+    name: "Model monitoring: check data drift for a deployment"
+    difficulty: medium
+    skills_under_test:
+      - datarobot-model-monitoring
+    requires_env:
+      - BEHAVIORAL_FIXTURE_DEPLOYMENT_ID
+    prompt: |
+      Check how our DataRobot deployment
+      {env:BEHAVIORAL_FIXTURE_DEPLOYMENT_ID} is doing. Pull its service stats
+      and data drift — both feature drift and target drift — for the last
+      week, and write what you find to ./drift_report.md. Include the
+      prediction volume, and call out any features that have drifted (or say
+      clearly that none have).
+    success_checks:
+      - type: file_exists
+        path: drift_report.md
+        min_bytes: 100
+      - type: file_matches
+        path: drift_report.md
+        pattern: "(?i)(feature drift|target drift)"
+      - type: file_matches
+        path: drift_report.md
+        pattern: "(?i)(tenure_months|contract_type|monthly_charges|prediction)"
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      inventing drift numbers when the API returns no data; trying to
+      configure alerts or notifications (no such API exists); hallucinated SDK
+      methods followed by retries.
+    common_pitfalls:
+      - Fabricating drift scores when the API returns empty results
+      - Attempting to set up alert rules the SDK has no API for
+      - Ignoring service stats when the user asked for prediction volume
+      - Crashing on deployment.get_target_drift() — the SDK raises a trafaret
+        DataError (segment_value is required) on unsegmented deployments; a
+        good trajectory recovers via the raw API or reports the gap honestly
+    timeout_minutes: 15

--- a/tests/behavioral/scenarios/datarobot-model-training/start-automl-training.yaml
+++ b/tests/behavioral/scenarios/datarobot-model-training/start-automl-training.yaml
@@ -1,0 +1,38 @@
+---
+scenarios:
+  - id: training-start-automl
+    kind: behavioral
+    name: "Model training: create project and start Quick AutoML"
+    difficulty: easy
+    skills_under_test:
+      - datarobot-model-training
+    prompt: |
+      I have customer churn data in ./data/churn_train.csv. Create a new
+      DataRobot project for it and start AutoML training to predict the
+      "churn" column — Quick mode is fine. I don't have an existing Use Case,
+      so create whatever you need. Don't wait for training to finish: kick it
+      off, then tell me the project ID and how I can monitor progress.
+    fixtures:
+      - source: ../../fixtures/churn_train.csv
+        dest: data/churn_train.csv
+    env:
+      automl_mode: quick
+      resource_prefix: "{run_id}"
+    success_checks:
+      - type: dr_use_case_exists
+        name_contains: "{run_id}"
+      - type: dr_project_exists
+        name_contains: "{run_id}"
+        stage: modeling
+        deadline_seconds: 180
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      skipping the Use Case linkage the skill mandates; blocking on
+      wait_for_autopilot after being told not to wait; hallucinated SDK
+      methods followed by retries; legacy Project.start()-era flows.
+    common_pitfalls:
+      - Forgetting to create/link a Use Case before creating the project
+      - Blocking until autopilot completes despite being told not to wait
+      - Passing the CSV path where an uploaded dataset ID is required
+      - Asking the user for a Use Case ID instead of creating one
+    timeout_minutes: 15

--- a/tests/behavioral/scenarios/datarobot-predictions/prediction-template.yaml
+++ b/tests/behavioral/scenarios/datarobot-predictions/prediction-template.yaml
@@ -1,0 +1,39 @@
+---
+scenarios:
+  - id: predictions-template
+    kind: behavioral
+    name: "Predictions: generate a prediction dataset template for a deployment"
+    difficulty: easy
+    skills_under_test:
+      - datarobot-predictions
+    requires_env:
+      - BEHAVIORAL_FIXTURE_DEPLOYMENT_ID
+    prompt: |
+      I need to score data against our DataRobot deployment
+      {env:BEHAVIORAL_FIXTURE_DEPLOYMENT_ID} but I don't know what columns it
+      expects. Generate a prediction dataset template for that deployment with
+      5 sample rows so I can see exactly which features and types it needs,
+      and save it as ./prediction_template.csv.
+    success_checks:
+      - type: file_exists
+        path: "*template*.csv"
+        min_bytes: 50
+      - type: file_matches
+        path: "*template*.csv"
+        pattern: "tenure_months"
+      # Header + the 5 requested sample rows, whether written by the skill's
+      # script (with its '#' metadata block) or an inline-pandas equivalent.
+      - type: file_matches
+        path: "*template*.csv"
+        pattern: "^[^#\\r\\n].*,.*,.*,.*,.*,"
+        min_count: 6
+    rubric: |
+      Process quality only — pass/fail comes from success_checks. Penalize:
+      hallucinating the deployment's features instead of fetching them from
+      the API; scoring the deployment when only a template was asked for;
+      retries caused by invented SDK methods.
+    common_pitfalls:
+      - Inventing feature names instead of reading them from the deployment's model
+      - Including the target column in the template
+      - Writing the template to stdout instead of ./prediction_template.csv
+    timeout_minutes: 10

--- a/tests/integration/sdk_conformance.py
+++ b/tests/integration/sdk_conformance.py
@@ -173,6 +173,8 @@ def _check_signature(
     if accepts_varargs or splatted:
         return out
 
+    # Positional parameters are satisfied either by position or by name, so the
+    # index into `required` is compared against how many positionals were passed.
     required = [
         p
         for p in params
@@ -184,6 +186,16 @@ def _check_signature(
         p.name
         for i, p in enumerate(required)
         if p.name not in passed_kw and i >= n_positional
+    ]
+    # Keyword-only parameters can only ever be supplied by name, so position is
+    # irrelevant: absent from the call keywords means absent. e.g. omitting
+    # connector_type from Connector.create(*, connector_type) is a TypeError.
+    missing += [
+        p.name
+        for p in params
+        if p.kind is p.KEYWORD_ONLY
+        and p.default is inspect.Parameter.empty
+        and p.name not in passed_kw
     ]
     if missing and missing[0] in ("self", "cls"):
         # Reached through the class rather than an instance, so the receiver is

--- a/tests/integration/sdk_conformance.py
+++ b/tests/integration/sdk_conformance.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve DataRobot SDK calls in skills against the installed SDK.
+
+Every ``dr.*`` call in a ``SKILL.md`` python fence or a skill ``scripts/*.py``
+is looked up in the real ``datarobot`` package and its signature checked, so
+methods that do not exist and calls with wrong arguments are caught without a
+DataRobot account, a coding agent, or an AutoML run.
+
+Run directly to list findings while fixing them::
+
+    uv run --group integration python tests/integration/sdk_conformance.py
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import datarobot as dr
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+PY_FENCE = re.compile(r"```(?:python|py)\n(.*?)```", re.S)
+SDK_ALIASES = {"dr", "datarobot"}
+
+# Nodes that introduce a new variable scope.  Type inference is per-scope so a
+# name reused for different SDK types in sibling functions is not conflated.
+SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+# Methods assumed to return an instance of their own class, subject to the
+# return-annotation check in _infer_var_types.  ``create`` is deliberately
+# included but guarded: e.g. PredictionExplanations.create() returns a Job.
+FACTORY_PREFIXES = ("create_from", "from_")
+FACTORY_NAMES = ("get", "create")
+
+# NOTE: deprecation detection is intentionally absent.  The SDK signals
+# deprecations with a runtime decorator rather than docstring text, so a static
+# check gives false confidence.  Importing under ``-W error::DeprecationWarning``
+# is the right tool for that.
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single SDK conformance violation."""
+
+    file: str
+    line: int
+    kind: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line} [{self.kind}] {self.message}"
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    """Flatten an attribute chain (``dr.Project.start``) into a dotted string."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _resolve(attr_path: list[str]) -> tuple[Any, bool]:
+    """Walk an attribute path from the datarobot module."""
+    obj: Any = dr
+    for part in attr_path:
+        if not hasattr(obj, part):
+            return None, False
+        obj = getattr(obj, part)
+    return obj, True
+
+
+def _scope_nodes(scope: ast.AST) -> Iterator[ast.AST]:
+    """Yield nodes belonging to ``scope``, without entering nested scopes."""
+    for child in ast.iter_child_nodes(scope):
+        if isinstance(child, SCOPE_NODES):
+            continue
+        yield child
+        yield from _scope_nodes(child)
+
+
+def _nested_scopes(scope: ast.AST) -> Iterator[ast.AST]:
+    """Yield the scopes directly nested inside ``scope`` (not their children)."""
+    for child in ast.iter_child_nodes(scope):
+        if isinstance(child, SCOPE_NODES):
+            yield child
+        else:
+            yield from _nested_scopes(child)
+
+
+def _infer_var_types(nodes: Iterable[ast.AST], aliases: set[str]) -> dict[str, type]:
+    """Map ``x = dr.Foo.get(...)`` to ``x: Foo`` so instance calls can be checked."""
+    var_types: dict[str, type] = {}
+    for node in nodes:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        name = _dotted_name(node.value.func)
+        if not name:
+            continue
+        parts = name.split(".")
+        if parts[0] not in aliases or len(parts) < 3:
+            continue
+        method = parts[-1]
+        if not (method in FACTORY_NAMES or method.startswith(FACTORY_PREFIXES)):
+            continue
+        cls, ok = _resolve(parts[1:-1])
+        if not (ok and inspect.isclass(cls)):
+            continue
+        # Only infer when the factory really returns its own class.
+        try:
+            annotation = str(inspect.signature(getattr(cls, method)).return_annotation)
+        except (ValueError, TypeError):
+            annotation = ""
+        if (
+            annotation
+            and "inspect._empty" not in annotation
+            and cls.__name__ not in annotation
+        ):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                var_types[target.id] = cls
+    return var_types
+
+
+def _check_signature(
+    call: ast.Call, target: Any, display: str, drop_self: bool
+) -> list[tuple[str, str]]:
+    """Return (kind, message) pairs for signature violations."""
+    out: list[tuple[str, str]] = []
+    if not callable(target):
+        return out
+    try:
+        signature = inspect.signature(target)
+    except (ValueError, TypeError):
+        return out
+
+    params = list(signature.parameters.values())
+    if drop_self and params and params[0].name in ("self", "cls"):
+        params = params[1:]
+
+    names = {p.name for p in params}
+    accepts_kwargs = any(p.kind is p.VAR_KEYWORD for p in params)
+    accepts_varargs = any(p.kind is p.VAR_POSITIONAL for p in params)
+    passed_kw = {kw.arg for kw in call.keywords if kw.arg}
+
+    unknown = passed_kw - names
+    if unknown and not accepts_kwargs:
+        out.append(
+            (
+                "bad-kwarg",
+                f"`{display}()` got unexpected keyword(s) {sorted(unknown)}; "
+                f"valid: {sorted(names)[:9]}",
+            )
+        )
+
+    # A named keyword is checkable even alongside a splat, but arity is not:
+    # ``f(**opts)`` may well supply every required parameter.
+    splatted = any(isinstance(arg, ast.Starred) for arg in call.args) or any(
+        kw.arg is None for kw in call.keywords
+    )
+    if accepts_varargs or splatted:
+        return out
+
+    required = [
+        p
+        for p in params
+        if p.default is inspect.Parameter.empty
+        and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+    n_positional = len(call.args)
+    missing = [
+        p.name
+        for i, p in enumerate(required)
+        if p.name not in passed_kw and i >= n_positional
+    ]
+    if missing and missing[0] in ("self", "cls"):
+        # Reached through the class rather than an instance, so the receiver is
+        # unbound.  Reporting a literal "self" as missing only confuses.
+        out.append(
+            (
+                "instance-method-on-class",
+                f"`{display}()` is an instance method reached through the class, "
+                "so there is no receiver; call it on an instance",
+            )
+        )
+    elif missing:
+        out.append(("missing-arg", f"`{display}()` missing required arg(s) {missing}"))
+    return out
+
+
+def _check_call(
+    call: ast.Call,
+    aliases: set[str],
+    var_types: dict[str, type],
+    rel_path: str,
+    line_offset: int,
+) -> list[Finding]:
+    name = _dotted_name(call.func)
+    if not name:
+        return []
+    parts = name.split(".")
+    line = call.lineno + line_offset
+    found: list[Finding] = []
+
+    def note(kind: str, message: str) -> None:
+        found.append(Finding(rel_path, line, kind, message))
+
+    classmethod_via_instance = False
+
+    if parts[0] in aliases:
+        # dr.Foo.bar(...) — resolvable directly against the module.
+        target, ok = _resolve(parts[1:])
+        if not ok:
+            note(
+                "missing-symbol",
+                f"`{name}` does not exist in datarobot {dr.__version__}",
+            )
+            return found
+        drop_self = False
+    elif len(parts) == 2 and parts[0] in var_types:
+        # instance.bar(...) — the descriptor kind decides how args bind.
+        cls = var_types[parts[0]]
+        if not hasattr(cls, parts[1]):
+            note("missing-method", f"`{cls.__name__}.{parts[1]}` does not exist")
+            return found
+        static = inspect.getattr_static(cls, parts[1], None)
+        target = getattr(cls, parts[1])
+        # getattr() pre-binds cls for classmethods but leaves `self` on plain
+        # methods, so only the latter needs its first parameter dropped.
+        drop_self = not isinstance(static, (classmethod, staticmethod))
+        classmethod_via_instance = isinstance(static, classmethod)
+    else:
+        return found
+
+    problems = _check_signature(call, target, name, drop_self)
+
+    # Reaching a classmethod through an instance is legal and works when the
+    # arguments are supplied, so it is only worth reporting as the explanation
+    # for an arity failure.
+    if classmethod_via_instance and any(kind == "missing-arg" for kind, _ in problems):
+        note(
+            "classmethod-on-instance",
+            f"`{name}()` calls a CLASSMETHOD on an instance "
+            f"({var_types[parts[0]].__name__}.{parts[1]}) — required args are "
+            "not auto-filled",
+        )
+
+    for kind, message in problems:
+        note(kind, message)
+    return found
+
+
+def _analyse_source(
+    source: str, rel_path: str, line_offset: int = 0
+) -> tuple[list[Finding], bool]:
+    """Analyse one code chunk. Returns (findings, parsed_ok)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return [], False
+
+    aliases = set(SDK_ALIASES)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "datarobot" and alias.asname:
+                    aliases.add(alias.asname)
+
+    def walk_scope(scope: ast.AST, inherited: dict[str, type]) -> list[Finding]:
+        nodes = list(_scope_nodes(scope))
+        # Names bound here shadow anything inherited from an enclosing scope.
+        var_types = {**inherited, **_infer_var_types(nodes, aliases)}
+        findings = [
+            finding
+            for node in nodes
+            if isinstance(node, ast.Call)
+            for finding in _check_call(node, aliases, var_types, rel_path, line_offset)
+        ]
+        for nested in _nested_scopes(scope):
+            findings.extend(walk_scope(nested, var_types))
+        return findings
+
+    return walk_scope(tree, {}), True
+
+
+def analyse_skill(skill_dir: Path) -> list[Finding]:
+    """Collect SDK conformance findings for one skill directory.
+
+    Nested SKILL.md files are included: agent-assist ships sub-skills in
+    subdirectories whose fences need the same checking.
+    """
+    findings: list[Finding] = []
+
+    for skill_md in sorted(skill_dir.rglob("SKILL.md")):
+        text = skill_md.read_text()
+        rel = str(skill_md.relative_to(REPO_ROOT))
+        for match in PY_FENCE.finditer(text):
+            offset = text[: match.start()].count("\n") + 1
+            chunk, parsed = _analyse_source(match.group(1), rel, offset)
+            if not parsed:
+                # Skipping silently would let a fence full of SDK calls go
+                # unchecked while this still reported success.
+                findings.append(
+                    Finding(
+                        rel,
+                        offset,
+                        "unparseable-fence",
+                        "python fence does not parse, so its SDK calls cannot be "
+                        "checked; fix the snippet or retag the fence",
+                    )
+                )
+                continue
+            findings.extend(chunk)
+
+    for script in sorted(skill_dir.rglob("*.py")):
+        rel = str(script.relative_to(REPO_ROOT))
+        chunk, parsed = _analyse_source(script.read_text(), rel)
+        if not parsed:
+            findings.append(
+                Finding(rel, 1, "unparseable-script", "file does not parse")
+            )
+            continue
+        findings.extend(chunk)
+
+    return findings
+
+
+def skill_dirs() -> list[Path]:
+    return sorted(
+        d for d in SKILLS_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")
+    )
+
+
+if __name__ == "__main__":
+    total = 0
+    for directory in skill_dirs():
+        for finding in analyse_skill(directory):
+            print(finding)
+            total += 1
+    print(f"\n{total} finding(s) against datarobot {dr.__version__}")

--- a/tests/integration/test_behavioral_scenarios.py
+++ b/tests/integration/test_behavioral_scenarios.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate behavioral scenario YAML so typos fail in lint, not in a live agent run.
+
+Two layers:
+- Structural checks that always run (pyyaml only).
+- Full schema validation through the engine's loader when dr_agents_tester is
+  importable (the behavioral/e2e environments; skipped in the base
+  integration environment).
+
+Plus a packaging guard: scenario/fixture content must never appear under
+``skills/`` — everything there ships to end users through every plugin
+channel, and the agent under test must not be able to read its own checks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BEHAVIORAL_DIR = REPO_ROOT / "tests" / "behavioral"
+SKILLS_DIR = REPO_ROOT / "skills"
+
+_REQUIRED_KEYS = {
+    "id",
+    "kind",
+    "name",
+    "difficulty",
+    "prompt",
+    "skills_under_test",
+    "success_checks",
+}
+
+
+def _scenario_files() -> list[Path]:
+    return sorted(BEHAVIORAL_DIR.glob("journeys/*.yaml")) + sorted(
+        BEHAVIORAL_DIR.glob("scenarios/*/*.yaml")
+    )
+
+
+def _scenarios() -> list[tuple[dict[str, Any], Path]]:
+    entries: list[tuple[dict[str, Any], Path]] = []
+    for path in _scenario_files():
+        data = yaml.safe_load(path.read_text())
+        assert isinstance(data, dict) and "scenarios" in data, (
+            f"{path}: expected a top-level 'scenarios' list"
+        )
+        for item in data["scenarios"]:
+            entries.append((item, path))
+    return entries
+
+
+class TestStructure:
+    def test_at_least_one_scenario_exists(self) -> None:
+        assert _scenario_files(), "tests/behavioral/ has no scenario YAML files"
+
+    def test_required_keys_and_kind(self) -> None:
+        for item, path in _scenarios():
+            missing = _REQUIRED_KEYS - set(item)
+            assert not missing, (
+                f"{path}: scenario {item.get('id')!r} missing {sorted(missing)}"
+            )
+            assert item["kind"] == "behavioral", (
+                f"{path}: {item['id']}: kind must be behavioral"
+            )
+
+    def test_ids_unique(self) -> None:
+        ids = [item["id"] for item, _ in _scenarios()]
+        assert len(ids) == len(set(ids)), f"duplicate scenario ids: {ids}"
+
+    def test_skills_under_test_exist(self) -> None:
+        for item, path in _scenarios():
+            for skill in item["skills_under_test"]:
+                skill_dir = SKILLS_DIR / skill
+                assert (skill_dir / "SKILL.md").is_file() or any(
+                    skill_dir.rglob("SKILL.md")
+                ), f"{path}: {item['id']}: unknown skill {skill!r}"
+
+    def test_fixture_sources_exist(self) -> None:
+        for item, path in _scenarios():
+            for fixture in item.get("fixtures", []):
+                source = fixture if isinstance(fixture, str) else fixture["source"]
+                resolved = (path.parent / source).resolve()
+                assert resolved.is_file(), (
+                    f"{path}: {item['id']}: missing fixture {source!r}"
+                )
+
+    def test_journeys_are_multi_skill(self) -> None:
+        for item, path in _scenarios():
+            n_skills = len(item["skills_under_test"])
+            if "journeys" in path.parts:
+                assert n_skills >= 2, f"{path}: {item['id']}: journeys span 2+ skills"
+            else:
+                assert n_skills == 1, (
+                    f"{path}: {item['id']}: per-skill scenarios test one skill"
+                )
+                assert path.parent.name == item["skills_under_test"][0], (
+                    f"{path}: {item['id']}: directory must match the skill under test"
+                )
+
+
+class TestEngineParse:
+    def test_engine_loader_accepts_all_scenarios(self) -> None:
+        scenarios_mod = pytest.importorskip(
+            "dr_agents_tester.eval.scenarios",
+            reason="engine not installed in this environment (behavioral/e2e groups have it)",
+        )
+        loaded = []
+        seen_dirs = sorted({p.parent for p in _scenario_files()})
+        for directory in seen_dirs:
+            loaded.extend(scenarios_mod.load_behavioral_scenarios(directory))
+        assert len(loaded) == len(_scenarios())
+
+
+class TestPackagingGuard:
+    def test_no_scenarios_or_fixtures_ship_inside_skills(self) -> None:
+        offenders = [
+            p
+            for name in ("scenarios", "fixtures")
+            for p in SKILLS_DIR.rglob(name)
+            if p.is_dir()
+        ]
+        assert not offenders, (
+            f"test content must not live under skills/ (it ships to customers): {offenders}"
+        )

--- a/tests/integration/test_sdk_conformance.py
+++ b/tests/integration/test_sdk_conformance.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate DataRobot SDK calls in skills against the installed SDK.
+
+Skills document python that agents copy verbatim, but nothing else in this repo
+imports ``datarobot``.  A call to a method that does not exist, or one with the
+wrong arguments, is therefore invisible to ruff, to mypy (which is configured
+with ``ignore_missing_imports``), and to the SKILL.md prose judge alike.
+"""
+
+from pathlib import Path
+
+import datarobot as dr
+import pytest
+from sdk_conformance import analyse_skill, skill_dirs
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "skill_dir" in metafunc.fixturenames:
+        dirs = skill_dirs()
+        metafunc.parametrize("skill_dir", dirs, ids=[d.name for d in dirs])
+
+
+def test_sdk_calls_match_installed_sdk(skill_dir: Path) -> None:
+    """Every DataRobot SDK call in the skill must exist and take these arguments."""
+    findings = analyse_skill(skill_dir)
+    if findings:
+        # pytest.fail rather than assert: the dataclass repr that assertion
+        # introspection appends buries the readable list.
+        pytest.fail(
+            f"{len(findings)} DataRobot SDK violation(s) in '{skill_dir.name}' "
+            f"(datarobot {dr.__version__}):\n  "
+            + "\n  ".join(str(f) for f in findings),
+            pytrace=False,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,18 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -358,6 +368,29 @@ wheels = [
 ]
 
 [[package]]
+name = "datarobot"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "strenum" },
+    { name = "trafaret" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/87/fe696ed62eb8f72a29b036a71086434e39db7ef096a280526c8073017652/datarobot-3.18.0.tar.gz", hash = "sha256:47f289b65211416fba37b384b57a0ec82efdb76546aabda95c1ff7076b41e72c", size = 834279, upload-time = "2026-07-28T18:34:22.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/5a/999f30688e3f352110e02034681f3393133a0fcc2db2bc88ee92377b15c8/datarobot-3.18.0-py3-none-any.whl", hash = "sha256:c1272693b9ebb3cbf6e4e4066bb714e003208cb3957d4489d751a380e7062a97", size = 900686, upload-time = "2026-07-28T18:34:20.498Z" },
+]
+
+[[package]]
 name = "datarobot-agent-skills"
 version = "0.0.1"
 source = { virtual = "." }
@@ -375,6 +408,7 @@ e2e = [
 ]
 integration = [
     { name = "codeowners" },
+    { name = "datarobot" },
     { name = "datarobot-genai" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -397,6 +431,7 @@ e2e = [
 ]
 integration = [
     { name = "codeowners", specifier = ">=0.8.0" },
+    { name = "datarobot", specifier = ">=3.6" },
     { name = "datarobot-genai" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1219,6 +1254,174 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1244,6 +1447,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ef/f1fd7431d635bf20015489bf0bd69c17fff1018de773540f651455a3916b/pandas-3.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2946e77e4a53cd248cbde631a12f0e51c8324ce354c3eba4d20147c1ad6f4282", size = 10397178, upload-time = "2026-07-22T22:17:48.274Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b4/0eafac990a431561187694126de01f9b12559549b4d86360c0c4bd870fde/pandas-3.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71ecc8fb7ed1a7aa4392316b5309a6347e8e7f832f38fd897846b3a1457a9298", size = 9990736, upload-time = "2026-07-22T22:17:52.388Z" },
+    { url = "https://files.pythonhosted.org/packages/de/21/359880af3ea9b7cb23bea5b51e8e70ef3866c03be09da9a2787e18e330a8/pandas-3.0.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b173f5951ff6b8b0ec7675e20dff3c97b7e7a57dfcce387c2d7c5afe87cb7899", size = 10814438, upload-time = "2026-07-22T22:17:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/d6cc4d7e508bbccf5d6027314a8312bc7ac73d0ec7f195f53838daafab40/pandas-3.0.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c0cf1dd9b55a22d105fc46c1b489af3bd42264fcba7c66297bf47a9a1d9c78a", size = 11323634, upload-time = "2026-07-22T22:17:56.858Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2b/d5f0a8c90dd0ae04e64ba53b871afb796ec026b615086d382ddc2ade729b/pandas-3.0.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0fac0010c75e4efb6b99e249c183a8993ce0dc95c240f9b120a5e67c727b7928", size = 11850860, upload-time = "2026-07-22T22:17:59.1Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/30/183aec2e19adf778a98d29b5729a0a68f4cc4ebf9b9c3b70d0297355bcb1/pandas-3.0.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:08d24fe11a17dc33bd6e937dc9c665f9cba08fbdc9f657f405713515febe300d", size = 12411100, upload-time = "2026-07-22T22:18:01.485Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9a/31f4983f191af51ab2a8f2d0c7b33dff3a84da26533f982fff02c2f9e28b/pandas-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:b1261758dfb6cf12c3cff8300e21cefad30e7ec709abb4c24ac7318e6a52462a", size = 9968804, upload-time = "2026-07-22T22:18:03.903Z" },
+    { url = "https://files.pythonhosted.org/packages/49/97/7886c89a39045c69ad82cbceaf3343810480c8ef49a216319ce8183860a6/pandas-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:679f4e85b30ddb1515458ab1e788d3e260eae369b1f78da7a3aa4cac8ebf4a2a", size = 9205447, upload-time = "2026-07-22T22:18:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d", size = 10411717, upload-time = "2026-07-22T22:18:08.307Z" },
+    { url = "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc", size = 9957095, upload-time = "2026-07-22T22:18:10.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc", size = 10485458, upload-time = "2026-07-22T22:18:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34", size = 10998091, upload-time = "2026-07-22T22:18:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6", size = 11499501, upload-time = "2026-07-22T22:18:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7", size = 12060559, upload-time = "2026-07-22T22:18:20.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ffbd852d58bd74a617fe2f8ee6a58a96982271ce41cf981eab22190b4a4b/pandas-3.0.5-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:b2acb4650527eec6822c3dadb2b771277b65e7dae7a267d4bccf65fd1bb3fbce", size = 7197652, upload-time = "2026-07-22T22:18:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41", size = 9831691, upload-time = "2026-07-22T22:18:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/dea1e89d6a6796b9c43f85a09b484ee03edb8a4c4842e73e200a8c11301c/pandas-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:25ff585b972a18ef1fe9ffa3ac6544d9950508aa76832e5147640b6022821e49", size = 9105796, upload-time = "2026-07-22T22:18:27.064Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2f/cf6aae281264f4463f0875bcbb15fd2bb6d291cc535187dad1732475e4a9/pandas-3.0.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2f264fc46911cc8131a7322a16199bbf8e353d27c10bb211f5bd0c814324dc36", size = 10390034, upload-time = "2026-07-22T22:18:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ec/5189518c7a7659c4bdcc6b1eb32c46c6f3c86b0661ffd84143d1112c7732/pandas-3.0.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:53730687fcd161883b24e10411c06d6a4c0f2275d2faf3bb2bc25deb4ba8007c", size = 9980065, upload-time = "2026-07-22T22:18:52.249Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/598503ce8d7e3c35601e0747ba288c7864baae66380725bc12f13f884dfe/pandas-3.0.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:960d3ebcf249f75206899fcd2c6de53f736b7265759ced0d3e559df0b8b709b0", size = 10545532, upload-time = "2026-07-22T22:18:54.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/ceae2adf7034e07e9910299fe412e1819c4f0dd520700a888bcb03625448/pandas-3.0.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e94c2c5ca43bd3ca32bf64d32308887b65e5f9bfd8023ea52755107a999f93b", size = 10963120, upload-time = "2026-07-22T22:18:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/66/25/86e0f4451874eb79e688deeebe3c451fec4557f8952005818d800ee8ac7e/pandas-3.0.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e819dd5f62966b481a8cb649d3299ebd886a1ea91ed5a99bf7ce77c98d18ab94", size = 11563178, upload-time = "2026-07-22T22:18:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/45/8643daa3b4147e433adfcccefdd0380d3aad79d86b15d8999730fe1944d5/pandas-3.0.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3c5ed2e7c06e91d340dfd091d7934f9bc82e4a36b95f647f090b9d1c9ac649da", size = 12028708, upload-time = "2026-07-22T22:19:02.164Z" },
+    { url = "https://files.pythonhosted.org/packages/96/58/ad979ae617615576e8aafd569c9d4b62f1191d896e38f51d66ba06f3b89a/pandas-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:cd8f7c6dc98527058ee6264219343f5392240a6f1bfa654fc5d79023020d0c92", size = 9951806, upload-time = "2026-07-22T22:19:04.596Z" },
+    { url = "https://files.pythonhosted.org/packages/69/32/7ac03886b304049a9d2625ee88f59af760d8a93bd30ed9239bce7b9869a8/pandas-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:5183427f5a8156d480f30333777bc978be93650a49a7c01db26adffe95b31e85", size = 9238297, upload-time = "2026-07-22T22:19:06.836Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1d1f2ee5547d5167face2376d11c8b2a4c7bfff5a416ee7a9046891fab1e/pandas-3.0.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:303da736987d481074ca720ada325f8bd80c64ebc2d45ed79b29df3aaa4a26ca", size = 10849690, upload-time = "2026-07-22T22:19:09.391Z" },
+    { url = "https://files.pythonhosted.org/packages/57/55/17e17152e98fbb0c4b1e562bc65387a2f20a80db0f4a86bf8d3a0e4248d4/pandas-3.0.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3b2801bbb049d0136f6c213eae02b5fca969384fc2064dd728d8620552aa49da", size = 10509945, upload-time = "2026-07-22T22:19:11.773Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/817d44dbf83facf9556f33576d9af0a241981e7bb5c00606c0bcb5df8dda/pandas-3.0.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cce3a9d11d2b1f82c69a27ec1f4948a170e2c403c4bbfa8cca62e3fdebe2ef3a", size = 10392197, upload-time = "2026-07-22T22:19:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/da/889f00c0a6f5aa1545add70abbf01502dff87ab577adb855bd631c54d2f2/pandas-3.0.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef01af4d8dc6cd2c8d6c7736f149574ef93fe043811eeb5e445f2647154b5040", size = 10862726, upload-time = "2026-07-22T22:19:16.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/f1e934fb3c98fce859c6147c6785816c7b5b9ab7821115c5d8c4de9842b9/pandas-3.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e2759e890db96dfcffdbd9b86c3c2cb6afaf58def482820317e06163ec1066cd", size = 11414864, upload-time = "2026-07-22T22:19:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/be/d448af7d657d82e1888dd8551f79c6d6fb161080b5b9752d84d910ec2319/pandas-3.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b58b1b39d46a5862e3fb18f50d1a201398619d16a0f9f73f57eea5583cf0e63c", size = 11925105, upload-time = "2026-07-22T22:19:21.515Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c1/ccb4238212c8c4f496c584f3044d94e0c030ed8e1d68999db46c91c2242f/pandas-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:1c10461f6eeb35d8f05b6184c65c8b9991663b66c46b1d559b682cb34ae7c6ea", size = 10387612, upload-time = "2026-07-22T22:19:24.257Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cf/6a51b2c38980e04c279fd2fa908a1b0982064e860444acfca4ec2e2c8359/pandas-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3c5015fd1730fbf883647e88068176c839c102cea883ba1769a6f4593bfc1f8c", size = 9509776, upload-time = "2026-07-22T22:19:26.694Z" },
 ]
 
 [[package]]
@@ -1514,6 +1772,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1532,6 +1802,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/21/88aefb4f1de6661b5a003175e21e4a5ad94f5e52b2abf4170a11883c7d81/python_frontmatter-1.2.0.tar.gz", hash = "sha256:5b26ccd3cb85af77feb11d83b922c7bb5aeccb0c9d3fb236b938c600b6322984", size = 16890, upload-time = "2026-05-17T23:42:05.493Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/b1/ec12e3e746234006b77dec69d53878253b1da09dbb55fa3cb456083d9069/python_frontmatter-1.2.0-py3-none-any.whl", hash = "sha256:e1ee1d4300450a2f84e778eb4f70edf573da6cd7d463801066f05edc4e819c78", size = 10396, upload-time = "2026-05-17T23:42:04.637Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
 ]
 
 [[package]]
@@ -1723,6 +2002,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1878,12 +2169,30 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
 ]
 
 [[package]]
@@ -1979,6 +2288,15 @@ wheels = [
 ]
 
 [[package]]
+name = "trafaret"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/ed/aac034e566f8846aee6472dcc90da6011a0b1829e3ffc768407df519a3b0/trafaret-2.1.1.tar.gz", hash = "sha256:d9d00800318fbd343fdfb3353e947b2ebb5557159c844696c5ac24846f76d41c", size = 26249, upload-time = "2022-04-01T17:36:25.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/32/17b47745df926eff2e5b89d79838337de88258f65a936f70416a15190142/trafaret-2.1.1-py3-none-any.whl", hash = "sha256:1966f432586797aed663edd54cbc201fd7ba59eed1638f1a7a33f17977b3a569", size = 28399, upload-time = "2022-04-01T17:36:29.066Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2012,6 +2330,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -396,6 +396,11 @@ version = "0.0.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]
+behavioral = [
+    { name = "datarobot" },
+    { name = "datarobot-agent-tester" },
+    { name = "python-dotenv" },
+]
 dev = [
     { name = "mypy" },
     { name = "ruff" },
@@ -419,6 +424,11 @@ integration = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+behavioral = [
+    { name = "datarobot", specifier = ">=3.6" },
+    { name = "datarobot-agent-tester", git = "https://github.com/datarobot/datarobot-agent-tester?rev=main" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+]
 dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "ruff", specifier = "==0.15.22" },


### PR DESCRIPTION
Skills-repo side of the behavioral-testing rollout — companion to [datarobot-oss/datarobot-agent-tester#10](https://github.com/datarobot-oss/datarobot-agent-tester/pull/10), which carries the engine. Design doc (now committed here with implementation amendments): `docs/proposals/skill-behavioral-testing.md`.

## What's in here

- **`tests/behavioral/`** — the golden-journey scenario (upload → train Quick → deploy → predict across `datarobot-model-training` / `-deployment` / `-predictions`) with programmatic `success_checks`; seeded churn fixtures (300-row train with a planted signal, 60-row holdout) + regenerator; an authoring README. Scenarios deliberately live here and **not** under `skills/` — everything in `skills/` ships to customers through every plugin channel, and the agent under test must not read its own checks (a guard test enforces this).
- **Validation in lint** — structural YAML checks always run; full engine-loader parsing runs where `dr_agents_tester` is installed; scenario typos fail in seconds, not in a 30-minute live run.
- **Local dev loop** — `task test:behavioral` (working-tree skills, k=1), `task test:behavioral:baseline` (no skills), `task test:behavioral:clean` (sweep leaked `drat-` resources). Runs create real, run-prefixed resources in your own account and tear them down per run.
- **CI workflow (`behavioral-e2e.yml`) — merged inert**: no-ops until `vars.BEHAVIORAL_LIVE_ENABLED` is set and the `behavioral-live` environment exists (dedicated test org + service-account token). Label-gated (`run-e2e`) + nightly; plain `pull_request` only with an explicit fork refusal, per-condition matrix over two checkouts, per-run teardown + nightly sweep, transcripts uploaded 30 days, advisory job-summary reporting.
- **Hygiene** — CONTRIBUTING step 8 (scenario authoring), version-bump exemption for test-only PRs, CODEOWNERS for `tests/behavioral/`, gitignore fixture negation.

## Verification

The golden journey was run end-to-end with this branch's skills via the engine PR: **PASS on all four checks** (project + deployment created under the run prefix, 60-row predictions CSV), all three skills triggered, teardown left zero resources.

Note: the `behavioral` uv group pins the engine to `@main` with a TODO to tighten to a tag once datarobot-agent-tester cuts its first release — `task test:behavioral` becomes functional when the engine PR merges.

## Update (2026-08-20): scenarios for all five README user journeys

Seven more commits (one per journey, each carrying its own live-run evidence, plus provisioning and proposal amendments 6–9) extend coverage from the golden journey to every user journey the README publishes:

| Scenario (`tests/behavioral/scenarios/<skill>/`) | Live k=1 result |
|---|---|
| `training-start-automl` — create project + start Quick AutoML *without waiting* | PASS (2 checks; `dr_project_exists stage=modeling` needed 104 s of polling) |
| `predictions-template` — the roadmap's fast every-PR scenario, ~2 min | PASS (3 checks, 12 turns) |
| `feature-impact-report` — report against the fixture model | PASS (right skill, 7 turns, 0 errors) |
| `monitoring-drift-report` — service stats + drift report | PASS (real PSI drift scores, 0 errors) |
| `external-agent-otel` — instrument a toy LangGraph agent | PASS (all 5 checks; real spans verified server-side via `dr_traces_received`) |

Supporting pieces:

- **`fixtures/provision_fixtures.py`** builds the long-lived **`bfix-`**-prefixed resources fixture scenarios assert against (Use Case → dataset → Quick-AutoML project → recommended model with Feature Impact → deployment with drift tracking + scored holdout) — idempotent, with `--check` (CI preflight), `--recreate`, `--refresh-traffic` (nightly keeps drift windows populated). `bfix-` is deliberately outside the sweeper's `drat-` family. Scenarios consume the ids via the engine's `requires_env`/`{env:VAR}` mechanism; CI includes the fixture-dependent directory only once `BEHAVIORAL_FIXTURE_*` environment variables exist.
- **`fixtures/toy_agent/`** — minimal LangGraph project on `FakeListChatModel`: runs (and the auto-instrumentor emits gen_ai spans) with no network and no model key.
- **Taskfile/workflow plumbing** — both scenario directories in every run; `test:behavioral:fixtures[:check]` targets; preflight + nightly traffic refresh in `behavioral-e2e.yml`.

Findings the spikes surfaced (tracked separately): plain "analyze the feature importance" phrasing organically triggers `datarobot-model-explainability` instead of `datarobot-feature-engineering` (now measured by the engine's expected-skill trigger metric); `deployment.get_target_drift()` raises a trafaret `DataError` on unsegmented deployments in datarobot 3.18.

**Verification**: one aggregated live invocation (golden journey + all five new scenarios) passed **6/6** with a 100% expected-skill trigger rate; teardown left zero `drat-` resources and the `bfix-` fixtures intact; the scenario parse tests (structure, naming, fixture resolution, engine loader) pass 8/8. Requires the engine PR's checks wave (now included in datarobot-oss/datarobot-agent-tester#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1787105116.979559 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When live CI is enabled, the workflow runs PR-authored skills and agent-generated code against a real test org using service-account secrets; misconfiguration or fork bypass would be costly. Scope is gated (variable, label, environment) and advisory by default.
> 
> **Overview**
> Adds **automated behavioral testing** for skills: scenarios and churn fixtures live under `tests/behavioral/` (not `skills/`), with a **train → deploy → predict** golden journey and programmatic DataRobot `success_checks`. Lint gains **scenario YAML validation** and a **packaging guard** so test fixtures never ship under `skills/`.
> 
> **Local loop:** `task test:behavioral`, baseline (`no_skill`), and `drat-` resource sweep. **`behavioral` uv group** wires `datarobot-agent-tester` (`dr-agent eval run-behavioral` / `sweep`).
> 
> **CI:** New `behavioral-e2e.yml` is **inert** until `vars.BEHAVIORAL_LIVE_ENABLED`; then label-gated `run-e2e` on same-repo PRs (fork refusal), nightly schedule, OpenCode matrix over `no_skill` / `skill_main` / `skill_pr`, teardown + artifact upload. Uses plain `pull_request` (not `pull_request_target`) for secret safety.
> 
> Also adds **static SDK conformance** (`test_sdk_conformance.py`) so `dr.*` calls in `SKILL.md` fences and skill scripts are checked against the installed `datarobot` package during `task lint`, plus CONTRIBUTING/CODEOWNERS/gitignore updates and the behavioral testing design doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ce01a5db88324e45a1c2df45953122a8fe0f4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
