### PR TITLE
Stop helper scripts inventing a DataRobot endpoint they cannot authenticate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.5.1"
+      "version": "1.5.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,11 +76,8 @@ Initialize client:
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 ```
 
 See each skill's "Using DataRobot SDK" section for specific operations and examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,7 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ### Fixed
 
-- All skills: helper scripts and examples passed
-  `endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com")` to `dr.Client()`.
-  When `DATAROBOT_ENDPOINT` is unset this supplies an endpoint with no matching token, and
-  the SDK requires both to come from the same source, so the call fails with
-  `ValueError: Token must be specified if endpoint is specified` — even when valid
-  credentials are present in `~/.config/datarobot/drconfig.yaml`, which is what
-  `dr auth login` (per `datarobot-setup`) writes. The default was also missing the
-  `/api/v2` suffix, so it could not work even with a token supplied. Dropping it lets
-  `dr.Client()` apply its own resolution order (arguments, then environment, then
-  `drconfig.yaml`), which already defaults to the public cloud endpoint correctly.
+- All skills: removed hardcoded default "https://app.datarobot.com" endpoint from helper scripts and examples. Dropping it lets `dr.Client()` apply its own resolution order (arguments, then environment, then `drconfig.yaml`), which already defaults to the public cloud endpoint correctly.
 
 ## [1.5.1] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-18
+
+### Fixed
+
+- All skills: helper scripts and examples passed
+  `endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com")` to `dr.Client()`.
+  When `DATAROBOT_ENDPOINT` is unset this supplies an endpoint with no matching token, and
+  the SDK requires both to come from the same source, so the call fails with
+  `ValueError: Token must be specified if endpoint is specified` — even when valid
+  credentials are present in `~/.config/datarobot/drconfig.yaml`, which is what
+  `dr auth login` (per `datarobot-setup`) writes. The default was also missing the
+  `/api/v2` suffix, so it could not work even with a token supplied. Dropping it lets
+  `dr.Client()` apply its own resolution order (arguments, then environment, then
+  `drconfig.yaml`), which already defaults to the public cloud endpoint correctly.
+
 ## [1.5.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ### Fixed
 
-- All skills: removed hardcoded default "https://app.datarobot.com" endpoint from helper scripts and examples. Dropping it lets `dr.Client()` apply its own resolution order (arguments, then environment, then `drconfig.yaml`), which already defaults to the public cloud endpoint correctly.
+- All skills: helper scripts and examples now call plain `dr.Client()` instead of re-reading `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` and passing them back in. The SDK reads those variables itself and then falls back to `~/.config/datarobot/drconfig.yaml`, so this fixes setups where only `drconfig.yaml` is configured — what `dr auth login` (per `datarobot-setup`) writes. Previously most sites hardcoded a `"https://app.datarobot.com"` endpoint default, which supplied an endpoint with no matching token and failed with `ValueError: Token must be specified if endpoint is specified` (and was missing the `/api/v2` suffix); `datarobot-model-explainability` used `os.environ["DATAROBOT_API_TOKEN"]` and failed the same setup with `KeyError`.
 
 ## [1.5.1] - 2026-08-13
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-data-preparation/SKILL.md
+++ b/skills/datarobot-data-preparation/SKILL.md
@@ -230,7 +230,7 @@ import os
 
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-data-preparation/SKILL.md
+++ b/skills/datarobot-data-preparation/SKILL.md
@@ -137,12 +137,9 @@ Claude can run this script directly or use it as reference when writing code.
 ### Pattern 1: Upload and validate
 ```python
 import datarobot as dr
-import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Upload dataset
 dataset = dr.Dataset.create_from_file(
@@ -226,12 +223,8 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 ## Resources

--- a/skills/datarobot-data-preparation/scripts/upload_dataset.py
+++ b/skills/datarobot-data-preparation/scripts/upload_dataset.py
@@ -34,10 +34,7 @@ def upload_dataset(
         Dataset information including dataset_id
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")

--- a/skills/datarobot-data-preparation/scripts/upload_dataset.py
+++ b/skills/datarobot-data-preparation/scripts/upload_dataset.py
@@ -36,7 +36,7 @@ def upload_dataset(
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     if not os.path.exists(file_path):

--- a/skills/datarobot-feature-engineering/SKILL.md
+++ b/skills/datarobot-feature-engineering/SKILL.md
@@ -120,12 +120,9 @@ See the [Common Patterns](#common-patterns) section below for complete examples.
 ### Pattern 1: Feature importance analysis
 ```python
 import datarobot as dr
