### PR TITLE
Basic implementation of openai completions compatible external model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Version bumps, `[Unreleased]` renames, and releases are automated&mdash;see
 
 ## [Unreleased]
 
+### Added
+
+- `datarobot-agent-assist`: Support an OpenAI-completions-compatible external LLM (`AGENT_ASSIST_LLM_MODEL_NAME`, `AGENT_ASSIST_LLM_API_KEY`, `AGENT_ASSIST_LLM_BASE_URL`) as a model source alongside the LLM Gateway and deployed models, so `list_llm_models.py` and `setup_template.py --llm-base-url` can wire up a template without a DataRobot endpoint or token. Also lets `clone_template.py` override the template repo via `AGENT_ASSIST_TEMPLATE_REPO_URL`/`_BRANCH`/`_TAG`, with branch now taking priority over tag when both are set.
+
 ## [1.6.0] - 2026-08-26
 
 ### Added

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/clone_template.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/clone_template.py
@@ -12,12 +12,14 @@ add, fetch, and checkout to clone the template into the target directory.
 Usage:
     python clone_template.py [--target-dir <directory>]
 
-The repository URL and branch/tag are hardcoded in the script constants REPO_URL,
-BRANCH, and TAG at the top of this file. TAG takes priority over BRANCH if both
-are set.
+The repository URL and branch/tag default to the script constants REPO_URL,
+BRANCH, and TAG. AGENT_ASSIST_TEMPLATE_REPO_URL,
+AGENT_ASSIST_TEMPLATE_REPO_BRANCH, and AGENT_ASSIST_TEMPLATE_REPO_TAG override
+their respective defaults. A branch takes priority over a tag when both are set.
 """
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -25,6 +27,24 @@ from pathlib import Path
 REPO_URL = "https://github.com/datarobot-community/datarobot-agent-application.git"
 BRANCH: str | None = None
 TAG: str | None = "11.10.7"
+TEMPLATE_REPO_URL_ENV = "AGENT_ASSIST_TEMPLATE_REPO_URL"
+TEMPLATE_REPO_BRANCH_ENV = "AGENT_ASSIST_TEMPLATE_REPO_BRANCH"
+TEMPLATE_REPO_TAG_ENV = "AGENT_ASSIST_TEMPLATE_REPO_TAG"
+
+
+def _environment_override(name: str, default: str | None) -> str | None:
+    """Return a non-empty environment override, or the configured default."""
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else default
+
+
+def template_repository_config() -> tuple[str, str | None, str | None]:
+    """Return the effective repository URL, branch, and tag configuration."""
+    return (
+        _environment_override(TEMPLATE_REPO_URL_ENV, REPO_URL) or REPO_URL,
+        _environment_override(TEMPLATE_REPO_BRANCH_ENV, BRANCH),
+        _environment_override(TEMPLATE_REPO_TAG_ENV, TAG),
+    )
 
 
 def cleanup_git_dir(target_dir: Path) -> None:
@@ -198,24 +218,26 @@ def clone_repository(repo_url: str, ref: str, ref_type: str, target_dir: Path) -
 
 def main() -> int:
     """Main entry point."""
-    # Determine which ref to use (TAG takes priority over BRANCH)
-    if TAG:
-        ref_type = "tag"
-        ref = TAG
-    elif BRANCH:
+    repo_url, branch, tag = template_repository_config()
+
+    # Determine which ref to use (branch takes priority over tag).
+    if branch:
         ref_type = "branch"
-        ref = BRANCH
+        ref = branch
+    elif tag:
+        ref_type = "tag"
+        ref = tag
     else:
         print("Error: Either TAG or BRANCH must be set in the script configuration")
         return 1
 
     parser = argparse.ArgumentParser(
-        description=f"Clone the DataRobot agent application template from {REPO_URL}",
+        description=f"Clone the DataRobot agent application template from {repo_url}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
-Repository: {REPO_URL}
-Tag: {TAG if TAG else "Not set"}
-Branch: {BRANCH if BRANCH else "Not set"}
+Repository: {repo_url}
+Tag: {tag if tag else "Not set"}
+Branch: {branch if branch else "Not set"}
 
 Example:
   %(prog)s
@@ -233,7 +255,7 @@ Example:
 
     target_dir = Path(args.target_dir).resolve()
 
-    return clone_repository(REPO_URL, ref, ref_type, target_dir)
+    return clone_repository(repo_url, ref, ref_type, target_dir)
 
 
 if __name__ == "__main__":

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/list_llm_models.py
@@ -32,8 +32,12 @@ from env_utils import get_datarobot_credentials
 
 SOURCE_GATEWAY = "gateway"
 SOURCE_DEPLOYED = "deployed"
+SOURCE_EXTERNAL = "external"
 DEPLOYED_LLM_MODEL = "datarobot-deployed-llm"
 TARGET_TYPE_TEXT_GENERATION = "TextGeneration"
+EXTERNAL_MODEL_NAME_ENV = "AGENT_ASSIST_LLM_MODEL_NAME"
+EXTERNAL_API_KEY_ENV = "AGENT_ASSIST_LLM_API_KEY"
+EXTERNAL_BASE_URL_ENV = "AGENT_ASSIST_LLM_BASE_URL"
 
 
 class LLMModel(TypedDict):
@@ -44,6 +48,7 @@ class LLMModel(TypedDict):
     api_model: str
     llm_default_model: str
     deployment_id: str
+    base_url: str
     description: str
     context_size: int
 
@@ -132,6 +137,7 @@ def _map_gateway_catalog_entry(entry: dict[str, object]) -> LLMModel | None:
         "api_model": api_model,
         "llm_default_model": ensure_datarobot_prefix(api_model),
         "deployment_id": "",
+        "base_url": "",
         "description": str(entry.get("description") or ""),
         "context_size": _as_int(entry.get("contextSize")),
     }
@@ -158,10 +164,45 @@ def _map_deployed_entry(entry: dict[str, object]) -> LLMModel | None:
         "api_model": DEPLOYED_LLM_MODEL,
         "llm_default_model": ensure_datarobot_prefix(DEPLOYED_LLM_MODEL),
         "deployment_id": deployment_id,
+        "base_url": "",
         "description": str(entry.get("description") or ""),
         "context_size": 0,
     }
     return mapped
+
+
+def _external_model_from_environment() -> LLMModel | None:
+    """Return the configured external model when its complete configuration exists."""
+    model_name = os.environ.get(EXTERNAL_MODEL_NAME_ENV, "").strip()
+    api_key = os.environ.get(EXTERNAL_API_KEY_ENV, "").strip()
+    base_url = os.environ.get(EXTERNAL_BASE_URL_ENV, "").strip()
+    if not (model_name and api_key and base_url):
+        return None
+
+    return {
+        "id": model_name,
+        "name": model_name,
+        "source": SOURCE_EXTERNAL,
+        "provider": "External",
+        "api_model": model_name,
+        "llm_default_model": model_name,
+        "deployment_id": "",
+        "base_url": base_url,
+        "description": "Configured external LLM",
+        "context_size": 0,
+    }
+
+
+def get_external_model_api_key(model_name: str, base_url: str) -> str | None:
+    """Return the external API key when the requested model and URL match config."""
+    external_model = _external_model_from_environment()
+    if (
+        external_model is None
+        or model_name.strip() != external_model["api_model"]
+        or base_url.strip() != external_model["base_url"]
+    ):
+        return None
+    return os.environ[EXTERNAL_API_KEY_ENV].strip()
 
 
 def _map_cli_entry(entry: dict[str, object]) -> LLMModel | None:
@@ -194,6 +235,7 @@ def _map_cli_entry(entry: dict[str, object]) -> LLMModel | None:
         "api_model": api_model,
         "llm_default_model": ensure_datarobot_prefix(api_model),
         "deployment_id": deployment_id,
+        "base_url": "",
         "description": str(entry.get("description") or ""),
         "context_size": _as_int(entry.get("context_size")),
     }
@@ -330,6 +372,12 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
     Uses ``dr llm-gateway list`` when available; falls back to direct REST calls.
     Each source is best-effort: warnings are logged to stderr when one source fails.
     """
