### PR TITLE
[CFX-7986] agent-assist: write the external LLM env the template reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Version bumps, `[Unreleased]` renames, and releases are automated&mdash;see
 
 ## [Unreleased]
 
+### Fixed
+
+- `datarobot-agent-assist`: External LLM setup writes the OpenAI-compatible env the agent template actually reads (`USE_DATAROBOT_LLM_GATEWAY=0`, `OPENAI_API_BASE`, `OPENAI_API_KEY`, and an `openai/`-prefixed `LLM_DEFAULT_MODEL`) instead of the unread `EXTERNAL_LLM_*` keys. The external path now stops after writing `.env` for local `task dev`, skipping the DataRobot-only `dr dotenv setup` and Pulumi deploy.
+
 ## [1.8.0] - 2026-09-02
 
 ### Added

--- a/skills/datarobot-agent-assist/agent-assist-build/SKILL.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/SKILL.md
@@ -56,7 +56,7 @@ Run in order before proceeding:
 3. **DataRobot CLI** — run `dr --version` and `dr auth check`. If either fails, invoke the `datarobot-setup` skill before continuing. Do not print manual install instructions.
 4. **Codespace** — run `python <skill_scripts_dir>/check_codespace.py` (no-op outside a Codespace). On non-zero exit, relay its message and stop; otherwise relay any exposed-ports warning it prints.
 
-If any helper script exits with a 401 / UNAUTHORIZED error: run `dr auth login` immediately and retry the script — do not present options to the user. The scripts create `.env` automatically via `dr dotenv setup`; the only prerequisite is an authenticated CLI session.
+If any helper script exits with a 401 / UNAUTHORIZED error: run `dr auth login` immediately and retry the script — do not present options to the user. The scripts create `.env` automatically (via `dr dotenv setup` for DataRobot models); for a DataRobot model the only prerequisite is an authenticated CLI session.
 
 ---
 
@@ -238,6 +238,14 @@ If `agent_spec.md` does not exist, inform the user and offer to run the Design p
      --target-dir .
    ```
 
+   If the spec has `llm_base_url` instead, the choice is an external OpenAI-compatible LLM — pass it, or the `OPENAI_*` keys are not written and setup fails. This path writes `.env` and stops for local `task dev` rather than deploying:
+   ```
+   python <skill_scripts_dir>/setup_template.py \
+     --llm-model <model-name> \
+     --llm-base-url <base-url> \
+     --target-dir .
+   ```
+
    **CRITICAL**: In case any of the above scripts fail due to any reason, do **not** proceed with coding. Instead, return the error message to the user and ask how they want to proceed.
 
    g. **Re-read `AGENTS.md`** now that the template is ready.
@@ -317,6 +325,8 @@ python <skill_scripts_dir>/setup_template.py \
 ```
 
 Add `--llm-deployment-id <deployment-id>` for a DataRobot-deployed LLM, so the template routes to the deployment instead of the gateway.
+
+Add `--llm-base-url <base-url>` for an external OpenAI-compatible LLM (the `external` source), so the template writes `USE_DATAROBOT_LLM_GATEWAY=0` / `OPENAI_API_BASE` / `OPENAI_API_KEY`, reads the key from `AGENT_ASSIST_LLM_API_KEY`, and stops after `.env` for local `task dev`.
 
 ### select_framework.py
 

--- a/skills/datarobot-agent-assist/agent-assist-build/references/agent-spec-schema.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/references/agent-spec-schema.md
@@ -5,6 +5,7 @@ Write specs in YAML to `<target_dir>/agent_spec.md`. Fields are optional when th
 ```yaml
 model: "datarobot/azure/gpt-5-2025-08-07"   # the listing's llm_default_model, verbatim
 llm_deployment_id: ""                       # required only for a DataRobot-deployed LLM
+llm_base_url: ""                            # required only for an external LLM
 system_prompt: "Your agent's instructions..."
 tools:
   - function_name: tool_name
@@ -29,6 +30,8 @@ frontend:
 ```
 
 `llm_deployment_id` selects an existing DataRobot text-generation deployment instead of an LLM Gateway model. Set it only when `model` is the `datarobot-deployed-llm` placeholder, which every deployment shares — the id is what identifies which one. Both fields are needed: pre-coding passes them to `setup_template.py` together, and the dress rehearsal resolves the deployment from the id.
