### PR TITLE
docs(model-training): fix sample code + helper scripts for datarobot SDK 3.x

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.5.1"
+      "version": "1.5.3"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.5.1"
+  "version": "1.5.3"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-08-25
+
+### Fixed
+- `datarobot-model-training`: Update the sample code and helper scripts for the current `datarobot` SDK (3.x). `set_target()` → `analyze_and_model()` (sets the target and starts AutoPilot), the removed `Project.start(autopilot_on=, max_wait=)` → `wait_for_autopilot()`, `project.status` → `project.stage`, `model.get_metrics()` → `model.metrics`, and select the recommended model via `ModelRecommendation.get(project.id).get_model()` instead of a broken `max(models, key=lambda m: m.metrics.get("AUC", 0))` that treats a per-partition dict as a scalar. `list_models.py` now sorts on the validation partition score (null-safe).
+
 ## [1.5.1] - 2026-08-13
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-model-training/SKILL.md
+++ b/skills/datarobot-model-training/SKILL.md
@@ -107,16 +107,17 @@ Use these DataRobot SDK methods for model training:
 - `dr.Project.create_from_dataset(dataset_id, project_name, use_case=use_case)` - Create project, linked to a Use Case
 - `dr.Project.get(project_id)` - Get project details
 - `dr.Project.list()` - List all projects
-- `project.set_target(target_column)` - Set target variable
+- `project.analyze_and_model(target, mode=dr.AUTOPILOT_MODE.QUICK)` - Set the target and start AutoPilot
 
 **Training**:
-- `project.start(autopilot_on=True)` - Start AutoML training
+- `project.wait_for_autopilot()` - Block until AutoPilot finishes
 - `project.get_status()` - Check training status
 - `dr.Model.list(project_id)` - List trained models
 - `dr.Model.get(model_id)` - Get model details
+- `dr.ModelRecommendation.get(project.id).get_model()` - Get DataRobot's recommended model
 
 **Model Analysis**:
