### PR TITLE
update agent assist test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
 integration = [
     "datarobot-genai",
     "python-frontmatter>=1.1",
+    "pyyaml>=6.0",
     "pytest>=8.0",
     "codeowners>=0.8.0",
     "httpx>=0.27",

--- a/skills/datarobot-agent-assist/agent-assist-build/references/agent-spec-examples.md
+++ b/skills/datarobot-agent-assist/agent-assist-build/references/agent-spec-examples.md
@@ -111,6 +111,34 @@ frontend:
 
 ---
 
+## Example 4: On-prem Agent (DataRobot-deployed LLM)
+
+Use when the instance has no LLM Gateway catalog and the agent routes to an
+existing text-generation deployment instead.
+
+```yaml
+model: datarobot/datarobot-deployed-llm
+llm_deployment_id: "6a43eb5f10dbecadbebc5b2b"
+system_prompt: You are an internal documentation assistant. Answer questions using
+  the search_docs tool and cite the document titles you used.
+tools:
+  - function_name: search_docs
+    inputs:
+      - arg_name: query
+        type: str
+    out:
+      - arg_name: matches
+        type: list
+        object_schema: "list of {title: str, excerpt: str}"
+examples:
+  - How do I configure runtime parameters?
+  - Where is the deployment checklist documented?
+frontend:
+  type: chat
+```
+
+---
+
 ## Auth Method Reference
 
 | `auth_method` | When to use |

--- a/tests/integration/agent_assist_contracts.py
+++ b/tests/integration/agent_assist_contracts.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract helpers for agent-assist integration tests.
+
+Field rules mirror resume-design.md § Spec complete and llm-selection.md.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+EXAMPLES_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/datarobot-agent-assist/agent-assist-build/references/agent-spec-examples.md"
+)
+
+# Shaped as /genai/llmgw/catalog/ returns them.
+GATEWAY_CATALOG_ENTRY = {
+    "llmId": "azure-openai-gpt-5",
+    "model": "azure/gpt-5-2025-08-07",
+    "name": "Azure OpenAI GPT-5",
+    "provider": "Azure OpenAI",
+    "contextSize": 400000,
+    "isActive": True,
+}
+
+CLI_ENTRY = {
+    "id": "azure-openai-gpt-5",
+    "name": "Azure OpenAI GPT-5",
+    "provider": "Azure OpenAI",
+    "model": "azure/gpt-5-2025-08-07",
+    "source": "gateway",
+}
+
+DEPLOYED_CATALOG_ENTRY = {
+    "id": "6a43eb5f10dbecadbebc5b2b",
+    "label": "DocsBot (stg)",
+    "status": "active",
+    "model": {"targetType": "TextGeneration"},
+}
+
+LLM_ID = "azure-openai-gpt-5"
+API_MODEL = "azure/gpt-5-2025-08-07"
+CANONICAL = "datarobot/azure/gpt-5-2025-08-07"
+DEPLOYED_PLACEHOLDER = "datarobot/datarobot-deployed-llm"
+
+CATALOG_PROVIDERS = {"anthropic", "azure", "bedrock", "vertex_ai"}
+
+DEPLOYED_ROUTING_KEYS = (
+    'LLM_DEPLOYMENT_ID="',
+    'INFRA_ENABLE_LLM="deployed_llm.py"',
+    'USE_DATAROBOT_LLM_GATEWAY="0"',
+)
+
+_YAML_BLOCK_RE = re.compile(r"```yaml\s*\n(.*?)```", re.DOTALL)
+
+
+def parse_yaml_blocks(markdown: str) -> list[dict[str, Any]]:
+    """Extract and parse every ```yaml block from a markdown file."""
+    specs: list[dict[str, Any]] = []
+    for match in _YAML_BLOCK_RE.finditer(markdown):
+        loaded = yaml.safe_load(match.group(1))
+        if isinstance(loaded, dict):
+            specs.append(loaded)
+    return specs
+
+
+def load_spec_examples() -> list[dict[str, Any]]:
+    return parse_yaml_blocks(EXAMPLES_PATH.read_text(encoding="utf-8"))
+
+
+def map_gateway_listing(list_llm_models: Any) -> dict[str, Any]:
+    mapped = list_llm_models._map_gateway_catalog_entry(GATEWAY_CATALOG_ENTRY)
+    assert mapped is not None
+    return dict(mapped)
+
+
+def map_deployed_listing(list_llm_models: Any) -> dict[str, Any]:
+    mapped = list_llm_models._map_deployed_entry(DEPLOYED_CATALOG_ENTRY)
+    assert mapped is not None
+    return dict(mapped)
+
+
+def is_valid_spec_model(model: str, list_llm_models: Any) -> bool:
+    """Whether ``model`` is an acceptable ``agent_spec.md`` value."""
+    value = model.strip()
+    if not value:
+        return False
+    if list_llm_models.is_deployed_llm_model(value):
+        return True
+    if not value.startswith("datarobot/"):
+        return False
+    bare = list_llm_models.normalize_gateway_model(value)
+    return "/" in bare
+
+
+def validate_spec_complete(spec: dict[str, Any], list_llm_models: Any) -> list[str]:
+    """Return human-readable errors; empty list means the spec is coding-ready."""
+    errors: list[str] = []
+
+    system_prompt = spec.get("system_prompt")
+    if system_prompt is None or not str(system_prompt).strip():
+        errors.append("missing or empty system_prompt")
+
+    model = spec.get("model")
+    if model is None or not str(model).strip():
+        errors.append("missing or empty model")
+    elif not is_valid_spec_model(str(model), list_llm_models):
+        errors.append(f"invalid model value: {model!r}")
+
+    frontend = spec.get("frontend")
+    if not isinstance(frontend, dict) or not str(frontend.get("type") or "").strip():
+        errors.append("missing frontend.type")
+
+    if "tools" not in spec:
+        errors.append("missing tools key")
+
+    model_str = str(model or "").strip()
+    if model_str and list_llm_models.is_deployed_llm_model(model_str):
+        deployment_id = spec.get("llm_deployment_id")
+        if deployment_id is None or not str(deployment_id).strip():
+            errors.append("missing llm_deployment_id for deployed placeholder model")
+        elif not list_llm_models.is_deployment_id(str(deployment_id)):
+            errors.append(f"invalid llm_deployment_id: {deployment_id!r}")
+
+    return errors
+
+
+def spec_fields_from_listing_entry(entry: dict[str, Any]) -> dict[str, str]:
+    """Fields an agent must write to agent_spec.md for a listing entry."""
+    model = str(entry["llm_default_model"])
+    if entry.get("source") == "deployed":
+        deployment_id = str(entry["deployment_id"])
+        return {"model": model, "llm_deployment_id": deployment_id}
+    return {"model": model}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for integration tests."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills/datarobot-agent-assist/agent-assist-build/scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from agent_assist_contracts import (  # noqa: E402
+    map_deployed_listing,
+    map_gateway_listing,
+)
+
+
+@pytest.fixture(scope="session")
+def list_llm_models() -> Any:
+    return importlib.import_module("list_llm_models")
+
+
+@pytest.fixture(scope="session")
+def setup_template() -> Any:
+    return importlib.import_module("setup_template")
+
+
+@pytest.fixture(scope="session")
+def rehearsal() -> Any:
+    return importlib.import_module("rehearsal")
+
+
+@pytest.fixture
+def gateway_listing(list_llm_models: Any) -> dict[str, Any]:
+    return map_gateway_listing(list_llm_models)
+
+
+@pytest.fixture
+def deployed_listing(list_llm_models: Any) -> dict[str, Any]:
+    return map_deployed_listing(list_llm_models)