+
+`llm_base_url` selects an external OpenAI-compatible LLM (the `external` source in the model listing), for an instance with no LLM Gateway. Set it only when `model` is that entry's model name; pre-coding passes both to `setup_template.py`, which reads the API key from `AGENT_ASSIST_LLM_API_KEY` and writes `USE_DATAROBOT_LLM_GATEWAY=0` with `OPENAI_API_BASE` / `OPENAI_API_KEY` (and prefixes the model `openai/`). Mutually exclusive with `llm_deployment_id`.
 
 When tools require external service auth, note that credentials must be configured as **runtime parameters** in the infrastructure code (see `AGENTS.md` for the pattern).
 

--- a/skills/datarobot-agent-assist/agent-assist-build/references/helper-scripts.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/references/helper-scripts.md
@@ -27,7 +27,7 @@ python <skill_scripts_dir>/clone_template.py \
 
 ### list_llm_models.py
 
-Lists the LLMs available on the instance the project's `.env` points at, from two sources: the LLM Gateway catalog (`source: gateway`) and existing DataRobot text-generation deployments (`source: deployed`). Sourced from `dr llm-gateway list`, with a direct REST call as fallback.
+Lists the LLMs available to the project, from three sources: the LLM Gateway catalog (`source: gateway`), existing DataRobot text-generation deployments (`source: deployed`), and an external OpenAI-compatible model configured through the `AGENT_ASSIST_LLM_*` environment (`source: external`). Gateway and deployed come from `dr llm-gateway list`, with a direct REST call as fallback; the external entry is added from the environment.
 
 ```bash
 python <skill_scripts_dir>/list_llm_models.py \
@@ -63,6 +63,17 @@ python <skill_scripts_dir>/setup_template.py \
 That writes `LLM_DEPLOYMENT_ID`, `INFRA_ENABLE_LLM=deployed_llm.py`, and `USE_DATAROBOT_LLM_GATEWAY=0` into `.env`, which is what makes the template route to the deployment. Passing the `datarobot-deployed-llm` placeholder as `--llm-model` **without** an id is refused: the template would stay on its gateway configuration and fail much later at `pulumi up` with `Model 'datarobot-deployed-llm' not found in catalog`.
 
 On the deployed path the deployment id is the only thing that selects the model. `dr dotenv setup` rebuilds `.env` from the template's `.datarobot/cli/llm.yml`, whose deployed-LLM group does not include `LLM_DEFAULT_MODEL`, so that key is dropped and the template falls back to its own `datarobot/datarobot-deployed-llm` placeholder. Routing is unaffected; a real model name passed as `--llm-model` alongside an id does not survive.
+
+For an external OpenAI-compatible LLM (the `external` source), pass the spec's `llm_base_url`:
+
+```bash
+python <skill_scripts_dir>/setup_template.py \
+  --llm-model <model-name> \
+  --llm-base-url <base-url> \
+  --target-dir <target_dir>
+```
+
+The model name and base URL must match `AGENT_ASSIST_LLM_MODEL_NAME` and `AGENT_ASSIST_LLM_BASE_URL` exactly; the script reads the key from `AGENT_ASSIST_LLM_API_KEY` and writes `USE_DATAROBOT_LLM_GATEWAY=0`, `OPENAI_API_BASE`, and `OPENAI_API_KEY` into `.env`, with `LLM_DEFAULT_MODEL` prefixed `openai/` so litellm routes to the base URL. If `--llm-base-url` is omitted or does not match, the value is treated as a gateway model and setup fails. Cannot be combined with `--llm-deployment-id`. The external path stops after writing `.env` (it skips `dr dotenv setup` and the Pulumi deploy, which assume a DataRobot backend); run it locally with `task dev`.
 
 ### select_framework.py
 

--- a/skills/datarobot-agent-assist/agent-assist-build/references/llm-selection.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/references/llm-selection.md
@@ -1,9 +1,10 @@
 ## LLM Selection
 
-`list_llm_models.py` returns two kinds of entry, told apart by `source`:
+`list_llm_models.py` returns three kinds of entry, told apart by `source`:
 
 - `gateway` — a model in the DataRobot LLM Gateway catalog. Selected by its `llm_default_model`.
 - `deployed` — an existing DataRobot text-generation deployment. Selected by its `deployment_id`.
+- `external` — an OpenAI-compatible model configured through the `AGENT_ASSIST_LLM_*` environment, for an instance with no LLM Gateway. Selected by its `llm_default_model` (the raw model name) together with its `base_url`.
 
 **Copy `llm_default_model` verbatim.** It is the only field that goes into `agent_spec.md` and `.env`. A `gateway` entry also carries an `id` (the catalog's `llmId`, e.g. `azure-openai-gpt-5`) and an `api_model` (e.g. `azure/gpt-5-2025-08-07`); neither works as a model name. The gateway rejects the `id` outright, and `api_model` is missing the `datarobot/` prefix that routes the request to DataRobot rather than straight to the provider. `setup_template.py` refuses an `id` rather than letting it reach `.env`. On a `deployed` entry, `id` is the deployment id instead, and it is what you want: see below.
 
@@ -11,7 +12,7 @@
 
 - Prefer a `gpt-5`, `claude-4-5`, or `gemini-2.5` gateway model unless the user gives cost or other constraints.
 - If none of those families appear, take the highest-capability gateway model by name: prefer `large`, `pro`, `opus`, `sonnet` over `mini`, `haiku`, `flash`.
-- **If there is no `gateway` entry at all**, the LLM Gateway is disabled or empty on this instance. That is the normal shape of an on-prem install, not an error. Recommend a `deployed` entry instead, name it by its `name` (the deployment label), and tell the user that is what you are doing and why.
+- **If there is no `gateway` entry at all**, the LLM Gateway is disabled or empty on this instance. That is the normal shape of an on-prem install, not an error. Recommend a `deployed` entry, or the `external` entry when one is configured, name it by its `name` (the deployment label), and tell the user that is what you are doing and why.
 - Only show the full catalog when the user explicitly asks to browse.
 
 ### Recording a deployed LLM in `agent_spec.md`
@@ -27,13 +28,25 @@ Take `llm_deployment_id` from the entry's `deployment_id`. Without it nothing do
 
 A gateway choice sets `model` only and leaves `llm_deployment_id` out.
 
+### Recording an external LLM in `agent_spec.md`
+
+An `external` entry appears only when `AGENT_ASSIST_LLM_MODEL_NAME`, `AGENT_ASSIST_LLM_BASE_URL`, and `AGENT_ASSIST_LLM_API_KEY` are all set. It is a pair too: `model` is the entry's `llm_default_model` (the raw model name, no `datarobot/` prefix) and `llm_base_url` is its `base_url`.
+
+```yaml
+model: "local-ollama"
+llm_base_url: "http://localhost:4000/v1"
+```
+
+Both are required at setup: `setup_template.py` recognizes the choice as external only when the model name **and** base URL match the environment exactly, otherwise it treats the value as a gateway model and fails. The API key is never written to the spec; it stays in the environment and the script reads it there. An external LLM cannot be combined with `llm_deployment_id`, and it is not wired into the dress rehearsal.
+
 ### What the choice changes downstream
 
-| Step | Gateway model | Deployed LLM |
-|---|---|---|
-| [Template setup](helper-scripts.md#setup_templatepy) | `--llm-model` | `--llm-model` **and** `--llm-deployment-id` |
-| `.env` written | `LLM_DEFAULT_MODEL` | plus `LLM_DEPLOYMENT_ID`, `INFRA_ENABLE_LLM=deployed_llm.py`, `USE_DATAROBOT_LLM_GATEWAY=0` |
-| [Dress rehearsal](dress-rehearsal.md) | LLM Gateway chat endpoint | the deployment's own chat endpoint |
+| Step | Gateway model | Deployed LLM | External LLM |
+|---|---|---|---|
+| [Template setup](helper-scripts.md#setup_templatepy) | `--llm-model` | `--llm-model` **and** `--llm-deployment-id` | `--llm-model` **and** `--llm-base-url` |
+| `.env` written | `LLM_DEFAULT_MODEL` | plus `LLM_DEPLOYMENT_ID`, `INFRA_ENABLE_LLM=deployed_llm.py`, `USE_DATAROBOT_LLM_GATEWAY=0` | `LLM_DEFAULT_MODEL` gets an `openai/` prefix, plus `USE_DATAROBOT_LLM_GATEWAY=0`, `OPENAI_API_BASE`, `OPENAI_API_KEY` |
+| Deploy | template Pulumi deploy | template Pulumi deploy | skipped, runs locally with `task dev`; deploy handled separately |
+| [Dress rehearsal](dress-rehearsal.md) | LLM Gateway chat endpoint | the deployment's own chat endpoint | not supported yet |
 
 On the deployed path the deployment id is the only thing that selects the model. `dr dotenv setup` rebuilds `.env` from the template's own prompt schema, which does not carry `LLM_DEFAULT_MODEL` for that path, so a real model name passed alongside an id is not persisted. Routing is unaffected.
 

--- a/skills/datarobot-agent-assist/agent-assist-build/references/pre-coding-checklist.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/references/pre-coding-checklist.md
@@ -170,7 +170,7 @@ When step 2 finds a problem in `agent_spec.md`:
 
    Invalidate `<dependency_check_passed>` after this step.
 
-9. **Setup** (skip if step 5b applied) — run [setup_template.py](helper-scripts.md#setup_templatepy). Use the `model` field from `agent_spec.md` as `--llm-model` (must be present — validated in Bootstrap step 2 for cold Code and deploy handoff, or produced by same-session design). If the spec also carries `llm_deployment_id`, pass it as `--llm-deployment-id`; it selects a DataRobot-deployed LLM, and the script refuses the deployed-LLM placeholder model without it.
+9. **Setup** (skip if step 5b applied) — run [setup_template.py](helper-scripts.md#setup_templatepy). Use the `model` field from `agent_spec.md` as `--llm-model` (must be present — validated in Bootstrap step 2 for cold Code and deploy handoff, or produced by same-session design). If the spec also carries `llm_deployment_id`, pass it as `--llm-deployment-id`; it selects a DataRobot-deployed LLM, and the script refuses the deployed-LLM placeholder model without it. If the spec carries `llm_base_url` instead, pass it as `--llm-base-url`; it selects an external OpenAI-compatible LLM (writing `OPENAI_API_BASE` / `OPENAI_API_KEY`), and that setup stops after `.env` for local `task dev` rather than deploying.
 
    Invalidate `<dependency_check_passed>` after this step.
 

--- a/skills/datarobot-agent-assist/agent-assist-build/scripts/setup_template.py
+++ b/skills/datarobot-agent-assist/agent-assist-build/scripts/setup_template.py
@@ -10,6 +10,9 @@ This script performs initial setup for a DataRobot agent application template by
 2. Initializing a Pulumi stack with the generated passphrase
 3. Running the template's start-non-interactive task
 
+For an external OpenAI-compatible LLM (--llm-base-url), it writes .env only and
+skips steps 1-3, which assume a DataRobot backend a raw base URL does not have.
+
 Usage:
     python setup_template.py --llm-model <model-name> [--llm-deployment-id <id>]
                              [--llm-base-url <url>]
@@ -46,6 +49,14 @@ from list_llm_models import (
 # directly. See the template's infra/configurations/llm/deployed_llm.py and
 # docs/llm.md ("DataRobot Deployed LLM").
 DEPLOYED_LLM_CONFIGURATION = "deployed_llm.py"
+
+
+# litellm routes to OPENAI_API_BASE only for the "openai" provider, so an external
+# base-URL model must carry that prefix; litellm strips it back off on the wire.
+def as_openai_compatible_model(model: str) -> str:
+    """Return an ``openai/``-prefixed model for external OpenAI-compatible routing."""
+    model = model.removeprefix("datarobot/")
+    return model if model.startswith("openai/") else f"openai/{model}"
 
 
 def generate_random_secret(length: int = 32) -> str:
@@ -222,6 +233,18 @@ def create_env_file(
         print(f"Error: {error_msg}", file=sys.stderr)
         return False, error_msg
 
+    # Same interpolation risk for the external creds: a quote, backslash, '$' or
+    # backtick would end the double-quoted .env line early and spill into new keys.
+    if external_api_key and any(
+        c in external_base_url + external_api_key for c in '"\\$`\n\r'
+    ):
+        error_msg = (
+            "the external base URL or API key contains a character that cannot go in "
+            'a .env value (one of " \\ $ ` or a newline).'
+        )
+        print(f"Error: {error_msg}", file=sys.stderr)
+        return False, error_msg
+
     lines = [
         "DATAROBOT_ENDPOINT=\n",
         "DATAROBOT_API_TOKEN=\n",
@@ -241,11 +264,16 @@ def create_env_file(
         )
 
     if external_api_key:
+        # USE_DATAROBOT_LLM_GATEWAY=0 selects datarobot-genai's EXTERNAL path; litellm
+        # then resolves the endpoint and key from OPENAI_API_BASE / OPENAI_API_KEY.
         lines.extend(
             [
-                f'EXTERNAL_LLM_MODEL="{llm_default_model}"\n',
-                f'EXTERNAL_LLM_API_KEY="{external_api_key}"\n',
-                f'EXTERNAL_LLM_BASE_URL="{external_base_url}"\n',
+                'USE_DATAROBOT_LLM_GATEWAY="0"\n',
+                f'OPENAI_API_BASE="{external_base_url}"\n',
+                f'OPENAI_API_KEY="{external_api_key}"\n',
+                # The external path skips 'dr dotenv setup', which normally generates this;
+                # fastapi_server has it as a required field and won't boot without it.
+                f'SESSION_SECRET_KEY="{generate_random_secret(64)}"\n',
             ]
         )
 
@@ -263,7 +291,10 @@ def create_env_file(
                 "USE_DATAROBOT_LLM_GATEWAY=0)"
             )
         elif external_api_key:
-            print(f'✓ Created .env file for external LLM "{llm_default_model}"')
+            print(
+                f"✓ Created .env file for external OpenAI-compatible LLM "
+                f'"{llm_default_model}" at {external_base_url}'
+            )
         else:
             print(f'✓ Created .env file with LLM_DEFAULT_MODEL="{llm_default_model}"')
 
@@ -529,6 +560,10 @@ def setup_and_run(
         if canonical is None:
             return 1
         llm_default_model = canonical
+    elif is_external_model:
+        # Route through litellm's OpenAI-compatible provider so it calls OPENAI_API_BASE
+        # (the LiteLLM proxy / custom endpoint), not api.openai.com.
+        llm_default_model = as_openai_compatible_model(llm_default_model)
 
     # Step 1: Create .env file
     success, _ = create_env_file(
@@ -540,6 +575,23 @@ def setup_and_run(
     )
     if not success:
         return 1
+
+    if is_external_model:
+        # 'dr dotenv setup' rewrites .env to the gateway path (dropping the OPENAI_* keys)
+        # and the Pulumi deploy wants a governed DataRobot deployment; a base URL fits neither.
+        print("\n" + "=" * 80)
+        print(
+            "✓ External OpenAI-compatible LLM written to .env. This path prepares .env "
+            "only: it skips 'dr dotenv setup' and the Pulumi deploy, which assume a "
+            "DataRobot backend a raw base URL does not have.\n"
+            "Run locally with `task install` then `task dev`. DATAROBOT_ENDPOINT and "
+            "DATAROBOT_API_TOKEN are left empty, so the LLM works but DataRobot-backed "
+            "app features (auth, chat history) need them set. A non-default agentic "
+            "framework must be materialized via the normal template setup first; deploy "
+            "separately once a deploy path is wired."
+        )
+        print("=" * 80)
+        return 0
 
     # Step 2: Run dr dotenv setup
     success, _ = run_command("dr dotenv setup --yes --output .", target_dir)


### PR DESCRIPTION
## What

The agent-assist skill's external LLM path (shipped in 1.8.0) wrote `EXTERNAL_LLM_MODEL/API_KEY/BASE_URL` to the generated app's `.env`, which nothing in the agent template or its shared LLM library reads. Pointing an agent at an OpenAI-compatible endpoint (a local LiteLLM proxy, say) silently failed: the model was never reached, and `task start-non-interactive` died at the deploy stage.

## Changes

- `setup_template.py`: the external path writes what the template actually reads to resolve an external LLM: `USE_DATAROBOT_LLM_GATEWAY=0`, `OPENAI_API_BASE`, `OPENAI_API_KEY`, and an `openai/`-prefixed `LLM_DEFAULT_MODEL` so litellm routes to the base URL.
- It stops after writing `.env` for the external case. `dr dotenv setup` rewrites the file onto the gateway path (dropping the OpenAI keys) and the Pulumi deploy wants a governed DataRobot deployment, neither of which fits a raw base URL. It also writes a generated `SESSION_SECRET_KEY` (the FastAPI server requires it) so `task dev` runs, and rejects a base URL or key carrying `.env`-breaking characters.
- Docs (llm-selection, helper-scripts, agent-spec-schema, pre-coding-checklist, SKILL) and CHANGELOG describe the external source with the correct contract.

## Verification

Built the app's LLM from the produced `.env` and confirmed it routes end to end to a local OpenAI-compatible proxy: external path selected, model name stripped on the wire, client auth accepted. Setup produces the correct `.env` and runs no dotenv or deploy for the external case.

## Scope

Local-run path. `DATAROBOT_ENDPOINT`/`DATAROBOT_API_TOKEN` are left empty, so the LLM works but DataRobot-backed app features (auth, chat history) need them set. Deploying an external-LLM agent is a separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to agent-assist setup scripting and documentation; gateway and deployed LLM paths are unchanged aside from clearer prereq wording.
> 
> **Overview**
> Fixes **`datarobot-agent-assist`** external OpenAI-compatible LLM setup, which previously wrote unread `EXTERNAL_LLM_*` keys so agents never reached the configured endpoint and still ran DataRobot-only deploy steps.
> 
> **`setup_template.py`** now writes **`USE_DATAROBOT_LLM_GATEWAY=0`**, **`OPENAI_API_BASE`**, **`OPENAI_API_KEY`**, and an **`openai/`-prefixed `LLM_DEFAULT_MODEL`** (from `AGENT_ASSIST_LLM_*` via `--llm-base-url`). It adds **`SESSION_SECRET_KEY`** for local FastAPI boot, validates dangerous characters in URL/key, and **returns after `.env`**—skipping **`dr dotenv setup`** and Pulumi so gateway rewrite/deploy do not break the external path.
> 
> Skill docs, **`llm_base_url`** in the agent spec schema, and **CHANGELOG** document the third **`external`** model source and local **`task dev`** workflow (deploy still out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7832448a168b56a8c246dcbc780878bc472a957. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->