-- `model.get_metrics()` - Get performance metrics
+- `model.metrics` - Performance metrics (dict of `{metric: {partition: score}}`)
 - `model.get_feature_impact()` - Get feature importance
 
 See the [Common Patterns](#common-patterns) section below for complete examples.
@@ -126,7 +127,7 @@ See the [Common Patterns](#common-patterns) section below for complete examples.
 This skill includes executable helper scripts that Claude can run directly:
 
 - `scripts/create_project.py` - Create a new project from a dataset, optionally linked to a Use Case
-- `scripts/start_training.py` - Start AutoML training
+- `scripts/start_training.py` - Set the target and start AutoML training
 - `scripts/list_models.py` - List trained models with metrics
 
 The `datarobot-data-preparation` skill's `scripts/upload_dataset.py` accepts the same optional `use_case_id` argument for linking an uploaded dataset to a Use Case.
@@ -139,13 +140,13 @@ python -c "import datarobot as dr; print(dr.UseCase.create(name='Sales Predictio
 # Upload dataset, linked to the Use Case
 python ../datarobot-data-preparation/scripts/upload_dataset.py sales_data.csv "Sales Data" use_case_456
 
-# Create project and set target, linked to the same Use Case
+# Create project, set target, and start training (one step), linked to the Use Case
 python scripts/create_project.py dataset_123 "Sales Prediction" revenue use_case_456
 
-# Start training
-python scripts/start_training.py project_456 Quick
+# (Alternatively, if the project was created without a target:)
+# python scripts/start_training.py project_456 revenue Quick
 
-# List models
+# List models once AutoPilot finishes
 python scripts/list_models.py project_456 AUC
 ```
 
@@ -191,23 +192,25 @@ project = dr.Project.create_from_dataset(
     dataset_id=dataset.id, project_name="Sales Prediction", use_case=use_case
 )
 
-# Set target
-project.set_target(target="revenue", mode=dr.AUTOPILOT_MODE.QUICK)
+# Set the target and start AutoPilot (Quick mode).
+# analyze_and_model() replaces the deprecated set_target() and starts AutoPilot,
+# so no separate start() call is needed.
+project.analyze_and_model(
+    target="revenue", mode=dr.AUTOPILOT_MODE.QUICK, worker_count=-1
+)
 
-# Start AutoML (Quick mode)
-project.start(autopilot_on=True, max_wait=3600)
+# Wait for AutoPilot to finish
+project.wait_for_autopilot()
 
-# Monitor training
-while project.get_status()["status"] not in ["complete", "error"]:
-    import time
+# Get DataRobot's recommended model (the one flagged "Recommended for Deployment")
+best_model = dr.ModelRecommendation.get(project.id).get_model()
 
-    time.sleep(30)
-    project.get_status()
-
-# Get trained models
-models = dr.Model.list(project.id)
-best_model = max(models, key=lambda m: m.metrics.get("AUC", 0))
-print(f"Best model: {best_model.id}, AUC: {best_model.metrics.get('AUC')}")
+# model.metrics maps each metric to per-partition scores; read the validation score.
+metric = project.metric  # the project's optimization metric, e.g. "LogLoss" or "AUC"
+print(
+    f"Recommended model: {best_model.id} ({best_model.model_type}), "
+    f"{metric} (validation): {best_model.metrics[metric]['validation']}"
+)
 ```
 
 ### Pattern 2: Time series forecasting

--- a/skills/datarobot-model-training/scripts/create_project.py
+++ b/skills/datarobot-model-training/scripts/create_project.py
@@ -53,15 +53,19 @@ def create_project(
     result = {
         "project_id": project.id,
         "project_name": project.project_name,
-        "status": project.status,
+        "stage": project.stage,
         "dataset_id": dataset_id,
         "use_case_id": use_case_id,
     }
 
-    # Set target if provided
+    # Set target and start AutoPilot if a target was provided.
+    # analyze_and_model() replaces the deprecated set_target() in SDK 3.x and both
+    # sets the target and launches AutoPilot in one call.
     if target_column:
         try:
-            project.set_target(target=target_column, mode=dr.AUTOPILOT_MODE.QUICK)
+            project.analyze_and_model(
+                target=target_column, mode=dr.AUTOPILOT_MODE.QUICK, worker_count=-1
+            )
             result["target"] = target_column
             result["target_set"] = True
         except (

--- a/skills/datarobot-model-training/scripts/create_project.py
+++ b/skills/datarobot-model-training/scripts/create_project.py
@@ -68,6 +68,8 @@ def create_project(
             )
             result["target"] = target_column
             result["target_set"] = True
+            # AutoPilot has advanced the project past "aim"; refresh the reported stage.
+            result["stage"] = project.stage
         except (
             dr.errors.AppPlatformError,
             dr.errors.AsyncTimeoutError,

--- a/skills/datarobot-model-training/scripts/list_models.py
+++ b/skills/datarobot-model-training/scripts/list_models.py
@@ -41,7 +41,7 @@ def list_models(project_id: str, sort_by: str = "validation") -> dict:
     model_list = []
     for model in models:
         try:
-            metrics = model.get_metrics()
+            metrics = model.metrics
             model_info = {
                 "model_id": model.id,
                 "model_type": model.model_type,
@@ -57,11 +57,17 @@ def list_models(project_id: str, sort_by: str = "validation") -> dict:
             }
             model_list.append(model_info)
 
-    # Sort models
+    # Sort models. model.metrics maps each metric to a dict of partition scores
+    # (e.g. {"AUC": {"validation": 0.81, "crossValidation": 0.80, ...}}), so read
+    # the validation score rather than treating the metric value as a scalar.
+    def validation_score(model_info: dict, metric: str, default: float) -> float:
+        scores = model_info.get("metrics", {}).get(metric)
+        return scores.get("validation", default) if isinstance(scores, dict) else default
+
     if sort_by == "AUC" and model_list:
-        model_list.sort(key=lambda x: x.get("metrics", {}).get("AUC", 0), reverse=True)
+        model_list.sort(key=lambda x: validation_score(x, "AUC", 0), reverse=True)
     elif sort_by == "RMSE" and model_list:
-        model_list.sort(key=lambda x: x.get("metrics", {}).get("RMSE", float("inf")))
+        model_list.sort(key=lambda x: validation_score(x, "RMSE", float("inf")))
 
     return {
         "project_id": project_id,

--- a/skills/datarobot-model-training/scripts/list_models.py
+++ b/skills/datarobot-model-training/scripts/list_models.py
@@ -61,8 +61,12 @@ def list_models(project_id: str, sort_by: str = "validation") -> dict:
     # (e.g. {"AUC": {"validation": 0.81, "crossValidation": 0.80, ...}}), so read
     # the validation score rather than treating the metric value as a scalar.
     def validation_score(model_info: dict, metric: str, default: float) -> float:
-        scores = model_info.get("metrics", {}).get(metric)
-        return scores.get("validation", default) if isinstance(scores, dict) else default
+        scores = (model_info.get("metrics") or {}).get(metric)
+        if not isinstance(scores, dict):
+            return default
+        score = scores.get("validation")
+        # A partition key can exist with a null score; keep the sort key numeric.
+        return default if score is None else score
 
     if sort_by == "AUC" and model_list:
         model_list.sort(key=lambda x: validation_score(x, "AUC", 0), reverse=True)

--- a/skills/datarobot-model-training/scripts/start_training.py
+++ b/skills/datarobot-model-training/scripts/start_training.py
@@ -6,7 +6,7 @@
 Start AutoML training for a project.
 
 Usage:
-    python start_training.py <project_id> [mode]
+    python start_training.py <project_id> <target> [mode]
 
 Modes: Quick, Comprehensive, Manual (default: Quick)
 """
@@ -18,12 +18,20 @@ import sys
 import datarobot as dr
 
 
-def start_training(project_id: str, mode: str = "Quick") -> dict:
+MODE_MAP = {
+    "Quick": dr.AUTOPILOT_MODE.QUICK,
+    "Comprehensive": dr.AUTOPILOT_MODE.COMPREHENSIVE,
+    "Manual": dr.AUTOPILOT_MODE.MANUAL,
+}
+
+
+def start_training(project_id: str, target: str, mode: str = "Quick") -> dict:
     """
-    Start AutoML training for a project.
+    Set the target and start AutoML training for a project.
 
     Args:
         project_id: The project ID
+        target: The target column to model
         mode: Training mode - "Quick", "Comprehensive", or "Manual"
 
     Returns:
@@ -37,30 +45,36 @@ def start_training(project_id: str, mode: str = "Quick") -> dict:
 
     project = dr.Project.get(project_id)
 
-    # Set training mode
-    if mode == "Quick":
-        project.start(autopilot_on=True, max_wait=3600)
-    elif mode == "Comprehensive":
-        project.start(autopilot_on=True, max_wait=7200)
-    else:  # Manual
-        project.start(autopilot_on=False)
+    # analyze_and_model() sets the target and launches AutoPilot in the given mode.
+    # (It replaces the older set_target()/start() calls; Manual mode sets the
+    # target without auto-running blueprints.)
+    project.analyze_and_model(
+        target=target,
+        mode=MODE_MAP.get(mode, dr.AUTOPILOT_MODE.QUICK),
+        worker_count=-1,
+    )
 
     return {
         "project_id": project_id,
-        "status": project.status,
+        "target": target,
+        "stage": project.stage,
         "mode": mode,
-        "message": f"Training started in {mode} mode",
+        "message": f"Training started for target '{target}' in {mode} mode",
     }
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python start_training.py <project_id> [mode]", file=sys.stderr)
+    if len(sys.argv) < 3:
+        print(
+            "Usage: python start_training.py <project_id> <target> [mode]",
+            file=sys.stderr,
+        )
         print("Modes: Quick, Comprehensive, Manual", file=sys.stderr)
         sys.exit(1)
 
     project_id = sys.argv[1]
-    mode = sys.argv[2] if len(sys.argv) > 2 else "Quick"
+    target = sys.argv[2]
+    mode = sys.argv[3] if len(sys.argv) > 3 else "Quick"
 
-    result = start_training(project_id, mode)
+    result = start_training(project_id, target, mode)
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Problem

The `datarobot-model-training` skill's sample code (Pattern 1 + the `scripts/` helpers + the SDK reference list) was written against an older SDK and does not run on the current `datarobot` SDK (**3.18**). Following it verbatim hits, in order:

- `project.set_target(...)` — **deprecated** (still warns); the current call is `analyze_and_model(...)`, which sets the target **and** launches AutoPilot.
- `project.start(autopilot_on=True, max_wait=...)` — **`TypeError`**: `Project.start()` no longer takes these kwargs. AutoPilot is started by `analyze_and_model()`; you then wait with `wait_for_autopilot()`.
- `project.status` — **`AttributeError`**: `Project` has no `.status`; the attribute is `.stage`.
- `model.get_metrics()` — **`AttributeError`**: does not exist; metrics live on the `model.metrics` attribute, a dict of `{metric: {partition: score}}`.
- `max(models, key=lambda m: m.metrics.get("AUC", 0))` — `m.metrics["AUC"]` is a **per-partition dict**, not a scalar, so this does not compare validation scores and does **not** return DataRobot's recommended model. The recommended model comes from `ModelRecommendation.get(project.id).get_model()`.

The last point is the most consequential: a user who follows the skill to "get the best model" ends up with a model chosen by broken logic rather than DataRobot's actual recommendation.

## Fix

- **SKILL.md — SDK reference list & Pattern 1**: `set_target` → `analyze_and_model`; drop the erroneous `project.start(...)` + the `get_status()["status"]` loop in favor of `wait_for_autopilot()`; select via `ModelRecommendation.get(project.id).get_model()`; read the validation score as `model.metrics[metric]["validation"]`; `get_metrics()` → `model.metrics`.
- **scripts/create_project.py**: `set_target` → `analyze_and_model`; `project.status` → `project.stage`.
- **scripts/start_training.py**: `project.start(autopilot_on=, max_wait=)` → `analyze_and_model(target, mode=...)` (adds the now-required `target` arg); `project.status` → `project.stage`.
- **scripts/list_models.py**: `model.get_metrics()` → `model.metrics`; sort by the per-partition `["<metric>"]["validation"]` score instead of treating the metric as a scalar.

## Verification (live DataRobot, SDK 3.18.0)

Ran the **patched helper scripts** end-to-end, then the fixed Pattern 1 selection, then cleaned up (zero residue):

```
create_project.py  -> project created (stage="aim")
start_training.py  -> analyze_and_model started AutoPilot (stage="modeling")
wait_for_autopilot -> done
list_models.py AUC -> 10 models, each with a populated metrics dict, sorted OK
ModelRecommendation.get(project).get_model()
                   -> Light Gradient Boosted Trees Classifier;
                      LogLoss (validation) = 0.60901
```

## Scope

Standard (non-time-series) flow only, which is what was verified live. **Pattern 2 (time series)** has the same class of issues **plus** datetime-partitioning specifics (`DatetimePartitioningSpecification`), so it needs a separate, TS-verified follow-up and is intentionally left unchanged in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local helper scripts only; no runtime services, auth, or data-path changes.
> 
> **Overview**
> Updates the **datarobot-model-training** skill and helper scripts so they match **DataRobot Python SDK 3.x** instead of deprecated or removed APIs.
> 
> **SKILL.md** now documents `project.analyze_and_model()` (target + AutoPilot in one step), `wait_for_autopilot()`, `ModelRecommendation.get(project.id).get_model()`, and `model.metrics[metric]['validation']` instead of `set_target()` / `project.start()`, polling `get_status()`, `get_metrics()`, and picking the “best” model via broken scalar `metrics.get("AUC")`. Pattern 1 and the CLI examples reflect the combined create-and-train flow; **Pattern 2 (time series) is unchanged** in this PR.
> 
> **Scripts:** `create_project.py` and `start_training.py` call `analyze_and_model()` and report `project.stage`; `start_training.py` **requires** a `target` argument. `list_models.py` reads `model.metrics` and sorts by per-partition validation scores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41dc198e399bf2194e26ec17747fbc1e95c1c595. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->