--- a/tests/integration/test_agent_assist_llm_model_contract.py
+++ b/tests/integration/test_agent_assist_llm_model_contract.py
@@ -123,7 +123,10 @@ def test_listing_entry_maps_to_spec_fields(
     assert recorded == expected_fields
     assert recorded["model"] == listing_entry["llm_default_model"]
     if listing_entry["source"] == "gateway":
-        assert recorded["model"] not in {listing_entry["id"], listing_entry["api_model"]}
+        assert recorded["model"] not in {
+            listing_entry["id"],
+            listing_entry["api_model"],
+        }
 
 
 # -- the table ------------------------------------------------------------------
@@ -326,7 +329,9 @@ def test_create_env_file_writes_correct_routing_keys(
 @pytest.mark.parametrize(
     ("llm_model", "deployment_id", "llm_base_url"),
     [
-        pytest.param(DEPLOYED_PLACEHOLDER, "", "", id="placeholder_without_deployment_id"),
+        pytest.param(
+            DEPLOYED_PLACEHOLDER, "", "", id="placeholder_without_deployment_id"
+        ),
         pytest.param(DEPLOYED_PLACEHOLDER, "null", "", id="invalid_deployment_id_null"),
         pytest.param(
             DEPLOYED_PLACEHOLDER,

--- a/tests/integration/test_agent_assist_llm_model_contract.py
+++ b/tests/integration/test_agent_assist_llm_model_contract.py
@@ -22,53 +22,30 @@ Nothing here touches the network. Catalog payloads are fixtures.
 
 from __future__ import annotations
 
-import importlib
-import sys
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 
+import list_llm_models
 import pytest
-
-SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "skills/datarobot-agent-assist/agent-assist-build/scripts"
+import rehearsal
+import setup_template
+from agent_assist_contracts import (
+    API_MODEL,
+    CANONICAL,
+    CLI_ENTRY,
+    DEPLOYED_CATALOG_ENTRY,
+    DEPLOYED_PLACEHOLDER,
+    DEPLOYED_ROUTING_KEYS,
+    GATEWAY_CATALOG_ENTRY,
+    LLM_ID,
+    map_deployed_listing,
+    map_gateway_listing,
+    spec_fields_from_listing_entry,
 )
-sys.path.insert(0, str(SCRIPTS_DIR))
 
-list_llm_models = importlib.import_module("list_llm_models")
-rehearsal = importlib.import_module("rehearsal")
-setup_template = importlib.import_module("setup_template")
-
-# Shaped as /genai/llmgw/catalog/ returns them.
-GATEWAY_ENTRY = {
-    "llmId": "azure-openai-gpt-5",
-    "model": "azure/gpt-5-2025-08-07",
-    "name": "Azure OpenAI GPT-5",
-    "provider": "Azure OpenAI",
-    "contextSize": 400000,
-    "isActive": True,
-}
-
-# Shaped as `dr llm-gateway list --output-format json` returns them.
-CLI_ENTRY = {
-    "id": "azure-openai-gpt-5",
-    "name": "Azure OpenAI GPT-5",
-    "provider": "Azure OpenAI",
-    "model": "azure/gpt-5-2025-08-07",
-    "source": "gateway",
-}
-
-DEPLOYED_ENTRY = {
-    "id": "6a43eb5f10dbecadbebc5b2b",
-    "label": "DocsBot (stg)",
-    "status": "active",
-    "model": {"targetType": "TextGeneration"},
-}
-
-LLM_ID = "azure-openai-gpt-5"
-API_MODEL = "azure/gpt-5-2025-08-07"
-CANONICAL = "datarobot/azure/gpt-5-2025-08-07"
+DEPLOYED_ENTRY = DEPLOYED_CATALOG_ENTRY
+GATEWAY_ENTRY = GATEWAY_CATALOG_ENTRY
 
 
 @pytest.fixture
@@ -79,9 +56,7 @@ def no_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _gateway_model() -> dict[str, Any]:
-    mapped = list_llm_models._map_gateway_catalog_entry(GATEWAY_ENTRY)
-    assert mapped is not None
-    return dict(mapped)
+    return map_gateway_listing(list_llm_models)
 
 
 # -- the listing ----------------------------------------------------------------
@@ -112,15 +87,43 @@ def test_cli_and_rest_mappers_agree() -> None:
 
 
 def test_deployed_entry_uses_the_prefixed_placeholder() -> None:
-    mapped = list_llm_models._map_deployed_entry(DEPLOYED_ENTRY)
-    assert mapped is not None
-    assert mapped["llm_default_model"] == "datarobot/datarobot-deployed-llm"
+    mapped = map_deployed_listing(list_llm_models)
+    assert mapped["llm_default_model"] == DEPLOYED_PLACEHOLDER
     assert mapped["api_model"] == "datarobot-deployed-llm"
 
 
 def test_prefixing_is_idempotent() -> None:
     once = list_llm_models.ensure_datarobot_prefix(API_MODEL)
     assert list_llm_models.ensure_datarobot_prefix(once) == once
+
+
+@pytest.mark.parametrize(
+    ("listing_entry", "expected_fields"),
+    [
+        pytest.param(
+            map_gateway_listing(list_llm_models),
+            {"model": CANONICAL},
+            id="gateway",
+        ),
+        pytest.param(
+            map_deployed_listing(list_llm_models),
+            {
+                "model": DEPLOYED_PLACEHOLDER,
+                "llm_deployment_id": DEPLOYED_ENTRY["id"],
+            },
+            id="deployed",
+        ),
+    ],
+)
+def test_listing_entry_maps_to_spec_fields(
+    listing_entry: dict[str, Any],
+    expected_fields: dict[str, str],
+) -> None:
+    recorded = spec_fields_from_listing_entry(listing_entry)
+    assert recorded == expected_fields
+    assert recorded["model"] == listing_entry["llm_default_model"]
+    if listing_entry["source"] == "gateway":
+        assert recorded["model"] not in {listing_entry["id"], listing_entry["api_model"]}
 
 
 # -- the table ------------------------------------------------------------------
@@ -130,15 +133,12 @@ def test_table_leads_with_the_env_value_not_the_llm_id() -> None:
     header, _rule, row = list_llm_models.format_as_table(
         [_gateway_model()]
     ).splitlines()
-    # Read the first column rather than searching the whole table: the llmId is a
-    # substring of nothing here today, but that is an accident of this fixture.
     assert header.split("|")[0].strip() == "LLM_DEFAULT_MODEL"
     assert row.split("|")[0].strip() == CANONICAL
 
 
 def test_table_hides_the_deployment_column_when_all_gateway() -> None:
-    deployed = list_llm_models._map_deployed_entry(DEPLOYED_ENTRY)
-    assert deployed is not None
+    deployed = map_deployed_listing(list_llm_models)
     gateway_only = list_llm_models.format_as_table([_gateway_model()])
     mixed = list_llm_models.format_as_table([_gateway_model(), deployed])
     assert "Deployment ID" not in gateway_only
@@ -184,7 +184,6 @@ def catalog(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
 
 
 def test_catalog_lookup_wins_on_spelling(tmp_path: Path, catalog: Any) -> None:
-    """With credentials, the catalog is the authority on the exact spelling."""
     catalog([_gateway_model()])
     assert (
         setup_template.canonical_gateway_model(API_MODEL.upper(), tmp_path) == CANONICAL
@@ -192,8 +191,6 @@ def test_catalog_lookup_wins_on_spelling(tmp_path: Path, catalog: Any) -> None:
 
 
 def test_catalog_overrules_the_slash_heuristic(tmp_path: Path, catalog: Any) -> None:
-    """The no-slash rule is a fallback for when the catalog cannot be read. A
-    catalog free to register a bare litellm name must not be second-guessed."""
     bare_name = dict(_gateway_model())
     bare_name["api_model"] = "gpt-4o"
     bare_name["llm_default_model"] = "datarobot/gpt-4o"
@@ -213,21 +210,16 @@ def test_model_absent_from_catalog_is_refused(tmp_path: Path, catalog: Any) -> N
 def test_catalog_present_still_refuses_a_bare_llm_id(
     tmp_path: Path, catalog: Any
 ) -> None:
-    """A readable catalog does not excuse a no-slash llmId. It matches no api_model
-    and is not a provider path, so it is refused rather than prefixed and written."""
     catalog([_gateway_model()])
     assert setup_template.canonical_gateway_model(LLM_ID, tmp_path) is None
 
 
 def test_unreachable_catalog_does_not_block_setup(tmp_path: Path, catalog: Any) -> None:
-    """An instance this process cannot reach must not stop a scaffold."""
     catalog(RuntimeError("connection refused"))
     assert setup_template.canonical_gateway_model(API_MODEL, tmp_path) == CANONICAL
 
 
 def test_connection_reset_does_not_block_setup(tmp_path: Path, catalog: Any) -> None:
-    """urlopen lets raw OSError subclasses past the fetch helper's URLError
-    handling, so catching RuntimeError alone let a reset kill the whole setup."""
     catalog(ConnectionResetError(54, "Connection reset by peer"))
     assert setup_template.canonical_gateway_model(API_MODEL, tmp_path) == CANONICAL
 
@@ -235,12 +227,8 @@ def test_connection_reset_does_not_block_setup(tmp_path: Path, catalog: Any) -> 
 def test_empty_gateway_points_at_a_deployed_llm(
     tmp_path: Path, catalog: Any, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """An on-prem instance with the gateway off must get a way forward, not a
-    refusal followed by an empty list of alternatives."""
     catalog([])
-
     assert setup_template.canonical_gateway_model(API_MODEL, tmp_path) is None
-
     err = capsys.readouterr().err
     assert "--llm-deployment-id" in err
     assert "Available:" not in err
@@ -249,12 +237,8 @@ def test_empty_gateway_points_at_a_deployed_llm(
 def test_disabled_gateway_is_treated_as_empty(
     tmp_path: Path, catalog: Any, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A 404 from the catalog endpoint is the instance answering that it has no
-    gateway, not a failure to reach it. Passing it as unverified would hand back a
-    model the instance cannot serve."""
     http_404 = HTTPError("https://x/api/v2/genai/llmgw/catalog/", 404, "", {}, None)  # type: ignore[arg-type]
     catalog(RuntimeError("Failed to fetch LLM Gateway catalog"), cause=http_404)
-
     assert setup_template.canonical_gateway_model(API_MODEL, tmp_path) is None
     assert "--llm-deployment-id" in capsys.readouterr().err
 
@@ -262,23 +246,12 @@ def test_disabled_gateway_is_treated_as_empty(
 def test_forbidden_catalog_is_not_a_disabled_gateway(
     tmp_path: Path, catalog: Any
 ) -> None:
-    """A 403 says this token may not read the catalog, not that the gateway is
-    absent. Refusing on it sends a user to a deployed LLM they do not need."""
     forbidden = HTTPError("https://x/api/v2/genai/llmgw/catalog/", 403, "", {}, None)  # type: ignore[arg-type]
     catalog(RuntimeError("Failed to fetch LLM Gateway catalog"), cause=forbidden)
-
     assert setup_template.canonical_gateway_model(API_MODEL, tmp_path) == CANONICAL
 
 
-def test_env_file_carries_the_canonical_value(tmp_path: Path) -> None:
-    ok, _ = setup_template.create_env_file(tmp_path, CANONICAL)
-    assert ok
-    assert f'LLM_DEFAULT_MODEL="{CANONICAL}"' in (tmp_path / ".env").read_text()
-
-
 def test_env_file_refuses_a_value_that_would_break_the_line(tmp_path: Path) -> None:
-    """The value lands in a double-quoted line the template's loader re-parses, so
-    a quote closes it early and the rest becomes further keys."""
     ok, _ = setup_template.create_env_file(tmp_path, 'a/b" \nFOO="bar')
     assert not ok
     assert not (tmp_path / ".env").exists()
@@ -288,60 +261,104 @@ def test_env_file_refuses_a_value_that_would_break_the_line(tmp_path: Path) -> N
 def test_env_file_rejects_each_dangerous_character(
     tmp_path: Path, bad_char: str
 ) -> None:
-    """Each break-out character is refused on its own, not only in the combined
-    value above, so no single one can slip through the guard."""
     ok, _ = setup_template.create_env_file(tmp_path, f"datarobot/azure/gpt-5{bad_char}")
     assert not ok
     assert not (tmp_path / ".env").exists()
 
 
 def test_env_file_rejects_an_empty_model(tmp_path: Path) -> None:
-    """An empty LLM_DEFAULT_MODEL is not a usable value; the '+' guard rejects it."""
     ok, _ = setup_template.create_env_file(tmp_path, "")
     assert not ok
     assert not (tmp_path / ".env").exists()
 
 
 def test_env_file_accepts_every_shape_the_real_catalog_uses(tmp_path: Path) -> None:
-    """':' and '@' are load-bearing, so the guard cannot be tightened to [\\w/-]."""
     for model in (
         "datarobot/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
         "datarobot/vertex_ai/claude-haiku-4-5@20251001",
         "datarobot/azure/gpt-5-2025-08-07",
-        "datarobot/datarobot-deployed-llm",
+        DEPLOYED_PLACEHOLDER,
     ):
         ok, msg = setup_template.create_env_file(tmp_path, model)
         assert ok, f"{model} rejected: {msg}"
 
 
-# -- the docs the agent copies from ---------------------------------------------
+@pytest.mark.parametrize(
+    ("llm_model", "deployment_id", "expected_fragments", "forbidden_fragments"),
+    [
+        pytest.param(
+            CANONICAL,
+            "",
+            [f'LLM_DEFAULT_MODEL="{CANONICAL}"'],
+            DEPLOYED_ROUTING_KEYS,
+            id="gateway",
+        ),
+        pytest.param(
+            DEPLOYED_PLACEHOLDER,
+            DEPLOYED_ENTRY["id"],
+            [
+                f'LLM_DEFAULT_MODEL="{DEPLOYED_PLACEHOLDER}"',
+                f'LLM_DEPLOYMENT_ID="{DEPLOYED_ENTRY["id"]}"',
+                'INFRA_ENABLE_LLM="deployed_llm.py"',
+                'USE_DATAROBOT_LLM_GATEWAY="0"',
+            ],
+            (),
+            id="deployed",
+        ),
+    ],
+)
+def test_create_env_file_writes_correct_routing_keys(
+    tmp_path: Path,
+    llm_model: str,
+    deployment_id: str,
+    expected_fragments: list[str],
+    forbidden_fragments: tuple[str, ...],
+) -> None:
+    ok, _ = setup_template.create_env_file(tmp_path, llm_model, deployment_id)
+    assert ok
+    contents = (tmp_path / ".env").read_text()
+    for fragment in expected_fragments:
+        assert fragment in contents
+    for fragment in forbidden_fragments:
+        assert fragment not in contents
 
 
-# Every provider the LLM Gateway catalog routes through. An example naming
-# anything else is addressing a provider that does not exist, which is how
-# `google/gemini-2.5-pro-preview-05-06` shipped: the real entry is under
-# `vertex_ai/`. Whether a given model is still listed cannot be checked without
-# the network, so this is the shape check, not a membership check.
-CATALOG_PROVIDERS = {"anthropic", "azure", "bedrock", "vertex_ai"}
+@pytest.mark.parametrize(
+    ("llm_model", "deployment_id", "llm_base_url"),
+    [
+        pytest.param(DEPLOYED_PLACEHOLDER, "", "", id="placeholder_without_deployment_id"),
+        pytest.param(DEPLOYED_PLACEHOLDER, "null", "", id="invalid_deployment_id_null"),
+        pytest.param(
+            DEPLOYED_PLACEHOLDER,
+            "not-a-valid-deployment-id",
+            "",
+            id="invalid_deployment_id_non_hex",
+        ),
+        pytest.param(
+            "external-model",
+            DEPLOYED_ENTRY["id"],
+            "https://llm.example.invalid/v1",
+            id="external_llm_with_deployment_id",
+        ),
+    ],
+)
+def test_setup_and_run_deployed_path_gates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    llm_model: str,
+    deployment_id: str,
+    llm_base_url: str,
+) -> None:
+    if llm_base_url:
+        monkeypatch.setenv("AGENT_ASSIST_LLM_MODEL_NAME", "external-model")
+        monkeypatch.setenv("AGENT_ASSIST_LLM_API_KEY", "test-key")
+        monkeypatch.setenv("AGENT_ASSIST_LLM_BASE_URL", llm_base_url)
 
-
-def test_spec_examples_use_canonical_model_names() -> None:
-    """The worked examples are what an agent imitates, so they have to be shaped
-    like values setup_template.py accepts: prefixed, and naming a real provider."""
-    examples = (SCRIPTS_DIR.parent / "references/agent-spec-examples.md").read_text()
-    models = [
-        line.split(":", 1)[1].strip().strip("\"'")
-        for line in examples.splitlines()
-        if line.startswith("model:")
-    ]
-    assert models, "no model: lines found in agent-spec-examples.md"
-    for model in models:
-        assert model.startswith("datarobot/"), f"{model} is missing the prefix"
-        bare = list_llm_models.normalize_gateway_model(model)
-        # A catalog model is a provider path. A bare name is an llmId.
-        assert "/" in bare, model
-        provider = bare.split("/", 1)[0]
-        assert provider in CATALOG_PROVIDERS, f"{model} names no real provider"
+    assert (
+        setup_template.setup_and_run(llm_model, tmp_path, deployment_id, llm_base_url)
+        == 1
+    )
+    assert not (tmp_path / ".env").exists()
 
 
 # -- the rehearsal still resolves it --------------------------------------------
@@ -355,23 +372,15 @@ def _model_catalog(monkeypatch: pytest.MonkeyPatch, entries: list[Any]) -> Any:
 def test_rehearsal_resolves_the_canonical_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Writing the prefixed form must not cost an exact match in the rehearsal."""
     model_catalog = _model_catalog(monkeypatch, [_gateway_model()])
-
     resolved, substituted = model_catalog.pick_available(CANONICAL)
-
     assert substituted is False
-    # Still the bare form on the wire, whatever spelling the spec carried.
     assert resolved.api_model == API_MODEL
 
 
 def test_rehearsal_keeps_the_provider_guard_on_a_prefixed_spec(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A near-miss spec falls through to slug matching, which reads a provider off
-    the front of the request. Left unprefixed, every request reads as provider
-    'datarobot', the cross-provider guard stops applying, and the rehearsal runs
-    against whichever model happens to be first in the catalog."""
     anthropic = list_llm_models._map_gateway_catalog_entry(
         {
             "llmId": "anthropic-1p-claude-sonnet-4-5",
@@ -382,12 +391,9 @@ def test_rehearsal_keeps_the_provider_guard_on_a_prefixed_spec(
         }
     )
     model_catalog = _model_catalog(monkeypatch, [_gateway_model(), anthropic])
-
-    # Dots where the catalog has dashes, so the exact match misses on purpose.
     resolved, substituted = model_catalog.pick_available(
         "datarobot/anthropic/claude-sonnet-4.5-20250929"
     )
-
     assert substituted is True
     assert resolved.api_model == "anthropic/claude-sonnet-4-5-20250929"
 
@@ -396,9 +402,7 @@ def test_model_was_substituted_false_for_exact_match(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model_catalog = _model_catalog(monkeypatch, [_gateway_model()])
-
     expected, _ = model_catalog.pick_available(CANONICAL)
-
     assert rehearsal._model_was_substituted(model_catalog, CANONICAL, expected) is False
 
 
@@ -415,10 +419,8 @@ def test_model_was_substituted_true_after_runtime_fallback(
         }
     )
     model_catalog = _model_catalog(monkeypatch, [_gateway_model(), anthropic])
-
     expected, _ = model_catalog.pick_available(CANONICAL)
     fallback, _ = model_catalog.pick_available(CANONICAL, exclude_id=expected.id)
-
     assert rehearsal._model_was_substituted(model_catalog, CANONICAL, expected) is False
     assert rehearsal._model_was_substituted(model_catalog, CANONICAL, fallback) is True
 
@@ -426,12 +428,10 @@ def test_model_was_substituted_true_after_runtime_fallback(
 def test_agent_model_was_substituted_uses_deployment_id_from_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    deployed = list_llm_models._map_deployed_entry(DEPLOYED_ENTRY)
-    assert deployed is not None
+    deployed = map_deployed_listing(list_llm_models)
     model_catalog = _model_catalog(monkeypatch, [_gateway_model(), deployed])
-
     config = {
-        "requested_model": "datarobot/datarobot-deployed-llm",
+        "requested_model": DEPLOYED_PLACEHOLDER,
         "requested_deployment_id": deployed["id"],
     }
     fallback, _ = model_catalog.pick_available(
@@ -439,7 +439,6 @@ def test_agent_model_was_substituted_uses_deployment_id_from_config(
         prefer_source="deployed",
         exclude_id=deployed["id"],
     )
-
     assert (
         rehearsal._agent_model_was_substituted(model_catalog, config, fallback) is True
     )

--- a/tests/integration/test_agent_assist_spec_contract.py
+++ b/tests/integration/test_agent_assist_spec_contract.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for agent_spec.md completeness and model shape."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from agent_assist_contracts import (
+    CANONICAL,
+    CATALOG_PROVIDERS,
+    DEPLOYED_PLACEHOLDER,
+    load_spec_examples,
+    validate_spec_complete,
+)
+
+_MINIMAL_GATEWAY_SPEC: dict[str, Any] = {
+    "model": CANONICAL,
+    "system_prompt": "You are a helpful assistant.",
+    "tools": [
+        {
+            "function_name": "lookup",
+            "inputs": [{"arg_name": "query", "type": "str"}],
+            "out": [{"arg_name": "result", "type": "str"}],
+        }
+    ],
+    "frontend": {"type": "chat"},
+}
+
+
+def _validate(spec: dict[str, Any], list_llm_models: Any) -> list[str]:
+    return validate_spec_complete(spec, list_llm_models)
+
+
+def _without(spec: dict[str, Any], *keys: str) -> dict[str, Any]:
+    trimmed = copy.deepcopy(spec)
+    for key in keys:
+        trimmed.pop(key, None)
+    return trimmed
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        pytest.param(_MINIMAL_GATEWAY_SPEC, id="minimal_gateway"),
+        pytest.param({**_MINIMAL_GATEWAY_SPEC, "tools": []}, id="explicit_empty_tools"),
+    ],
+)
+def test_spec_complete_accepts_valid_specs(
+    spec: dict[str, Any], list_llm_models: Any
+) -> None:
+    assert _validate(spec, list_llm_models) == []
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected_errors"),
+    [
+        pytest.param(
+            _without(_MINIMAL_GATEWAY_SPEC, "system_prompt"),
+            ["missing or empty system_prompt"],
+            id="missing_system_prompt",
+        ),
+        pytest.param(
+            _without(_MINIMAL_GATEWAY_SPEC, "model"),
+            ["missing or empty model"],
+            id="missing_model",
+        ),
+        pytest.param(
+            _without(_MINIMAL_GATEWAY_SPEC, "frontend"),
+            ["missing frontend.type"],
+            id="missing_frontend",
+        ),
+        pytest.param(
+            _without(_MINIMAL_GATEWAY_SPEC, "tools"),
+            ["missing tools key"],
+            id="missing_tools_key",
+        ),
+        pytest.param(
+            {
+                **_MINIMAL_GATEWAY_SPEC,
+                "model": DEPLOYED_PLACEHOLDER,
+                "llm_deployment_id": "",
+            },
+            ["missing llm_deployment_id for deployed placeholder model"],
+            id="placeholder_without_deployment_id",
+        ),
+        pytest.param(
+            {**_MINIMAL_GATEWAY_SPEC, "model": "azure/gpt-5-2025-08-07"},
+            ["invalid model value: 'azure/gpt-5-2025-08-07'"],
+            id="bare_api_model",
+        ),
+        pytest.param(
+            {**_MINIMAL_GATEWAY_SPEC, "model": "azure-openai-gpt-5"},
+            ["invalid model value: 'azure-openai-gpt-5'"],
+            id="catalog_llm_id",
+        ),
+    ],
+)
+def test_spec_complete_rejects_invalid_specs(
+    spec: dict[str, Any],
+    expected_errors: list[str],
+    list_llm_models: Any,
+) -> None:
+    assert _validate(spec, list_llm_models) == expected_errors
+
+
+def test_spec_examples_satisfy_contract(list_llm_models: Any) -> None:
+    examples = load_spec_examples()
+    assert examples, "no yaml examples found in agent-spec-examples.md"
+
+    has_deployed_example = False
+    for index, spec in enumerate(examples, start=1):
+        errors = _validate(spec, list_llm_models)
+        assert errors == [], f"example {index} failed spec_complete: {errors}"
+
+        model = str(spec["model"])
+        assert model.startswith("datarobot/"), f"{model} is missing the prefix"
+
+        if list_llm_models.is_deployed_llm_model(model):
+            has_deployed_example = True
+            assert list_llm_models.is_deployment_id(
+                str(spec.get("llm_deployment_id") or "")
+            )
+            continue
+
+        bare = list_llm_models.normalize_gateway_model(model)
+        provider = bare.split("/", 1)[0]
+        assert provider in CATALOG_PROVIDERS, f"{model} names no real provider"
+
+    assert has_deployed_example, (
+        "agent-spec-examples.md must include at least one deployed-LLM example"
+    )

--- a/tests/integration/test_agent_assist_workflow_scenarios.py
+++ b/tests/integration/test_agent_assist_workflow_scenarios.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 DataRobot, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for how an agent should record LLM choices in agent_spec.md."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_assist_contracts import spec_fields_from_listing_entry
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills/datarobot-agent-assist/agent-assist-build/scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+list_llm_models = importlib.import_module("list_llm_models")
+
+GATEWAY_ENTRY = {
+    "llmId": "azure-openai-gpt-5",
+    "model": "azure/gpt-5-2025-08-07",
+    "name": "Azure OpenAI GPT-5",
+    "provider": "Azure OpenAI",
+    "contextSize": 400000,
+    "isActive": True,
+}
+
+DEPLOYED_ENTRY = {
+    "id": "6a43eb5f10dbecadbebc5b2b",
+    "label": "DocsBot (stg)",
+    "status": "active",
+    "model": {"targetType": "TextGeneration"},
+}
+
+CANONICAL = "datarobot/azure/gpt-5-2025-08-07"
+LLM_ID = "azure-openai-gpt-5"
+
+
+def _gateway_listing() -> dict[str, Any]:
+    mapped = list_llm_models._map_gateway_catalog_entry(GATEWAY_ENTRY)
+    assert mapped is not None
+    return dict(mapped)
+
+
+def _deployed_listing() -> dict[str, Any]:
+    mapped = list_llm_models._map_deployed_entry(DEPLOYED_ENTRY)
+    assert mapped is not None
+    return dict(mapped)
+
+
+@pytest.mark.parametrize(
+    ("listing_entry", "expected_fields", "forbidden_model_values"),
+    [
+        pytest.param(
+            _gateway_listing(),
+            {"model": CANONICAL},
+            {LLM_ID, "azure/gpt-5-2025-08-07"},
+            id="gateway",
+        ),
+        pytest.param(
+            _deployed_listing(),
+            {
+                "model": "datarobot/datarobot-deployed-llm",
+                "llm_deployment_id": DEPLOYED_ENTRY["id"],
+            },
+            set(),
+            id="deployed",
+        ),
+    ],
+)
+def test_agent_records_llm_choice_in_spec(
+    listing_entry: dict[str, Any],
+    expected_fields: dict[str, str],
+    forbidden_model_values: set[str],
+) -> None:
+    recorded = spec_fields_from_listing_entry(listing_entry)
+    assert recorded == expected_fields
+    assert recorded["model"] == listing_entry["llm_default_model"]
+    assert recorded["model"] not in forbidden_model_values
+    if listing_entry["source"] == "gateway":
+        assert "llm_deployment_id" not in recorded
+        assert recorded["model"] != listing_entry["id"]
+        assert recorded["model"] != listing_entry["api_model"]

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,7 @@ integration = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "python-frontmatter" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -402,6 +403,7 @@ integration = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "python-frontmatter", specifier = ">=1.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
CFX-7722 Add more test coverage in skills repository for Agent Assist skill

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes with a new integration dependency; no modifications to Agent Assist runtime scripts in this diff.
> 
> **Overview**
> **Expands Agent Assist integration coverage** around how LLM choices flow from catalog listings into `agent_spec.md` and `.env`, without changing the build scripts themselves.
> 
> Introduces **`agent_assist_contracts.py`** and **`conftest.py`** so gateway vs deployed fixtures, `validate_spec_complete`, and YAML parsing of `agent-spec-examples.md` are shared across tests. The existing LLM model contract suite is refactored onto those helpers and gains **parametrized checks** for gateway vs deployed `.env` routing (`LLM_DEPLOYMENT_ID`, `INFRA_ENABLE_LLM`, `USE_DATAROBOT_LLM_GATEWAY`) and **`setup_and_run` failure paths** when deployment IDs or external LLM config are invalid.
> 
> Adds **`test_agent_assist_spec_contract.py`** (spec completeness and invalid model shapes) and **`test_agent_assist_workflow_scenarios.py`** (which fields agents must write per listing). **`agent-spec-examples.md`** now includes an **on-prem / deployed-LLM** YAML example required by the new example contract test. **`pyyaml`** is added to the integration dependency group for parsing fenced YAML in the examples file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad0832e5cc8dbb5492088528c449d62c146859d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->