+    external_model = _external_model_from_environment()
+    if not endpoint or not api_token:
+        if external_model:
+            return [external_model]
+        raise RuntimeError("DataRobot endpoint and API token are required")
+
     warnings: list[str] = []
 
     try:
@@ -348,7 +396,7 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
                     warnings.append(f"could not list deployed LLMs: {e}")
             for warning in warnings:
                 print(f"Warning: {warning}", file=sys.stderr)
-            return models
+            return models + ([external_model] if external_model else [])
         warnings.append("dr llm-gateway list returned no models")
     except RuntimeError as e:
         warnings.append(str(e))
@@ -367,6 +415,8 @@ def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
         warnings.append(str(e))
 
     models = gateway_models + deployed_models
+    if external_model:
+        models.append(external_model)
     if not models:
         joined = "; ".join(warnings) if warnings else "no models available"
         raise RuntimeError(f"Failed to list LLM models: {joined}")
@@ -462,18 +512,20 @@ def main() -> int:
         return 1
     endpoint, api_token = get_datarobot_credentials(target_dir)
 
-    if not endpoint and not api_token:
+    external_model = _external_model_from_environment()
+
+    if not endpoint and not api_token and not external_model:
         print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
         print(
             "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
         )
         return 1
 
-    if not endpoint:
+    if not endpoint and not external_model:
         print("Error: DATAROBOT_ENDPOINT environment variable not set", file=sys.stderr)
         return 1
 