-import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Get model and feature importance
 model = dr.Model.get("xyz123")
@@ -207,12 +204,8 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 ## Resources

--- a/skills/datarobot-feature-engineering/SKILL.md
+++ b/skills/datarobot-feature-engineering/SKILL.md
@@ -211,7 +211,7 @@ import os
 
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-model-deployment/SKILL.md
+++ b/skills/datarobot-model-deployment/SKILL.md
@@ -129,12 +129,9 @@ See the [Common Patterns](#common-patterns) section below for complete examples.
 ### Pattern 1: Standard deployment
 ```python
 import datarobot as dr
-import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Get best model from project
 models = dr.Model.list("abc123")
@@ -206,12 +203,8 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 ## Resources

--- a/skills/datarobot-model-deployment/SKILL.md
+++ b/skills/datarobot-model-deployment/SKILL.md
@@ -210,7 +210,7 @@ import os
 
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-model-explainability/SKILL.md
+++ b/skills/datarobot-model-explainability/SKILL.md
@@ -61,14 +61,10 @@ XEMP prediction explanations, analyze anomaly explanations, or retrieve model di
 ## Setup
 
 ```python
-import os
 import datarobot as dr
 from datarobot.insights import ShapMatrix, ShapImpact, ShapPreview, ShapDistributions
 
-dr.Client(
-    token=os.environ["DATAROBOT_API_TOKEN"],
-    endpoint=os.environ.get("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2"),
-)
+dr.Client()
 ```
 
 ---

--- a/skills/datarobot-model-explainability/scripts/compute_shap_matrix.py
+++ b/skills/datarobot-model-explainability/scripts/compute_shap_matrix.py
@@ -13,7 +13,6 @@ Usage:
 """
 
 import argparse
-import os
 from typing import Any
 
 import datarobot as dr
@@ -75,12 +74,7 @@ def main() -> None:
     parser.add_argument("--list-existing", action="store_true")
     args = parser.parse_args()
 
-    dr.Client(
-        token=os.environ["DATAROBOT_API_TOKEN"],
-        endpoint=os.environ.get(
-            "DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2"
-        ),
-    )
+    dr.Client()
 
     if args.list_existing:
         matrices = ShapMatrix.list(entity_id=args.model_id)

--- a/skills/datarobot-model-monitoring/SKILL.md
+++ b/skills/datarobot-model-monitoring/SKILL.md
@@ -218,7 +218,7 @@ import os
 
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-model-monitoring/SKILL.md
+++ b/skills/datarobot-model-monitoring/SKILL.md
@@ -122,12 +122,9 @@ Use these DataRobot SDK and MLOps API methods for monitoring:
 ### Pattern 1: Health check
 ```python
 import datarobot as dr
-import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Get deployment
 deployment = dr.Deployment.get("abc123")
@@ -214,12 +211,8 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 **Note**: Some monitoring features require DataRobot MLOps API access. Check your DataRobot plan for MLOps availability.

--- a/skills/datarobot-model-training/SKILL.md
+++ b/skills/datarobot-model-training/SKILL.md
@@ -169,9 +169,7 @@ import datarobot as dr
 import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Reuse an existing Use Case if the user gave us one, otherwise create a new one
 existing_use_case_id = os.getenv("DATAROBOT_USE_CASE_ID")  # or ask the user for it
@@ -284,12 +282,8 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 ## Resources

--- a/skills/datarobot-model-training/SKILL.md
+++ b/skills/datarobot-model-training/SKILL.md
@@ -288,7 +288,7 @@ import os
 
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-model-training/scripts/create_project.py
+++ b/skills/datarobot-model-training/scripts/create_project.py
@@ -13,7 +13,6 @@ project to an existing Use Case so it isn't orphaned in the DataRobot UI.
 """
 
 import json
-import os
 import sys
 
 import datarobot as dr
@@ -38,10 +37,7 @@ def create_project(
         Project information
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     use_case = dr.UseCase.get(use_case_id) if use_case_id else None
 

--- a/skills/datarobot-model-training/scripts/create_project.py
+++ b/skills/datarobot-model-training/scripts/create_project.py
@@ -40,7 +40,7 @@ def create_project(
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     use_case = dr.UseCase.get(use_case_id) if use_case_id else None

--- a/skills/datarobot-model-training/scripts/list_models.py
+++ b/skills/datarobot-model-training/scripts/list_models.py
@@ -32,7 +32,7 @@ def list_models(project_id: str, sort_by: str = "validation") -> dict:
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     models = dr.Model.list(project_id)

--- a/skills/datarobot-model-training/scripts/list_models.py
+++ b/skills/datarobot-model-training/scripts/list_models.py
@@ -12,7 +12,6 @@ Sort options: AUC, RMSE, accuracy (default: by validation score)
 """
 
 import json
-import os
 import sys
 
 import datarobot as dr
@@ -30,10 +29,7 @@ def list_models(project_id: str, sort_by: str = "validation") -> dict:
         List of models with metrics
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     models = dr.Model.list(project_id)
 

--- a/skills/datarobot-model-training/scripts/start_training.py
+++ b/skills/datarobot-model-training/scripts/start_training.py
@@ -12,7 +12,6 @@ Modes: Quick, Comprehensive, Manual (default: Quick)
 """
 
 import json
-import os
 import sys
 
 import datarobot as dr
@@ -30,10 +29,7 @@ def start_training(project_id: str, mode: str = "Quick") -> dict:
         Training job information
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     project = dr.Project.get(project_id)
 

--- a/skills/datarobot-model-training/scripts/start_training.py
+++ b/skills/datarobot-model-training/scripts/start_training.py
@@ -32,7 +32,7 @@ def start_training(project_id: str, mode: str = "Quick") -> dict:
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     project = dr.Project.get(project_id)

--- a/skills/datarobot-predictions/SKILL.md
+++ b/skills/datarobot-predictions/SKILL.md
@@ -352,7 +352,7 @@ import os
 # Initialize client with API credentials
 client = dr.Client(
     token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
 )
 ```
 

--- a/skills/datarobot-predictions/SKILL.md
+++ b/skills/datarobot-predictions/SKILL.md
@@ -148,7 +148,7 @@ import datarobot as dr
 import pandas as pd
 from datarobot_predict.deployment import predict as dr_predict
 
-dr.Client(token=..., endpoint=...)
+dr.Client()
 deployment = dr.Deployment.get("abc123")
 
 result = dr_predict(
@@ -244,15 +244,11 @@ Claude can run these scripts directly or use them as reference when writing code
 ### Pattern 1: Get deployment features and make single prediction (optionally with explanations)
 ```python
 import datarobot as dr
-import os
 import pandas as pd
 from datarobot_predict.deployment import predict as dr_predict
 
 # Initialize client
-dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 
 deployment = dr.Deployment.get("abc123")
 
@@ -276,12 +272,9 @@ print(result.dataframe.to_dict(orient="records"))
 ```python
 import datarobot as dr
 import pandas as pd
-import os
 
 # Initialize client
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"), endpoint=os.getenv("DATAROBOT_ENDPOINT")
-)
+dr.Client()
 
 # Get deployment features
 deployment = dr.Deployment.get("abc123")
@@ -347,13 +340,9 @@ pip install datarobot
 
 ```python
 import datarobot as dr
-import os
 
 # Initialize client with API credentials
-client = dr.Client(
-    token=os.getenv("DATAROBOT_API_TOKEN"),
-    endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-)
+dr.Client()
 ```
 
 ### Environment Variables

--- a/skills/datarobot-predictions/scripts/generate_prediction_data_template.py
+++ b/skills/datarobot-predictions/scripts/generate_prediction_data_template.py
@@ -35,7 +35,7 @@ def generate_prediction_data_template(
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     # Get deployment features

--- a/skills/datarobot-predictions/scripts/generate_prediction_data_template.py
+++ b/skills/datarobot-predictions/scripts/generate_prediction_data_template.py
@@ -12,7 +12,6 @@ Generates a CSV template with all required columns and sample values.
 """
 
 import csv
-import os
 import sys
 
 import datarobot as dr
@@ -33,10 +32,7 @@ def generate_prediction_data_template(
         CSV template content
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     # Get deployment features
     deployment = dr.Deployment.get(deployment_id)

--- a/skills/datarobot-predictions/scripts/get_deployment_features.py
+++ b/skills/datarobot-predictions/scripts/get_deployment_features.py
@@ -31,7 +31,7 @@ def get_deployment_features(deployment_id: str) -> dict:
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     deployment = dr.Deployment.get(deployment_id)

--- a/skills/datarobot-predictions/scripts/get_deployment_features.py
+++ b/skills/datarobot-predictions/scripts/get_deployment_features.py
@@ -12,7 +12,6 @@ Outputs JSON with feature information, types, importance, and time series config
 """
 
 import json
-import os
 import sys
 
 import datarobot as dr
@@ -29,10 +28,7 @@ def get_deployment_features(deployment_id: str) -> dict:
         Dictionary with feature information, types, importance, and time series config
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     deployment = dr.Deployment.get(deployment_id)
     model = dr.Model.get(deployment.model["id"])

--- a/skills/datarobot-predictions/scripts/make_prediction.py
+++ b/skills/datarobot-predictions/scripts/make_prediction.py
@@ -35,7 +35,6 @@ produced that prediction.
 
 import argparse
 import json
-import os
 import sys
 
 import datarobot as dr
@@ -55,10 +54,7 @@ def make_prediction(
     passthrough_columns: str | None = None,
 ) -> dict:
     """Score `data` against `deployment_id`, optionally returning prediction explanations."""
-    dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     deployment = dr.Deployment.get(deployment_id)
 

--- a/skills/datarobot-predictions/scripts/make_prediction.py
+++ b/skills/datarobot-predictions/scripts/make_prediction.py
@@ -57,7 +57,7 @@ def make_prediction(
     """Score `data` against `deployment_id`, optionally returning prediction explanations."""
     dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     deployment = dr.Deployment.get(deployment_id)

--- a/skills/datarobot-predictions/scripts/validate_prediction_data.py
+++ b/skills/datarobot-predictions/scripts/validate_prediction_data.py
@@ -33,7 +33,7 @@ def validate_prediction_data(deployment_id: str, file_path: str) -> dict:
     # Initialize client
     client = dr.Client(
         token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
+        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
     )
 
     deployment = dr.Deployment.get(deployment_id)

--- a/skills/datarobot-predictions/scripts/validate_prediction_data.py
+++ b/skills/datarobot-predictions/scripts/validate_prediction_data.py
@@ -31,10 +31,7 @@ def validate_prediction_data(deployment_id: str, file_path: str) -> dict:
         Validation report with errors, warnings, and info
     """
     # Initialize client
-    client = dr.Client(
-        token=os.getenv("DATAROBOT_API_TOKEN"),
-        endpoint=os.getenv("DATAROBOT_ENDPOINT"),
-    )
+    dr.Client()
 
     deployment = dr.Deployment.get(deployment_id)
     model = dr.Model.get(deployment.model["id"])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Helper scripts and SKILL.md examples build their client like this:

```python
dr.Client(
    token=os.getenv("DATAROBOT_API_TOKEN"),
    endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com"),
)
```

There is no fallback for the token, so when `DATAROBOT_*` is not in the environment this passes an endpoint alongside a `None` token. The SDK requires both to come from the same source and refuses before making a request:

```
ValueError: Token must be specified if endpoint is specified
```

Removing the default lets `dr.Client()` run its own resolution order. One line, 14 files.

## Rationale

**This is the state `datarobot-setup` produces.** `dr auth login` writes `~/.config/datarobot/drconfig.yaml` and sets no environment variables. So a user who follows our own setup skill, with entirely valid credentials, runs a helper script and is told their token is missing. The natural next step — reissuing the API token — cannot help, because the token was never the problem.

**The default value is also wrong on its own terms.** The API lives at `https://app.datarobot.com/api/v2`. Supplying the un-suffixed URL *with* a valid token fails differently:

```
ClientError: Server did not reply with an API version
```

So the default could not work in either direction: without a token it raises, with a token it points at the web app instead of the API.

**The SDK already does this correctly.** `dr.Client()` resolves explicit arguments, then environment, then `drconfig.yaml`, and defaults to the public cloud endpoint with the right suffix. The line duplicated a decision the SDK owns, one layer too high, and got it wrong. Passing `None` is how you tell the SDK to decide.

Verified against `datarobot` 3.18.0:

| Call | Result |
| --- | --- |
| `dr.Client(token=None, endpoint=None)` | OK — resolves to `https://app.datarobot.com/api/v2` |
| `dr.Client(token=None, endpoint="https://app.datarobot.com")` | `ValueError: Token must be specified if endpoint is specified` |
| `dr.Client(token=<valid>, endpoint="https://app.datarobot.com")` | `ClientError: Server did not reply with an API version` |

## No configuration regresses

| User's setup | Before | After |
| --- | --- | --- |
| `DATAROBOT_ENDPOINT` set | works | unchanged — `os.getenv` still returns it |
| `drconfig.yaml` only | `ValueError` | works |
| neither | confusing `ValueError` | clearer missing-credentials error |

## Scope

**This removes the first blocker; it does not make the scripts work end to end.** Several still fail afterwards on separate SDK mismatches — methods that do not exist, calls with the wrong arguments. Those are being handled separately, and are deliberately not mixed in here. This change is worth landing on its own because it is the one failure every script shares, it happens before anything else can run, and it misdirects whoever hits it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-script credential wiring only; no runtime service or auth logic changes beyond aligning with SDK defaults.
> 
> **Overview**
> **Release 1.5.2** bumps shared plugin metadata (`package.json`, Claude/Cursor/Gemini manifests) and documents the fix in `CHANGELOG.md`.
> 
> Across **data preparation, feature engineering, model training/deployment/monitoring, and predictions** skills, `dr.Client()` initialization no longer passes `endpoint=os.getenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com")`. Examples in `SKILL.md` and the same pattern in helper scripts (`upload_dataset.py`, training scripts, prediction scripts) now use **`endpoint=os.getenv("DATAROBOT_ENDPOINT")` only**.
> 
> That change fixes a common failure when users authenticate via **`dr auth login`** / `drconfig.yaml` without env vars: supplying a default endpoint with a `None` token triggers **`ValueError: Token must be specified if endpoint is specified`**, and the old default URL was not the API base path anyway. With no explicit endpoint, **`dr.Client()`** applies its normal resolution (args → env → config file → public cloud API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab0b1f5a17176f497cd4caedd97b9b5b018a99e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->