### PR TITLE
Added autoreleaser

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,10 +28,8 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
-      # npm stage publish requires npm >= 11.15.0, newer than the npm bundled with Node 24.
-      # Remove this step once setup-node's default Node ships npm >= 11.15.0.
-      - name: Pin npm with staged-publishing support
-        run: npm install -g npm@11.15.0
+      - name: Pin npm with trusted-publishing support
+        run: npm install -g npm@12.0.2
 
       - name: Publish
-        run: npm stage publish --access public
+        run: npm publish --access public

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -81,15 +81,13 @@ jobs:
         id: bump
         run: task version:bump
 
-      - name: Push release commit
-        if: steps.check.outputs.should_release == 'true'
-        run: git push origin main
-
       - name: Tag the release
         if: steps.check.outputs.should_release == 'true'
-        run: |
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin "v${{ steps.bump.outputs.version }}"
+        run: git tag "v${{ steps.bump.outputs.version }}"
+
+      - name: Push release commit and tag
+        if: steps.check.outputs.should_release == 'true'
+        run: git push --atomic origin main "v${{ steps.bump.outputs.version }}"
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,105 @@
+---
+name: Version Bump
+
+# Bumps the shared plugin version, tags, and cuts a GitHub Release whenever a
+# merge to main changes anything under skills/. See scripts/version_bump.py
+# and CONTRIBUTING.md for the full flow.
+#
+# Pushing directly to main (a protected, review-required branch) requires a
+# GitHub App installed on this repo and added to main's ruleset bypass list.
+# The app's ID and private key must exist as the RELEASE_APP_ID and
+# RELEASE_APP_PRIVATE_KEY repository secrets before this workflow can push.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Bump version and release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate a token for the release app
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check for skills/ changes since the last release
+        id: check
+        run: |
+          LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$LAST_TAG" ]; then
+            RANGE=$(git rev-list --max-parents=0 HEAD)
+          else
+            RANGE="$LAST_TAG"
+          fi
+          if git diff --quiet "${RANGE}..HEAD" -- skills/; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: astral-sh/setup-uv@v4
+        if: steps.check.outputs.should_release == 'true'
+
+      - uses: arduino/setup-task@v2
+        if: steps.check.outputs.should_release == 'true'
+
+      - name: Configure release bot identity
+        if: steps.check.outputs.should_release == 'true'
+        id: bot-identity
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: git config
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.bot-identity.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+      - name: Bump version, rename CHANGELOG.md, and commit
+        if: steps.check.outputs.should_release == 'true'
+        id: bump
+        run: task version:bump
+
+      - name: Push release commit
+        if: steps.check.outputs.should_release == 'true'
+        run: git push origin main
+
+      - name: Tag the release
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin "v${{ steps.bump.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          awk -v ver="## [$VERSION]" '
+            index($0, ver) == 1 { found=1; print; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          gh release create "v${VERSION}" --title "v${VERSION}" --notes-file /tmp/release-notes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,74 +1,76 @@
 # DataRobot Agent Skills Library
 
-This file provides instructions for an agent to use DataRobot skills. An agent will automatically load these instructions when working with DataRobot-related tasks.
+This file provides instructions for an agent to use DataRobot skills. An agent automatically loads these instructions when working with DataRobot-related tasks.
 
-## DataRobot Authentication
+## DataRobot authentication
 
-If any DataRobot skill fails due to missing or invalid credentials, invoke `datarobot-setup` before retrying the original task. Do not print manual instructions — run the skill.
+If any DataRobot skill fails due to missing or invalid credentials, invoke `datarobot-setup` before retrying the original task. Do not print manual instructions—run the skill.
 
-## Should I Add a Skill Here?
+## Should I add a skill here?
 
-There are many places you can add skills for use. This repository is for customer facing skills that help other build more effectively in DataRobot. Here is the goal, intended use, and criteria for determining if your skill is correct for this library.
+There are many places to add skills for use. This repository is for customer-facing skills that help others build more effectively in DataRobot. This section covers the goal, intended use, and criteria for determining if a skill belongs in this library.
 
 ### Goal
-As always, our goal is to ensure that enterprises can get agents into production. Skills offer powerful functionality that tell agents how to THINK while protecting their context window. This allows agent to one/few shot tasks that before needed complex logic built into the agent + would always run into context issues. Skills DR offers should open up enterprise use cases, making them more viable in production.
+The goal is to ensure that enterprises can get agents into production. Skills offer powerful functionality that tells agents how to *think* while protecting their context window. This allows agents to one-shot or few-shot tasks that previously required complex logic built into the agent and often ran into context window issues. Skills DataRobot offers open up enterprise use cases, making them more viable in production.
 
-### Intended Use of This Skill Library
+### Intended use of this skill library
 
-Generally, we expect these skills to be used by code assistants. We will make the skills in the DR Skills repo in code assist marketplaces like Cursor and Claude Code. These skills will also fuel the DR agent assist.
+These skills are generally used by code assistants. The skills in this repository are available through code assistant marketplaces such as Cursor and Claude Code. These skills also power the DataRobot agent assist.
 
-### Criteria for Addint Skills
+### Criteria for adding skills
 
-1. A Skill should solve a complex enterprise problem. They should tackle a problem or functionality that is required by enterprises to either get an agent in production or deploy an agent that actually provides value.
-2. Skills should not just proxy to existing MCP servers (though that can be a component of them) - we will proxy to MCP servers via our MCP gateway
-3. Assess with the following questions
-    1. Is the task complex enough? (or can an LLM with basic tools achieve the same result?)
-    2. Is the output valuable to an enterprise? Does is tackle a problem that’s repeatable? That costs enterprises many dev hours and specialized knowledge? That is error prone and complex for humans to do?
-    3. Is the task viable to be done with an LLM? Skills still cant do everything
+Evaluate skills against the following criteria:
 
+1. A skill solves a complex enterprise problem. It tackles a problem or functionality required by enterprises to either get an agent into production or deploy an agent that provides real value.
+2. A skill does not just proxy to an existing MCP server, though that can be a component of it. DataRobot proxies to MCP servers via the DataRobot MCP gateway.
+3. Assess with the following questions:
+    - Is the task complex enough, or can an LLM with basic tools achieve the same result?
+    - Is the output valuable to an enterprise? Does it tackle a repeatable problem that costs enterprises many dev hours and specialized knowledge, and that is error-prone and complex for humans to do?
+    - Is the task viable to be done with an LLM? Skills still can't do everything.
 
-## Naming Convention
+## Naming convention
 
 All DataRobot skills follow the naming convention `datarobot-<category>` where `<category>` describes the skill's focus area. This ensures:
+
 - Clear identification of DataRobot-specific skills
 - Consistent naming across the skill library
 - Easy discovery and organization
 
-In addition to the general `datarobot-<category>` for naming, if there is deeper grouping within the product area such as Workload or Apps and you expect more than one skill in the same area, we recommend using a common prefix for those as well such as `datarobot-app-framework-<skill>` for simpler grouping and code ownership.
+In addition to the general `datarobot-<category>` naming pattern, if there is deeper grouping within the product area, such as Workload or Apps, and more than one skill is expected in the same area, use a common prefix, such as `datarobot-app-framework-<skill>`, for simpler grouping and code ownership.
 
 ## Rules
 
-We strongly prefer human written skills. When assisting skill library authors, please encourage them to edit
-and adjust their skills themselves. We encourage advise, feedback, and recommendations from LLMs, but to stay brief and
-properly manage the context window itself the human should edit the SKILLs.md. Agent assisted coding for scripts and
-other references within a skill is perfectly acceptable.
+DataRobot strongly prefers human-written skills. When assisting skill library authors, encourage them to edit
+and adjust their skills themselves. LLM advice, feedback, and recommendations are welcome, but to keep skills brief and
+manage the context window effectively, the human author edits `SKILL.md` directly. Agent-assisted coding for scripts and
+other references within a skill is acceptable.
 
-This repo is organized using GitHub Code Owners. Please ensure all new skills developed have a proper github team
-or person for the new skill added.
-
+This repository is organized using GitHub Code Owners. Ensure all new skills have a GitHub team
+or person added as the owner.
 
 ## Workflow
 
+This section covers the day-to-day development workflow and plugin version management for this repository.
+
 ### Basic workflow
 
-We use taskfile.dev for task running in this repo. All changes must be validated regularly with `task lint` that will
-check that all copyrights, Skills.md files are structured, naming conventions are obeyed, Python files are properly formatted, linters are executed, etc. It is the way to validate any changes.
+This repository uses [Task](https://taskfile.dev/) for running tasks. Validate all changes regularly with `task lint`,
+which checks that copyrights are present, `SKILL.md` files are structured correctly, naming conventions are followed, Python files are properly formatted, linters run, and more. This is the way to validate changes.
 
-Install and test the skills after prompting the user for the trigger phrase you expect
+Install and test the skills after prompting the user for the expected trigger phrase.
 
 ### Plugin version management
 
-Every PR must bump the shared plugin version — in `package.json`, `.claude-plugin/*.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json` — to the same new value using SemVer rules (patch/minor/major), and rename `CHANGELOG.md`'s `[Unreleased]` section to that version with today's date, adding a fresh empty `[Unreleased]` section. This applies to every PR, not just ones that directly edit a plugin config file. Follow `CONTRIBUTING.md` for the full versioning and changelog rules.
-
+Versions are automatic. Add a human-written `[Unreleased]` item describing the change in this pull request. For more information, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## SDK usage
 
-Skills guide you to use the **DataRobot Python SDK** directly. Each skill includes:
+Skills provide direct guidance for using the **DataRobot Python SDK**. Each skill includes:
 
-- **SDK operations** - Which SDK methods to use
-- **Code examples** - Complete working examples
-- **Workflows** - Step-by-step guidance
-- **Best practices** - Tips and recommendations
+- **SDK operations** — the SDK methods to use.
+- **Code examples** — complete, working examples.
+- **Workflows** — step-by-step guidance.
+- **Best practices** — tips and recommendations.
 
 Install the SDK: `pip install datarobot`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 All notable changes to DataRobot agent skills are tracked here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
-version numbers track the shared plugin version maintained across
+version numbers track the shared plugin version maintained across `package.json`,
 `.claude-plugin/`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`.
 
 Each entry should be prefixed with the affected skill folder name (for example,
 `` `datarobot-predictions`: ... ``) so it's easy to scan what changed per skill.
+
+Version bumps, `[Unreleased]` renames, and releases are automated&mdash;see
+[`CONTRIBUTING.md`](CONTRIBUTING.md#plugin-version-management).
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,27 @@ Guidelines for developing and contributing to this project.
 
 ## List of project maintainers
 
+This project is maintained by the following people:
+
 - [Your Name](Your GitHub User URL)
 
-## Opening new issues
+## Open a new issue
 
-- Before opening a new issue, check if there are any existing FAQ entries (if one exists), issues, or pull requests that match your case.
-- Open an issue and label it accordingly — bug, improvement, feature request, etc.
+Follow these steps before opening a new issue:
+
+- Before opening a new issue, check if there are any existing FAQ entries (if one exists), issues, or pull requests that match the issue.
+- Open an issue and label it accordingly—bug, improvement, feature request, etc.
 - Be as specific and detailed as possible.
 
 ## Did you find a bug?
 
+Follow these steps when reporting a bug:
+
 - Do not open a GitHub issue if the bug is a security vulnerability. Instead, email the maintainers directly or email oss-community-management@datarobot.com if they do not respond within seven days.
 - Ensure the bug was not already reported in the project's Issues section.
-- Open an issue as described above.
+- Open an issue as described in [Open a new issue](#open-a-new-issue).
 
-## Running e2e skill tests
+## Run e2e skill tests
 
 Skill quality is evaluated end-to-end by an LLM judge. To keep CI cheap, unchanged skills are skipped via an MD5 cache at `tests/e2e/skill_hashes.json`.
 
@@ -26,35 +32,37 @@ Skill quality is evaluated end-to-end by an LLM judge. To keep CI cheap, unchang
 
 Run once after cloning:
 
-```
+```bash
 cp .env.example .env  # fill in DATAROBOT_ENDPOINT + DATAROBOT_API_TOKEN
 task setup            # installs .githooks/ as the project hooks path
 ```
 
-After that, any commit touching `skills/**` or `tests/e2e/**` will run the LLM judge on the affected skills, and — if they pass — stage the refreshed `skill_hashes.json` into the same commit. By the time the PR hits CI, the hashes already match and the e2e job is a no-op for those skills.
+After that, any commit touching `skills/**` or `tests/e2e/**` runs the LLM judge on the affected skills and—if they pass—stages the refreshed `skill_hashes.json` into the same commit. By the time the PR hits CI, the hashes already match and the e2e job is a no-op for those skills.
 
-If `DATAROBOT_ENDPOINT` / `DATAROBOT_API_TOKEN` aren't set, the hook prints a notice and skips; CI will run the judge as a safety net. To bypass the hook for a single commit: `git commit --no-verify`.
+If `DATAROBOT_ENDPOINT` / `DATAROBOT_API_TOKEN` aren't set, the hook prints a notice and skips; CI runs the judge as a safety net. To bypass the hook for a single commit: `git commit --no-verify`.
 
-### Running the suite manually
+### Run the suite manually
 
-```
+```bash
 task test:e2e         # or: uv run --group e2e pytest tests/e2e/ -v
 task test:e2e:force   # re-evaluate every skill, ignore the cache
 ```
 
 CI does not write back to `main`; if the committed cache drifts the workflow logs a warning, and the fix is to run the command above locally and commit the refreshed file.
 
-## Responding to issues and pull requests
+## Respond to issues and pull requests
 
-This project's maintainers will make every effort to respond to any open issues as soon as possible.
+The project maintainers make every effort to respond to open issues as soon as possible.
 
-If you don't get a response within seven days of creating your issue or pull request, send us an email at oss-community-management@datarobot.com.
+If a response doesn't arrive within seven days of creating an issue or pull request, send an email to oss-community-management@datarobot.com.
 
 ## Should I add a skill here?
 
+Evaluate a new skill against the following goal, intended use, and criteria before adding it to this library.
+
 ### Goal
 
-The goal of this library is to ensure that enterprises can get agents into production. Skills offer powerful functionality that tells agents how to think while protecting their context window. This allows agents to one- or few-shot tasks that previously needed complex logic built into the agent, avoiding context window issues. Skills DataRobot offers should open up enterprise use cases, making them more viable in production.
+The goal of this library is to ensure that enterprises can get agents into production. Skills offer powerful functionality that tells agents how to think while protecting their context window. This allows agents to one- or few-shot tasks that previously needed complex logic built into the agent, avoiding context window issues. Skills DataRobot offers open up enterprise use cases, making them more viable in production.
 
 ### Intended use
 
@@ -75,13 +83,13 @@ Before adding a skill, evaluate it against these criteria:
 
 All DataRobot skills follow the naming convention `datarobot-<category>`, where `<category>` describes the skill's focus area. This ensures clear identification of DataRobot-specific skills, consistent naming across the skill library, and easy discovery and organization.
 
-If there is deeper grouping within a product area and you expect more than one skill in the same area, use a common prefix. For example, use `datarobot-app-framework-<skill>` for simpler grouping and code ownership.
+If there is deeper grouping within a product area and more than one skill is expected in the same area, use a common prefix. For example, use `datarobot-app-framework-<skill>` for simpler grouping and code ownership.
 
 Both the **folder name** and the `name` field in `SKILL.md` frontmatter must match exactly.
 
-## Creating a skill
+## Create a skill
 
-The easiest way to create a new skill is to start from an existing one close to your use case.
+The easiest way to create a new skill is to start from an existing one close to the intended use case.
 
 1. Copy one of the existing skill folders, such as `skills/datarobot-model-training/`, and rename it following the naming convention above.
 2. Update the new folder's `SKILL.md` frontmatter and instructions:
@@ -99,25 +107,25 @@ The easiest way to create a new skill is to start from an existing one close to 
 
 3. The `description` field must begin with "Use when" so the agent knows when to load the skill.
 4. Add or update any supporting scripts, templates, or documents referenced by the skill.
-5. Add an entry for the new skill in `.well-known/ai-catalog.json`. Copy an existing entry and update the `identifier`, `displayName`, `url`, `description`, and `representativeQueries` fields. Write `representativeQueries` as natural-language phrases a user would type to discover the skill — these drive semantic search quality in ARD discovery services.
-6. Reinstall or reload the skill bundle in your coding agent so the updated skill is available.
-7. Test the skill with a prompt that exercises the workflow you expect users to follow.
+5. Add an entry for the new skill in `.well-known/ai-catalog.json`. Copy an existing entry and update the `identifier`, `displayName`, `url`, `description`, and `representativeQueries` fields. Write `representativeQueries` as natural-language phrases a user would type to discover the skill—these drive semantic search quality in ARD discovery services.
+6. Reinstall or reload the skill bundle in the coding agent so the updated skill is available.
+7. Test the skill with a prompt that exercises the expected user workflow.
 
 ## Workflow rules
 
-We strongly prefer human-written skills. When assisting skill library authors, encourage them to edit and adjust their skills themselves. Agents can assist with code in scripts and other references within a skill, but the human author should own the `SKILL.md` content itself.
+DataRobot strongly prefers human-written skills. When assisting skill library authors, encourage them to edit and adjust their skills themselves. Agents can assist with code in scripts and other references within a skill, but the human author owns the `SKILL.md` content itself.
 
-**Every PR must bump the shared plugin version**&mdash;not just PRs that directly edit a plugin config file. The version is shared across `package.json`, `.claude-plugin/*.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`, and it must always move in lockstep with `CHANGELOG.md`. If your PR changes anything under `skills/` (or otherwise warrants a changelog entry), bump the version string in all of those files to the same new value using SemVer rules:
+**PRs never bump the shared plugin version themselves.** The version is shared across `package.json`, `.claude-plugin/*.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`. When a PR that changes anything under `skills/` merges to `main`, [`version-bump.yml`](.github/workflows/version-bump.yml) automatically bumps all of those files to the same new value, renames `CHANGELOG.md`'s `[Unreleased]` section, commits, tags, and cuts a GitHub Release&mdash;see [`scripts/version_bump.py`](scripts/version_bump.py).
 
-- **Patch** (`x.x.N`)&mdash;bug fixes, typos, clarifications.
-- **Minor** (`x.N.0`)&mdash;new skills added, existing skills expanded.
-- **Major** (`N.0.0`)&mdash;breaking changes to skill structure or interface.
+Every merge bumps **minor** (`x.N.0`) by default&mdash;this is a skills/marketplace repo where any merge under `skills/` is effectively new content. **Major** (`N.0.0`, breaking changes to skill structure or interface) is never inferred automatically; if a change is genuinely breaking, bump and tag it by hand instead of relying on the automated flow. **Patch** (`x.x.N`) is also manual&mdash;used to hot-fix a version that's already sealed into a product build, without moving the marketplace's current minor line forward:
 
-A PR that only bumps the version in some of these files (or bumps the version but forgets the changelog rename below) is incomplete.
+```bash
+task version:bump -- --bump patch
+```
 
 ## Changelog
 
-Every PR that touches anything under `skills/` adds a one-line entry to [`CHANGELOG.md`](CHANGELOG.md) under the `[Unreleased]` section, prefixed with the affected skill folder name. For example:
+Every PR that touches anything under `skills/` adds a one-line entry to [`CHANGELOG.md`](CHANGELOG.md) under the `[Unreleased]` section, prefixed with the affected skill folder name, under one of `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security` (see [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)). The category header is required, not optional&mdash;always nest the bullet under one. For example:
 
 ```markdown
 ## [Unreleased]
@@ -125,11 +133,11 @@ Every PR that touches anything under `skills/` adds a one-line entry to [`CHANGE
 - `datarobot-predictions`: added JSON output mode to `validate_prediction_data.py`.
 ```
 
-Use `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security` groupings as appropriate (see [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)).
-
-Since every PR bumps the plugin version (per the SemVer rules above), every PR also renames `[Unreleased]` to the new version with today's date and adds a fresh empty `[Unreleased]` section at the top.
+Don't rename `[Unreleased]` manually&mdash;`version-bump.yml` does that automatically once the PR merges (see "Plugin version management" above). A PR that changes `skills/` but leaves `[Unreleased]` empty merges fine, but the automated release fails loudly instead of shipping a version bump with no changelog entry; fix it by adding the missing entry.
 
 ## Validation and linting
+
+This section covers the prerequisites, common tasks, and rules enforced by this repository's validation and linting tooling.
 
 ### Prerequisites
 
@@ -137,7 +145,8 @@ Install these tools before running validation tasks:
 
 - [Task](https://taskfile.dev/)&mdash;task runner (`brew install go-task`).
 - [uv](https://docs.astral.sh/uv/)&mdash;Python package and environment manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
-- [license-eye](https://github.com/apache/skywalking-eyes)&mdash;license header checker (`go install github.com/apache/skywalking-eyes/cmd/license-eye@latest`, then ensure `~/go/bin` is on your PATH).
+- [license-eye](https://github.com/apache/skywalking-eyes)&mdash;license header checker (`go install github.com/apache/skywalking-eyes/cmd/license-eye@latest`, then ensure `~/go/bin` is on the PATH).
+- [jq](https://jqlang.org/)&mdash;JSON processor used by `scripts/version_bump.py` (`brew install jq`).
 
 ### Common tasks
 
@@ -180,7 +189,7 @@ datarobot-my-skill/
       ---
 ```
 
-## Testing the OpenCode plugin locally
+## Test the OpenCode plugin locally
 
 The `opencode-datarobot-skills` npm package is defined by `package.json` at the repo root. To test it locally before publishing, point OpenCode at the local clone using a `file:` reference in `~/.config/opencode/opencode.json`:
 
@@ -196,10 +205,14 @@ OpenCode (via Bun) resolves `file:` paths and loads the plugin directly from dis
 
 This repository uses GitHub Actions for automated checks:
 
-- **Validate skills**&mdash;validates skill naming and structure on every push and pull request.
+- **Lint**&mdash;runs `task lint` (skill validation, ruff, mypy, shellcheck, yamlfmt, license headers) on every push and pull request.
+- **Test Skills E2E**&mdash;runs the LLM-judge skill quality suite on pushes/PRs that touch `skills/**` or `tests/e2e/**`.
 - **Trivy security scan**&mdash;scans for secrets and security issues daily and on every push and pull request.
+- **Version Bump**&mdash;on every push to `main`, bumps the plugin version, tags, and cuts a GitHub Release if `skills/` changed (see "Plugin version management" above).
+- **Publish to npm**&mdash;publishes to npm whenever a GitHub Release is published.
+- **Publish AI Catalog**&mdash;deploys `docs/` to GitHub Pages when it changes on `main`.
 
-All checks must pass before merging a pull request.
+All required checks must pass before merging a pull request.
 
 ## Code ownership
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -47,7 +47,7 @@ tasks:
   mypy:
     desc: Run mypy type checker on Python scripts (override dir with DIR=<path>)
     vars:
-      DIR: '{{.DIR | default "skills/"}}'
+      DIR: '{{.DIR | default "skills/ scripts/"}}'
     cmds:
       - uv run --group dev mypy {{.DIR}}
 
@@ -60,6 +60,11 @@ tasks:
     desc: Add missing copyright headers to code files
     cmds:
       - license-eye header fix
+
+  version:bump:
+    desc: Bump the shared plugin version, rename CHANGELOG.md's Unreleased section, and commit
+    cmds:
+      - uv run scripts/version_bump.py {{.CLI_ARGS}}
 
   lint:
     desc: Run all linting checks (validate skills + ruff + mypy + shellcheck + yamlfmt + license)

--- a/scripts/version_bump.py
+++ b/scripts/version_bump.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bump the shared plugin version across all tracked files and rename
+CHANGELOG.md's ``[Unreleased]`` section, committing the result.
+
+The version is shared across ``package.json``, ``.claude-plugin/plugin.json``,
+``.claude-plugin/marketplace.json``, ``.cursor-plugin/plugin.json``, and
+``gemini-extension.json``. This script bumps all five to the same new value,
+renames CHANGELOG.md's ``[Unreleased]`` heading to that version with today's
+date, adds a fresh empty ``[Unreleased]`` section, and commits the change.
+
+It never pushes, tags, or creates a GitHub Release — a caller (normally a
+GitHub Actions workflow) decides whether to run this at all and is
+responsible for everything past the local commit.
+
+Usage:
+    uv run scripts/version_bump.py                    # minor bump (default)
+    uv run scripts/version_bump.py --bump patch
+    uv run scripts/version_bump.py --repo-root /path/to/checkout
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+CHANGELOG_HEADING = "## [Unreleased]"
+
+VERSION_FILES = (
+    ("package.json", ".version"),
+    (".claude-plugin/plugin.json", ".version"),
+    (".claude-plugin/marketplace.json", ".plugins[0].version"),
+    (".cursor-plugin/plugin.json", ".version"),
+    ("gemini-extension.json", ".version"),
+)
+
+
+def bump_version(current_version: str, bump: str) -> str:
+    major, minor, patch = (int(part) for part in current_version.split("."))
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def read_version(package_json: Path) -> str:
+    result = subprocess.run(
+        ["jq", "-r", ".version", str(package_json)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def bump_json_version(
+    repo_root: Path, relative_path: str, jq_path: str, new_version: str
+) -> None:
+    file_path = repo_root / relative_path
+    result = subprocess.run(
+        ["jq", "--arg", "v", new_version, f"{jq_path} = $v", str(file_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    file_path.write_text(result.stdout)
+
+
+def extract_unreleased_body(changelog_text: str) -> str:
+    start = changelog_text.index(CHANGELOG_HEADING) + len(CHANGELOG_HEADING)
+    rest = changelog_text[start:]
+    next_heading = rest.find("\n## [")
+    body = rest if next_heading == -1 else rest[:next_heading]
+    return body.strip()
+
+
+def rename_unreleased_section(
+    changelog_text: str, new_version: str, today: date
+) -> str:
+    replacement = f"{CHANGELOG_HEADING}\n\n## [{new_version}] - {today.isoformat()}"
+    return changelog_text.replace(CHANGELOG_HEADING, replacement, 1)
+
+
+def commit_release(repo_root: Path, new_version: str) -> None:
+    changed_files = [relative_path for relative_path, _ in VERSION_FILES] + [
+        "CHANGELOG.md"
+    ]
+    subprocess.run(["git", "add", *changed_files], cwd=repo_root, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"chore: release v{new_version}"],
+        cwd=repo_root,
+        check=True,
+    )
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bump", choices=("patch", "minor", "major"), default="minor")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root to operate on (defaults to the current directory).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path.cwd()
+
+    changelog_path = repo_root / "CHANGELOG.md"
+    changelog_text = changelog_path.read_text()
+    unreleased_body = extract_unreleased_body(changelog_text)
+
+    if not unreleased_body:
+        print(
+            "Nothing under [Unreleased] in CHANGELOG.md — add an entry before releasing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    current_version = read_version(repo_root / "package.json")
+    new_version = bump_version(current_version, args.bump)
+
+    for relative_path, jq_path in VERSION_FILES:
+        bump_json_version(repo_root, relative_path, jq_path, new_version)
+
+    changelog_path.write_text(
+        rename_unreleased_section(changelog_text, new_version, date.today())
+    )
+
+    commit_release(repo_root, new_version)
+
+    print(new_version)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write(f"version={new_version}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_version_bump.py
+++ b/tests/integration/test_version_bump.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise scripts/version_bump.py end to end against a scratch fixture repo,
+so the real bump/rename/commit logic is tested, not a reimplementation of it."""
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+version_bump = importlib.import_module("version_bump")
+
+VERSION_FILE_FIXTURES = {
+    "package.json": {"name": "example-plugin", "version": "1.0.0"},
+    ".claude-plugin/plugin.json": {"name": "example-plugin", "version": "1.0.0"},
+    ".claude-plugin/marketplace.json": {
+        "plugins": [{"name": "example-plugin", "version": "1.0.0"}]
+    },
+    ".cursor-plugin/plugin.json": {"name": "example-plugin", "version": "1.0.0"},
+    "gemini-extension.json": {"name": "example-plugin", "version": "1.0.0"},
+}
+
+CHANGELOG_WITH_ENTRY = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+- `datarobot-example`: fixed a thing.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- Initial release.
+"""
+
+CHANGELOG_EMPTY_UNRELEASED = """# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- Initial release.
+"""
+
+
+def _write_fixture_repo(tmp_path: Path, changelog_text: str) -> Path:
+    for relative_path, content in VERSION_FILE_FIXTURES.items():
+        file_path = tmp_path / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(json.dumps(content, indent=2) + "\n")
+    (tmp_path / "CHANGELOG.md").write_text(changelog_text)
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial fixture"], cwd=tmp_path, check=True
+    )
+    return tmp_path
+
+
+def _read_version(tmp_path: Path, relative_path: str, jq_path: str) -> str:
+    result = subprocess.run(
+        ["jq", "-r", jq_path, str(tmp_path / relative_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_bump_updates_all_five_files_to_the_same_version(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, CHANGELOG_WITH_ENTRY)
+
+    exit_code = version_bump.main(["--repo-root", str(repo), "--bump", "minor"])
+
+    assert exit_code == 0
+    for relative_path, jq_path in version_bump.VERSION_FILES:
+        assert _read_version(repo, relative_path, jq_path) == "1.1.0"
+
+
+def test_bump_renames_unreleased_section_with_fresh_empty_one(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, CHANGELOG_WITH_ENTRY)
+
+    version_bump.main(["--repo-root", str(repo), "--bump", "minor"])
+
+    changelog_text = (repo / "CHANGELOG.md").read_text()
+    assert changelog_text.startswith("# Changelog\n\n## [Unreleased]\n\n## [1.1.0] -")
+    assert "`datarobot-example`: fixed a thing." in changelog_text
+    assert version_bump.extract_unreleased_body(changelog_text) == ""
+
+
+def test_bump_commits_the_change(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, CHANGELOG_WITH_ENTRY)
+
+    version_bump.main(["--repo-root", str(repo), "--bump", "minor"])
+
+    log = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert log.stdout.strip() == "chore: release v1.1.0"
+
+
+def test_patch_and_major_bumps(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, CHANGELOG_WITH_ENTRY)
+    version_bump.main(["--repo-root", str(repo), "--bump", "patch"])
+    assert _read_version(repo, "package.json", ".version") == "1.0.1"
+
+    repo2 = _write_fixture_repo(tmp_path / "major", CHANGELOG_WITH_ENTRY)
+    version_bump.main(["--repo-root", str(repo2), "--bump", "major"])
+    assert _read_version(repo2, "package.json", ".version") == "2.0.0"
+
+
+def test_empty_unreleased_section_fails_without_changing_anything(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path, CHANGELOG_EMPTY_UNRELEASED)
+    original_changelog = (repo / "CHANGELOG.md").read_text()
+
+    exit_code = version_bump.main(["--repo-root", str(repo), "--bump", "minor"])
+
+    assert exit_code == 1
+    assert (repo / "CHANGELOG.md").read_text() == original_changelog
+    assert _read_version(repo, "package.json", ".version") == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    ("current", "bump", "expected"),
+    [
+        ("1.5.1", "patch", "1.5.2"),
+        ("1.5.1", "minor", "1.6.0"),
+        ("1.5.1", "major", "2.0.0"),
+        ("1.9.9", "minor", "1.10.0"),
+    ],
+)
+def test_bump_version_arithmetic(current: str, bump: str, expected: str) -> None:
+    assert version_bump.bump_version(current, bump) == expected


### PR DESCRIPTION
## Summary

Add automatic releasing and version bumping

## Rationale

Merge conflicts on every merge due to constant version updates are quite frustrating. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The workflow pushes directly to protected `main` and cuts releases automatically, so misconfiguration (App bypass, empty changelog, or tag collisions) could block or duplicate releases; npm publish behavior also changes from staged to standard trusted publishing.
> 
> **Overview**
> **Replaces per-PR manual version bumps** with an automated release path so contributors only add `[Unreleased]` changelog bullets under `skills/` changes—no more editing `package.json`, plugin manifests, or renaming changelog sections in every PR.
> 
> On push to `main`, the new **Version Bump** workflow checks whether `skills/` changed since the last `v*` tag. When it did, it authenticates via a GitHub App (`RELEASE_APP_*` secrets), runs `task version:bump` (`scripts/version_bump.py`) to minor-bump the shared version in five JSON files, promote `[Unreleased]` in `CHANGELOG.md` (fails if that section is empty), commit, push `main`, tag `v*`, and create a GitHub Release from the new changelog section.
> 
> **npm publishing** moves from staged publish (`npm stage publish` + npm 11.15) to **`npm publish`** with npm 12 for trusted publishing. Docs (`CONTRIBUTING.md`, `AGENTS.md`, `CHANGELOG.md`) and CI descriptions are updated accordingly; `Taskfile` adds `version:bump` and extends mypy to `scripts/`. Integration tests cover the bump script end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86513dc5c8494c73a9e18b80dee5060fa2b45c1b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->