### PR TITLE
docs(predictions): install datarobot-predict — examples import it but setup omits it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.5.1"
+      "version": "1.5.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-25
+
+### Fixed
+- `datarobot-predictions`: Install `datarobot-predict` alongside `datarobot` in the skill setup. The real-time prediction and prediction-explanation examples import `datarobot_predict`, a separate PyPI package that is not a dependency of `datarobot`, so following the skill with `pip install datarobot` alone failed with `ModuleNotFoundError: No module named 'datarobot_predict'`.
+
 ## [1.5.1] - 2026-08-13
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-predictions/SKILL.md
+++ b/skills/datarobot-predictions/SKILL.md
@@ -105,7 +105,7 @@ Execute predictions using various methods:
 This skill guides you to use the DataRobot Python SDK directly. Install the SDK if needed:
 
 ```bash
-pip install datarobot
+pip install datarobot datarobot-predict
 ```
 
 ### Key SDK Operations
@@ -340,7 +340,7 @@ Common errors and solutions:
 ### Install DataRobot SDK
 
 ```bash
-pip install datarobot
+pip install datarobot datarobot-predict
 ```
 
 ### Initialize Client


### PR DESCRIPTION
## Problem

The `datarobot-predictions` skill's real-time prediction and prediction-explanation examples import `datarobot_predict`:

```python
from datarobot_predict.deployment import predict as dr_predict   # SKILL.md
```

…but the setup instructions install only `datarobot`:

```bash
pip install datarobot
```

`datarobot-predict` is a **separate PyPI package** and is **not** a dependency of `datarobot`, so following the skill exactly as written fails at import:

```
ModuleNotFoundError: No module named 'datarobot_predict'
```

This is environment-independent (pure Python import) — it happens on every platform, Cloud or self-managed.

## Reproduce (clean venv)

```bash
python -m venv env && ./env/bin/pip install datarobot        # exactly what the skill says
./env/bin/python -c "from datarobot_predict.deployment import predict"
#  -> ModuleNotFoundError: No module named 'datarobot_predict'
./env/bin/pip install datarobot-predict
./env/bin/python -c "from datarobot_predict.deployment import predict"   # OK
```

## Fix

Add `datarobot-predict` to the two `pip install` lines in the skill's setup so the documented examples run as written. Two-line docs change, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only install-line change; no runtime, auth, or data-handling code is modified.
> 
> **Overview**
> Fixes skill setup so documented prediction examples can actually import `datarobot_predict`.
> 
> Both `pip install` snippets in `SKILL.md` now include `datarobot-predict` as well as `datarobot`, matching the real-time/explanation samples that `from datarobot_predict.deployment import predict`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e67d00c89ca6f05d2389a01f28bfa0f7e24cb18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->