### PR TITLE
docs(model-monitoring): read ServiceStats via .metrics; fix model.get_metrics reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "datarobot-agent-skills",
       "source": "./",
       "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-      "version": "1.5.4"
+      "version": "1.5.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "datarobot-agent-skills",
   "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datarobot-agent-skills",
   "description": "A collection of DataRobot agent skills for model training, deployment, predictions, monitoring, and more.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "DataRobot",
     "email": "carson.gee@datarobot.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Each entry should be prefixed with the affected skill folder name (for example,
 
 ## [Unreleased]
 
+## [1.5.5] - 2026-08-26
+
+### Fixed
+- `datarobot-model-monitoring`: The Pattern 1 health-check example read `stats.prediction_count` and `stats.mean_response_time`, which do not exist on the SDK 3.x `ServiceStats` object (`AttributeError`). Read them from the `.metrics` dict instead (`stats.metrics["totalPredictions"]`, `stats.metrics["responseTime"]`). Also corrected the SDK reference list: `model.get_metrics()` → `model.metrics` (a dict of `{metric: {partition: score}}`); `get_metrics()` does not exist.
+
 ## [1.5.4] - 2026-08-25
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "datarobot-skills",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "DataRobot Skills for AI/ML workflows including model training, deployment, predictions, feature engineering, monitoring, data preparation, and Workload API management",
   "author": "DataRobot",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-datarobot-skills",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "OpenCode plugin providing DataRobot skills for AI/ML workflows and a DataRobot-branded theme.",
   "type": "module",
   "main": ".opencode-plugin/index.ts",

--- a/skills/datarobot-model-monitoring/SKILL.md
+++ b/skills/datarobot-model-monitoring/SKILL.md
@@ -103,7 +103,7 @@ Use these DataRobot SDK and MLOps API methods for monitoring:
 - `deployment.get_prediction_results(...)` - Retrieve recorded prediction results (if enabled)
 
 **Model Performance**:
-- `model.get_metrics()` - Get model performance metrics
+- `model.metrics` - Model performance metrics (dict of `{metric: {partition: score}}`)
 - `model.get_roc_curve()` - Get ROC curve for comparison
 
 **Note**: Some monitoring features may require DataRobot MLOps API. See the [Common Patterns](#common-patterns) section below for examples.
@@ -130,9 +130,10 @@ dr.Client()
 deployment = dr.Deployment.get("abc123")
 
 # Get service stats (requires MLOps monitoring to be enabled)
+# ServiceStats exposes values via the .metrics dict, not as attributes.
 stats = deployment.get_service_stats()
-print(f"Prediction count: {stats.prediction_count}")
-print(f"Mean response time (ms): {stats.mean_response_time}")
+print(f"Prediction count: {stats.metrics['totalPredictions']}")
+print(f"Mean response time (ms): {stats.metrics['responseTime']}")
 
 # Get recorded prediction results (if available / enabled)
 try:


### PR DESCRIPTION
## Problem

The Pattern 1 health-check example reads `stats.prediction_count` / `stats.mean_response_time`, which don't exist on the SDK 3.x `ServiceStats` object — copying it raises `AttributeError`. The SDK reference list also lists `model.get_metrics()`, which doesn't exist either.

## Fix

Read service stats from the `.metrics` dict (`stats.metrics["totalPredictions"]`, `stats.metrics["responseTime"]`), and correct the reference to `model.metrics` (a dict of `{metric: {partition: score}}`).

## Verification (live DataRobot, SDK 3.18.0)

```
stats = deployment.get_service_stats()
stats.metrics["totalPredictions"] -> 0      # was: stats.prediction_count  (AttributeError)
stats.metrics["responseTime"]     -> None   # was: stats.mean_response_time (AttributeError)
type(model.metrics)               -> dict (keys: AUC, ...)   # was: model.get_metrics() (AttributeError)
```

`hasattr(stats,'prediction_count')` and `hasattr(model,'get_metrics')` are both `False` on SDK 3.18.

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1787721822.920479 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes in a skill file; no production code or auth/data paths affected.
> 
> **Overview**
> **Release 1.5.5** bumps the shared plugin version everywhere manifests are kept in sync, and documents the fix in `CHANGELOG.md`.
> 
> The **`datarobot-model-monitoring`** skill is updated for **DataRobot Python SDK 3.x**: Pattern 1’s health-check sample no longer reads `stats.prediction_count` / `stats.mean_response_time` (they raise `AttributeError` on `ServiceStats`) and instead uses `stats.metrics['totalPredictions']` and `stats.metrics['responseTime']`, with a short note that values live on `.metrics`. The SDK reference list replaces the nonexistent `model.get_metrics()` with **`model.metrics`** (`{metric: {partition: score}}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ce5c5dd024695a34bd5dd8165ced007900bfd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->