### PR TITLE
Verify lint yaml dependency version conflicts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Install gemini CLI
         run: npm install -g @google/gemini-cli
       - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.3"
       - name: Install go tools
         run: |
           go install github.com/google/yamlfmt/cmd/yamlfmt@latest

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/rehearsal.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/rehearsal.py
@@ -622,7 +622,7 @@ def llm_call(
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=240) as resp:
             return cast(dict[str, Any], json.loads(resp.read())), resolved
     except urllib.error.HTTPError as e:
         body = e.read().decode()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
https://datarobot.atlassian.net/browse/CFX-7939
dr agent skills dependency mismatch of lint.yml
## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:C03AUH9KWG4:1788172286.618349 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout constant change in a rehearsal script with no auth, data, or API contract changes.
> 
> **Overview**
> **Rehearsal build script:** the `llm_call` helper now waits up to **240 seconds** (was 120) before timing out on chat-completions HTTP requests to the configured endpoint.
> 
> This only affects how long `urllib.request.urlopen` blocks during rehearsal runs when model responses are slow; retry and error handling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 932b9bf798f545eff649ca84cf6c3a2a9f8b4838. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->