-    if not api_token:
+    if not api_token and not external_model:
         print(
             "Error: DATAROBOT_API_TOKEN environment variable not set", file=sys.stderr
         )

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/list_llm_models.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/list_llm_models.py
@@ -366,7 +366,7 @@ def _fetch_llm_models_via_cli(
     return models, warnings
 
 
-def fetch_llm_models(endpoint: str, api_token: str) -> list[LLMModel]:
+def fetch_llm_models(endpoint: str | None, api_token: str | None) -> list[LLMModel]:
     """Fetch active LLMs from gateway catalog and deployed TextGeneration models.
 
     Uses ``dr llm-gateway list`` when available; falls back to direct REST calls.

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/setup_template.py
@@ -12,6 +12,7 @@ This script performs initial setup for a DataRobot agent application template by
 
 Usage:
     python setup_template.py --llm-model <model-name> [--llm-deployment-id <id>]
+                             [--llm-base-url <url>]
                              [--target-dir <directory>]
 
 The script generates cryptographically secure random secrets for session
@@ -34,6 +35,7 @@ from list_llm_models import (
     LLMModel,
     _fetch_gateway_models_rest,
     ensure_datarobot_prefix,
+    get_external_model_api_key,
     is_deployed_llm_model,
     is_deployment_id,
     normalize_gateway_model,
@@ -184,7 +186,11 @@ def canonical_gateway_model(value: str, target_dir: Path) -> str | None:
 
 
 def create_env_file(
-    target_dir: Path, llm_default_model: str, llm_deployment_id: str = ""
+    target_dir: Path,
+    llm_default_model: str,
+    llm_deployment_id: str = "",
+    external_api_key: str = "",
+    external_base_url: str = "",
 ) -> tuple[bool, str]:
     """
     Create .env file with the LLM configuration.
@@ -197,6 +203,8 @@ def create_env_file(
         target_dir: Directory where .env file should be created
         llm_default_model: Value for LLM_DEFAULT_MODEL
         llm_deployment_id: Deployment id of a DataRobot-deployed LLM, if selected
+        external_api_key: API key for an external LLM, if selected
+        external_base_url: Base URL for an external LLM, if selected
 
     Returns:
         Tuple of (success, message)
@@ -232,6 +240,15 @@ def create_env_file(
             ]
         )
 
+    if external_api_key:
+        lines.extend(
+            [
+                f'EXTERNAL_LLM_MODEL="{llm_default_model}"\n',
+                f'EXTERNAL_LLM_API_KEY="{external_api_key}"\n',
+                f'EXTERNAL_LLM_BASE_URL="{external_base_url}"\n',
+            ]
+        )
+
     try:
         print(f"Creating .env file in {target_dir}")
 
@@ -245,6 +262,8 @@ def create_env_file(
                 f"{llm_deployment_id} (INFRA_ENABLE_LLM={DEPLOYED_LLM_CONFIGURATION}, "
                 "USE_DATAROBOT_LLM_GATEWAY=0)"
             )
+        elif external_api_key:
+            print(f'✓ Created .env file for external LLM "{llm_default_model}"')
         else:
             print(f'✓ Created .env file with LLM_DEFAULT_MODEL="{llm_default_model}"')
 
@@ -402,7 +421,10 @@ def run_command(command: str, target_dir: Path, timeout: int = 300) -> tuple[boo
 
 
 def setup_and_run(
-    llm_default_model: str, target_dir: Path, llm_deployment_id: str = ""
+    llm_default_model: str,
+    target_dir: Path,
+    llm_deployment_id: str = "",
+    llm_base_url: str = "",
 ) -> int:
     """
     Create .env file and run required setup commands.
@@ -411,6 +433,7 @@ def setup_and_run(
         llm_default_model: Value for LLM_DEFAULT_MODEL in .env file
         target_dir: Target directory for operations
         llm_deployment_id: Deployment id of a DataRobot-deployed LLM, if selected
+        llm_base_url: Base URL for an external LLM, if selected
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -421,7 +444,23 @@ def setup_and_run(
     print(f"Target directory: {target_dir}")
     print(f"LLM model: {llm_default_model}")
 
+    external_api_key = get_external_model_api_key(llm_default_model, llm_base_url)
+    is_external_model = external_api_key is not None
+
+    if llm_base_url and not is_external_model:
+        print(
+            "Error: --llm-base-url does not match the configured external LLM.",
+            file=sys.stderr,
+        )
+        return 1
+
     if llm_deployment_id:
+        if is_external_model:
+            print(
+                "Error: an external LLM cannot be combined with --llm-deployment-id.",
+                file=sys.stderr,
+            )
+            return 1
         print(f"LLM deployment: {llm_deployment_id}")
 
         # The id is written verbatim into a double-quoted .env line that the template's
@@ -485,14 +524,20 @@ def setup_and_run(
     # Canonicalize before anything writes .env: create_env_file truncates the file,
     # taking with it the credentials the catalog check reads. The deployed path is
     # exempt, since there the model is only a label and 'dr dotenv setup' drops it.
-    if not llm_deployment_id:
+    if not llm_deployment_id and not is_external_model:
         canonical = canonical_gateway_model(llm_default_model, target_dir)
         if canonical is None:
             return 1
         llm_default_model = canonical
 
     # Step 1: Create .env file
-    success, _ = create_env_file(target_dir, llm_default_model, llm_deployment_id)
+    success, _ = create_env_file(
+        target_dir,
+        llm_default_model,
+        llm_deployment_id,
+        external_api_key or "",
+        llm_base_url if is_external_model else "",
+    )
     if not success:
         return 1
 
@@ -543,6 +588,12 @@ def main() -> int:
     )
 
     parser.add_argument(
+        "--llm-base-url",
+        default="",
+        help="Base URL of the configured external LLM (omit for DataRobot models)",
+    )
+
+    parser.add_argument(
         "--target-dir",
         required=True,
         help="Target directory for operations (required — use the session <target_dir>)",
@@ -555,7 +606,12 @@ def main() -> int:
         print(f"Error: target directory does not exist: {target_dir}", file=sys.stderr)
         return 1
 
-    return setup_and_run(args.llm_model, target_dir, args.llm_deployment_id.strip())
+    return setup_and_run(
+        args.llm_model,
+        target_dir,
+        args.llm_deployment_id.strip(),
+        args.llm_base_url.strip(),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

Basic implementation of openai completions compatible external model

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build scripts now read API keys from the environment and write them into `.env`; mistakes in validation or credential handling could leak or misconfigure LLM routing, though scope is limited to local agent-assist tooling.
> 
> **Overview**
> Adds **external LLM** support to the agent-assist build scripts so a third-party, OpenAI-completions-compatible endpoint can be listed and wired into template setup without relying on DataRobot gateway or deployed models.
> 
> **`list_llm_models.py`** introduces a `external` model source driven by `AGENT_ASSIST_LLM_MODEL_NAME`, `AGENT_ASSIST_LLM_API_KEY`, and `AGENT_ASSIST_LLM_BASE_URL`. When that trio is set, the model appears in listings (with `base_url` on all mapped models), listing can succeed with **no** DataRobot endpoint/token, and `get_external_model_api_key` validates model/URL before setup uses the key.
> 
> **`setup_template.py`** adds `--llm-base-url`, writes `EXTERNAL_LLM_*` into `.env` for external selections, skips gateway catalog canonicalization for externals, and rejects mixing external config with `--llm-deployment-id` or a mismatched base URL.
> 
> **`clone_template.py`** allows overriding the template repo via `AGENT_ASSIST_TEMPLATE_REPO_URL` / `_BRANCH` / `_TAG` (defaults unchanged) and **inverts ref priority** so branch wins over tag when both are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1552dcb7fdc173dd2062d6b0951d97dd89ba035. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->